### PR TITLE
Store left, right instead of children array

### DIFF
--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -84,20 +84,19 @@ export default class MeshBVH extends MeshBVHNode {
 
 			} else {
 
+				node.splitAxis = split.axis;
+
 				// create the left child and compute its bounding box
-				const left = new MeshBVHNode();
+				const left = node.left = new MeshBVHNode();
 				const lstart = offset, lcount = splitOffset - offset;
 				left.boundingData = ctx.getBounds( lstart, lcount, new Float32Array( 6 ) );
 				splitNode( left, lstart, lcount, depth + 1 );
 
 				// repeat for right
-				const right = new MeshBVHNode();
+				const right = node.right = new MeshBVHNode();
 				const rstart = splitOffset, rcount = count - lcount;
 				right.boundingData = ctx.getBounds( rstart, rcount, new Float32Array( 6 ) );
 				splitNode( right, rstart, rcount, depth + 1 );
-
-				node.splitAxis = split.axis;
-				node.children = [ left, right ];
 
 			}
 

--- a/src/MeshBVHNode.js
+++ b/src/MeshBVHNode.js
@@ -12,7 +12,7 @@ class MeshBVHNode {
 
 	constructor() {
 
-		// internal nodes have boundingData, children, and splitAxis
+		// internal nodes have boundingData, left, right, and splitAxis
 		// leaf nodes have offset and count (referring to primitives in the mesh geometry)
 
 	}
@@ -28,12 +28,14 @@ class MeshBVHNode {
 	raycast( mesh, raycaster, ray, intersects ) {
 
 		if ( this.count ) intersectTris( mesh, mesh.geometry, raycaster, ray, this.offset, this.count, intersects );
-		else this.children.forEach( c => {
+		else {
 
-			if ( c.intersectRay( ray, boxIntersection ) )
-				c.raycast( mesh, raycaster, ray, intersects );
+			if ( this.left.intersectRay( ray, boxIntersection ) )
+				this.left.raycast( mesh, raycaster, ray, intersects );
+			if ( this.right.intersectRay( ray, boxIntersection ) )
+				this.right.raycast( mesh, raycaster, ray, intersects );
 
-		} );
+		}
 
 	}
 
@@ -48,7 +50,6 @@ class MeshBVHNode {
 
 			// consider the position of the split plane with respect to the oncoming ray; whichever direction
 			// the ray is coming from, look for an intersection among that side of the tree first
-			const children = this.children;
 			const splitAxis = this.splitAxis;
 			const xyzAxis = xyzFields[ splitAxis ];
 			const rayDir = ray.direction[ xyzAxis ];
@@ -58,13 +59,13 @@ class MeshBVHNode {
 			let c1, c2;
 			if ( leftToRight ) {
 
-				c1 = children[ 0 ];
-				c2 = children[ 1 ];
+				c1 = this.left;
+				c2 = this.right;
 
 			} else {
 
-				c1 = children[ 1 ];
-				c2 = children[ 0 ];
+				c1 = this.right;
+				c2 = this.left;
 
 			}
 

--- a/src/MeshBVHVisualizer.js
+++ b/src/MeshBVHVisualizer.js
@@ -32,9 +32,11 @@ class MeshBVHVisualizer extends THREE.Object3D {
 
 				const recurse = ( n, d ) => {
 
+					let isLeaf = 'count' in n;
+
 					if ( d === this.depth ) return;
 
-					if ( d === this.depth - 1 || n.children == null || n.children.length === 0 ) {
+					if ( d === this.depth - 1 || isLeaf ) {
 
 						let m = requiredChildren < this.children.length ? this.children[ requiredChildren ] : null;
 						if ( ! m ) {
@@ -51,9 +53,10 @@ class MeshBVHVisualizer extends THREE.Object3D {
 
 					}
 
-					if ( n.children != null ) {
+					if ( ! isLeaf ) {
 
-						n.children.forEach( n => recurse( n, d + 1 ) );
+						recurse( n.left, d + 1 );
+						recurse( n.right, d + 1 );
 
 					}
 

--- a/test/test.js
+++ b/test/test.js
@@ -63,15 +63,16 @@ describe( 'Options', () => {
 	describe( 'maxDepth', () => {
 
 		// Returns the max tree depth of the BVH
-		function getMaxDepth( node, depth = 0 ) {
+		function getMaxDepth( node ) {
 
-			if ( ! node.children ) return depth;
+			const isLeaf = 'count' in node;
 
-			return node.children.reduce( ( acc, n ) => {
+			if ( isLeaf ) return 0;
 
-				return Math.max( getMaxDepth( n, depth + 1 ), acc );
-
-			}, depth );
+			return 1 + Math.max(
+				getMaxDepth( node.left ),
+				getMaxDepth( node.right )
+			);
 
 		}
 


### PR DESCRIPTION
This doesn't really move the needle in a measurable way for me on the benchmark, but it's very easy to do and nice to make the resulting tree more memory-efficient.

In Chrome, taking a heap snapshot of the example page, the tree size before this change is 6617152 bytes, and the tree size after this change is 581236 bytes.