### PR TITLE
Fix bugs in partition

### DIFF
--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -176,13 +176,13 @@ export default class BVHConstructionContext {
 		// hoare partitioning, see e.g. https://en.wikipedia.org/wiki/Quicksort#Hoare_partition_scheme
 		while ( left <= right ) {
 
-			while ( centroids[ tris[ left ] * 3 + axis ] < pos ) {
+			while ( left <= right && centroids[ tris[ left ] * 3 + axis ] < pos) {
 
 				left ++;
 
 			}
 
-			while ( centroids[ tris[ right ] * 3 + axis ] >= pos ) {
+			while ( left <= right && centroids[ tris[ right ] * 3 + axis ] >= pos ) {
 
 				right --;
 

--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -174,7 +174,7 @@ export default class BVHConstructionContext {
 		const centroids = this.centroids;
 
 		// hoare partitioning, see e.g. https://en.wikipedia.org/wiki/Quicksort#Hoare_partition_scheme
-		while ( left <= right ) {
+		while ( true ) {
 
 			while ( left <= right && centroids[ tris[ left ] * 3 + axis ] < pos) {
 
@@ -188,7 +188,7 @@ export default class BVHConstructionContext {
 
 			}
 
-			if ( left <= right ) {
+			if ( left < right ) {
 
 				let tmp = tris[ left ];
 				tris[ left ] = tris[ right ];
@@ -196,11 +196,13 @@ export default class BVHConstructionContext {
 				left ++;
 				right --;
 
+			} else {
+
+				return left;
+
 			}
 
 		}
-
-		return left;
 
 	}
 

--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -176,7 +176,7 @@ export default class BVHConstructionContext {
 		// hoare partitioning, see e.g. https://en.wikipedia.org/wiki/Quicksort#Hoare_partition_scheme
 		while ( true ) {
 
-			while ( left <= right && centroids[ tris[ left ] * 3 + axis ] < pos) {
+			while ( left <= right && centroids[ tris[ left ] * 3 + axis ] < pos ) {
 
 				left ++;
 


### PR DESCRIPTION
1. When zipping through the things on the left and right side of the range that were already in the correct order with respect to the split plane, we weren't checking the range bounds. That means that if we made a really terrible split, such that all the triangles are on one side, it could go "off the end", do an arbitrary amount of extra work, and return an invalid left index. This caused #53.

2. At the end of the partitioning, we would tend to do one unnecessary swap. Now we don't.

This doesn't seem like it impacts performance much. I guess you would expect it to be a tiny bit slower on typical geometries on accounts of the bounds checks.