### PR TITLE
Move depth check to top of splitNode

### DIFF
--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -45,7 +45,7 @@ export default class MeshBVH extends MeshBVHNode {
 		const splitNode = ( node, offset, count, depth = 0 ) => {
 
 			// early out if we've met our capacity
-			if ( count <= options.maxLeafTris ) {
+			if ( count <= options.maxLeafTris || depth >= options.maxDepth ) {
 
 				ctx.writeReorderedIndices( offset, count, indices );
 				node.offset = offset;
@@ -68,7 +68,7 @@ export default class MeshBVH extends MeshBVHNode {
 			const splitOffset = ctx.partition( offset, count, split );
 
 			// create the two new child nodes
-			if ( splitOffset === offset || splitOffset === offset + count || depth >= options.maxDepth ) {
+			if ( splitOffset === offset || splitOffset === offset + count ) {
 
 				ctx.writeReorderedIndices( offset, count, indices );
 				node.offset = offset;


### PR DESCRIPTION
Addresses something I mentioned in #51 -- previously, if we reached the maximum depth, we would do a final split + partition and then predictably throw out the result and turn the node into a leaf. So let's not do that extra work.