### PR TITLE
Rename the global umd variable `MeshBVH` to `MeshBVHLib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import * as THREE from 'three';
 import { computeBoundsTree, disposeBoundsTree, acceleratedRaycast } 'three-mesh-bvh';
 
 // Or UMD
-const { computeBoundsTree, disposeBoundsTree, acceleratedRaycast } = window.MeshBVH;
+const { computeBoundsTree, disposeBoundsTree, acceleratedRaycast } = window.MeshBVHLib;
 
 
 // Add the extension functions
@@ -43,7 +43,7 @@ import * as THREE from 'three';
 import { MeshBVH, acceleratedRaycast } 'three-mesh-bvh';
 
 // Or UMD
-const { MeshBVH, acceleratedRaycast } = window.MeshBVH;
+const { MeshBVH, acceleratedRaycast } = window.MeshBVHLib;
 
 
 // Add the raycast function. Assumes the BVH is available on

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ export default
 
 	output: {
 
-		name: 'MeshBVH',
+		name: 'MeshBVHLib',
 		extend: true,
 		format: 'umd',
 		file: './umd/index.js',


### PR DESCRIPTION
Rename the global UMD variable from `MeshBVH` to `MeshBVHLib`, as discussed [here](https://github.com/gkjohnson/three-mesh-bvh/pull/60#discussion_r244400200).