### PR TITLE
Update max leaf tris check

### DIFF
--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -44,7 +44,6 @@ export default class MeshBVH extends MeshBVHNode {
 		// recording the offset and count of its triangles and writing them into the reordered geometry index.
 		const splitNode = ( node, offset, count, depth = 0 ) => {
 
-
 			// early out if we've met our capacity
 			if ( depth >= options.maxDepth ) {
 
@@ -84,13 +83,13 @@ export default class MeshBVH extends MeshBVHNode {
 
 				// create the left child and compute its bounding box
 				const left = new MeshBVHNode();
-				const lstart = offset, lcount = splitOffset - offset;
+				const lstart = offset;
 				left.boundingData = ctx.getBounds( lstart, lcount, new Float32Array( 6 ) );
 				splitNode( left, lstart, lcount, depth + 1 );
 
 				// repeat for right
 				const right = new MeshBVHNode();
-				const rstart = splitOffset, rcount = count - lcount;
+				const rstart = splitOffset;
 				right.boundingData = ctx.getBounds( rstart, rcount, new Float32Array( 6 ) );
 				splitNode( right, rstart, rcount, depth + 1 );
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -46,7 +46,7 @@ export default class MeshBVH extends MeshBVHNode {
 
 
 			// early out if we've met our capacity
-			if ( count <= options.maxLeafTris || depth >= options.maxDepth ) {
+			if ( depth >= options.maxDepth ) {
 
 				ctx.writeReorderedIndices( offset, count, indices );
 				node.offset = offset;
@@ -71,11 +71,10 @@ export default class MeshBVH extends MeshBVHNode {
 			const rcount = count - lcount;
 
 			const didntSplit = splitOffset === offset || splitOffset === offset + count;
-			const reachedMaxDepth = depth >= options.maxDepth;
 			const tooFewTris = lcount <= options.maxLeafTris || rcount <= options.maxLeafTris;
 
 			// create the two new child nodes
-			if ( didntSplit || reachedMaxDepth || tooFewTris ) {
+			if ( didntSplit || tooFewTris ) {
 
 				ctx.writeReorderedIndices( offset, count, indices );
 				node.offset = offset;


### PR DESCRIPTION
Fix #55 

Checks to make sure both child nodes will have enough triangles before committing to a split.

Bounds tree computation time seems to be improved in the benchmark.

**Before**
```
Compute Bounds Tree      : ~212 - 220 ms
```

**After**
```
Compute Bounds Tree      : ~140 - 160 ms
```