### PR TITLE
Don't do extra work to generate child node bounds

### DIFF
--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -106,8 +106,8 @@ export default class BVHConstructionContext {
 
 	}
 
-	// shrinks the provided bounds on any dimensions to fit the provided triangles
-	shrinkBoundsTo( offset, count, parent, target ) {
+	// computes the union of the bounds of all of the given triangles and puts the resulting box in target
+	getBounds( offset, count, target ) {
 
 		let minx = Infinity;
 		let miny = Infinity;
@@ -131,13 +131,13 @@ export default class BVHConstructionContext {
 
 		}
 
-		target[ 0 ] = Math.max( minx, parent[ 0 ] );
-		target[ 1 ] = Math.max( miny, parent[ 1 ] );
-		target[ 2 ] = Math.max( minz, parent[ 2 ] );
+		target[ 0 ] = minx;
+		target[ 1 ] = miny;
+		target[ 2 ] = minz;
 
-		target[ 3 ] = Math.min( maxx, parent[ 3 ] );
-		target[ 4 ] = Math.min( maxy, parent[ 4 ] );
-		target[ 5 ] = Math.min( maxz, parent[ 5 ] );
+		target[ 3 ] = maxx;
+		target[ 4 ] = maxy;
+		target[ 5 ] = maxz;
 
 		return target;
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -76,16 +76,16 @@ export default class MeshBVH extends MeshBVHNode {
 
 			} else {
 
-				// create the left child, keeping the bounds within the bounds of the parent
+				// create the left child and compute its bounding box
 				const left = new MeshBVHNode();
 				const lstart = offset, lcount = splitOffset - offset;
-				left.boundingData = ctx.shrinkBoundsTo( lstart, lcount, node.boundingData, new Float32Array( 6 ) );
+				left.boundingData = ctx.getBounds( lstart, lcount, new Float32Array( 6 ) );
 				splitNode( left, lstart, lcount, depth + 1 );
 
 				// repeat for right
 				const right = new MeshBVHNode();
 				const rstart = splitOffset, rcount = count - lcount;
-				right.boundingData = ctx.shrinkBoundsTo( rstart, rcount, node.boundingData, new Float32Array( 6 ) );
+				right.boundingData = ctx.getBounds( rstart, rcount, new Float32Array( 6 ) );
 				splitNode( right, rstart, rcount, depth + 1 );
 
 				node.splitAxis = split.axis;


### PR DESCRIPTION
It doesn't seem to me like we had any reason to intersect the new bounds with the bounds of the parent -- since the triangles in the child are a subset of the triangles in the parent, it seems patently impossible for the child bounds to not already be a subset of the parent bounds.