### PR TITLE
Support building BVH for geometries with material groups

### DIFF
--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -168,4 +168,33 @@ export default class MeshBVH {
 
 	}
 
+	raycast( mesh, raycaster, ray, intersects ) {
+
+		for ( const root of this._roots ) {
+
+			root.raycast( mesh, raycaster, ray, intersects );
+
+		}
+
+	}
+
+	raycastFirst( mesh, raycaster, ray ) {
+
+		let closestResult = null;
+
+		for ( const root of this._roots ) {
+
+			const result = root.raycastFirst( mesh, raycaster, ray );
+			if ( result != null && ( closestResult == null || result.distance < closestResult.distance ) ) {
+
+				closestResult = result;
+
+			}
+
+		}
+
+		return closestResult;
+
+	}
+
 }

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -79,9 +79,10 @@ export default class MeshBVH {
 			rangeBoundaries.add( group.start + group.count );
 
 		}
+
 		// note that if you don't pass in a comparator, it sorts them lexicographically as strings :-(
 		const sortedBoundaries = Array.from( rangeBoundaries.values() ).sort( ( a, b ) => a - b );
-		for ( let i = 0; i < sortedBoundaries.length - 2; i ++ ) {
+		for ( let i = 0; i < sortedBoundaries.length - 1; i ++ ) {
 
 			const start = sortedBoundaries[ i ], end = sortedBoundaries[ i + 1 ];
 			ranges.push( { offset: ( start / 3 ), count: ( end - start ) / 3 } );

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -4,11 +4,9 @@ import BVHConstructionContext from './BVHConstructionContext.js';
 import { boundsToArray } from './BoundsUtilities.js';
 import { CENTER } from './Constants.js';
 
-export default class MeshBVH extends MeshBVHNode {
+export default class MeshBVH {
 
 	constructor( geo, options = {} ) {
-
-		super();
 
 		// default options
 		options = Object.assign( {
@@ -23,7 +21,7 @@ export default class MeshBVH extends MeshBVHNode {
 
 		if ( geo.isBufferGeometry ) {
 
-			this._root = this._buildTree( geo, options );
+			this._roots = this._buildTree( geo, options );
 
 		} else {
 
@@ -120,9 +118,10 @@ export default class MeshBVH extends MeshBVHNode {
 
 		};
 
+		const root = new MeshBVHNode();
 		if ( ! geo.boundingBox ) geo.computeBoundingBox();
-		this.boundingData = boundsToArray( geo.boundingBox );
-		splitNode( this, 0, geo.index.count / 3 );
+		root.boundingData = boundsToArray( geo.boundingBox );
+		splitNode( root, 0, geo.index.count / 3 );
 
 		if ( reachedMaxDepth && options.verbose ) {
 
@@ -131,7 +130,7 @@ export default class MeshBVH extends MeshBVHNode {
 
 		}
 
-		return this;
+		return [ root ];
 
 	}
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import MeshBVHNode from './MeshBVHNode.js';
 import BVHConstructionContext from './BVHConstructionContext.js';
-import { boundsToArray } from './BoundsUtilities.js';
 import { CENTER } from './Constants.js';
 
 export default class MeshBVH {
@@ -66,9 +65,9 @@ export default class MeshBVH {
 	//
 	_getRootIndexRanges( geo ) {
 
-		if ( !geo.groups || !geo.groups.length ) {
+		if ( ! geo.groups || ! geo.groups.length ) {
 
-			return [{ offset: 0, count: geo.index.count / 3 }];
+			return [ { offset: 0, count: geo.index.count / 3 } ];
 
 		}
 
@@ -81,11 +80,12 @@ export default class MeshBVH {
 
 		}
 		// note that if you don't pass in a comparator, it sorts them lexicographically as strings :-(
-		const sortedBoundaries = Array.from( rangeBoundaries.values() ).sort((a, b) => a - b);
+		const sortedBoundaries = Array.from( rangeBoundaries.values() ).sort( ( a, b ) => a - b );
 		for ( let i = 0; i < sortedBoundaries.length - 2; i ++ ) {
 
 			const start = sortedBoundaries[ i ], end = sortedBoundaries[ i + 1 ];
 			ranges.push( { offset: ( start / 3 ), count: ( end - start ) / 3 } );
+
 		}
 		return ranges;
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -52,6 +52,18 @@ export default class MeshBVH {
 
 	}
 
+	// Computes the set of { offset, count } ranges which need independent BVH roots. Each
+	// region in the geometry index that belongs to a different set of material groups requires
+	// a separate BVH root, so that triangles indices belonging to one group never get swapped
+	// with triangle indices belongs to another group. For example, if the groups were like this:
+	//
+	// [-------------------------------------------------------------]
+	// |__________________|
+	//   g0 = [0, 20]  |______________________||_____________________|
+	//                      g1 = [16, 40]           g2 = [41, 60]
+	//
+	// we would need four BVH roots: [0, 15], [16, 20], [21, 40], [41, 60].
+	//
 	_getRootIndexRanges( geo ) {
 
 		if ( !geo.groups || !geo.groups.length ) {

--- a/src/index.js
+++ b/src/index.js
@@ -18,12 +18,12 @@ function acceleratedRaycast( raycaster, intersects ) {
 
 		if ( raycaster.firstHitOnly === true ) {
 
-			const res = this.geometry.boundsTree._roots[0].raycastFirst( this, raycaster, ray );
+			const res = this.geometry.boundsTree.raycastFirst( this, raycaster, ray );
 			if ( res ) intersects.push( res );
 
 		} else {
 
-			this.geometry.boundsTree._roots[0].raycast( this, raycaster, ray, intersects );
+			this.geometry.boundsTree.raycast( this, raycaster, ray, intersects );
 
 		}
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,12 +18,12 @@ function acceleratedRaycast( raycaster, intersects ) {
 
 		if ( raycaster.firstHitOnly === true ) {
 
-			const res = this.geometry.boundsTree.raycastFirst( this, raycaster, ray );
+			const res = this.geometry.boundsTree._roots[0].raycastFirst( this, raycaster, ray );
 			if ( res ) intersects.push( res );
 
 		} else {
 
-			this.geometry.boundsTree.raycast( this, raycaster, ray, intersects );
+			this.geometry.boundsTree._roots[0].raycast( this, raycaster, ray, intersects );
 
 		}
 

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,50 @@ describe( 'Bounds Tree', () => {
 
 	} );
 
+	it( 'should respect index group invariants', () => {
+
+		const geo = new THREE.TorusBufferGeometry( 5, 5, 400, 100 );
+		const groupCount = 10;
+		const groupSize = geo.index.array.length / groupCount;
+
+		for ( let g = 0; g < groupCount; g ++ ) {
+
+			const groupStart = g * groupSize;
+			geo.addGroup( groupStart, groupSize, 0 );
+
+		}
+
+		const indicesByGroup = () => {
+
+			const result = {};
+
+			for ( let g = 0; g < geo.groups.length; g ++ ) {
+
+				result[ g ] = new Set();
+				const { start, count } = geo.groups[ g ];
+				for ( let i = start; i < start + count; i ++ ) {
+
+					result[ g ].add( geo.index.array[ i ] );
+
+				}
+
+			}
+			return result;
+
+		};
+
+		const before = indicesByGroup();
+		geo.computeBoundsTree();
+		const after = indicesByGroup();
+
+		for ( let g in before ) {
+
+			expect( before[ g ] ).toEqual( after[ g ] );
+
+		}
+
+	} );
+
 } );
 
 describe( 'Options', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -34,8 +34,12 @@ describe( 'Bounds Tree', () => {
 		let calledRaycastFirst = false;
 		geom.boundsTree = {
 
-			raycast: () => calledRaycast = true,
-			raycastFirst: () => calledRaycastFirst = true
+			_roots: [{
+
+				raycast: () => calledRaycast = true,
+				raycastFirst: () => calledRaycastFirst = true
+
+			}]
 
 		};
 
@@ -80,7 +84,7 @@ describe( 'Options', () => {
 
 			mesh.geometry.computeBoundsTree();
 
-			const depth = getMaxDepth( mesh.geometry.boundsTree );
+			const depth = getMaxDepth( mesh.geometry.boundsTree._roots[0] );
 			expect( depth ).toBeGreaterThan( 10 );
 
 		} );
@@ -89,7 +93,7 @@ describe( 'Options', () => {
 
 			mesh.geometry.computeBoundsTree( { maxDepth: 10, verbose: false } );
 
-			const depth = getMaxDepth( mesh.geometry.boundsTree );
+			const depth = getMaxDepth( mesh.geometry.boundsTree._roots[0] );
 			expect( depth ).toEqual( 10 );
 
 		} );

--- a/test/test.js
+++ b/test/test.js
@@ -63,16 +63,22 @@ describe( 'Options', () => {
 	describe( 'maxDepth', () => {
 
 		// Returns the max tree depth of the BVH
-		function getMaxDepth( node ) {
+		function getMaxDepth( bvh ) {
 
-			const isLeaf = 'count' in node;
+			function getMaxDepthFrom( node ) {
 
-			if ( isLeaf ) return 0;
+				const isLeaf = 'count' in node;
 
-			return 1 + Math.max(
-				getMaxDepth( node.left ),
-				getMaxDepth( node.right )
-			);
+				if ( isLeaf ) return 0;
+
+				return 1 + Math.max(
+					getMaxDepthFrom( node.left ),
+					getMaxDepthFrom( node.right )
+				);
+
+			}
+
+			return Math.max.apply( null, bvh._roots.map( getMaxDepthFrom ) );
 
 		}
 
@@ -80,7 +86,7 @@ describe( 'Options', () => {
 
 			mesh.geometry.computeBoundsTree();
 
-			const depth = getMaxDepth( mesh.geometry.boundsTree._roots[ 0 ] );
+			const depth = getMaxDepth( mesh.geometry.boundsTree );
 			expect( depth ).toBeGreaterThan( 10 );
 
 		} );
@@ -89,7 +95,7 @@ describe( 'Options', () => {
 
 			mesh.geometry.computeBoundsTree( { maxDepth: 10, verbose: false } );
 
-			const depth = getMaxDepth( mesh.geometry.boundsTree._roots[ 0 ] );
+			const depth = getMaxDepth( mesh.geometry.boundsTree );
 			expect( depth ).toEqual( 10 );
 
 		} );

--- a/test/test.js
+++ b/test/test.js
@@ -34,12 +34,8 @@ describe( 'Bounds Tree', () => {
 		let calledRaycastFirst = false;
 		geom.boundsTree = {
 
-			_roots: [{
-
-				raycast: () => calledRaycast = true,
-				raycastFirst: () => calledRaycastFirst = true
-
-			}]
+			raycast: () => calledRaycast = true,
+			raycastFirst: () => calledRaycastFirst = true
 
 		};
 

--- a/test/test.js
+++ b/test/test.js
@@ -80,7 +80,7 @@ describe( 'Options', () => {
 
 			mesh.geometry.computeBoundsTree();
 
-			const depth = getMaxDepth( mesh.geometry.boundsTree._roots[0] );
+			const depth = getMaxDepth( mesh.geometry.boundsTree._roots[ 0 ] );
 			expect( depth ).toBeGreaterThan( 10 );
 
 		} );
@@ -89,7 +89,7 @@ describe( 'Options', () => {
 
 			mesh.geometry.computeBoundsTree( { maxDepth: 10, verbose: false } );
 
-			const depth = getMaxDepth( mesh.geometry.boundsTree._roots[0] );
+			const depth = getMaxDepth( mesh.geometry.boundsTree._roots[ 0 ] );
 			expect( depth ).toEqual( 10 );
 
 		} );


### PR DESCRIPTION
Resolves #66. Now the BVH respects [groups](https://threejs.org/docs/#api/en/core/BufferGeometry.groups) on geometries, instead of mucking up the index and rendering the groups meaningless. This implements "option 3" as discussed in the linked issue. It seems to work well on some test Hubs scenes that have geometries with groups. There's no measurable change in performance for geometries that don't have groups, as it just adds one trivial layer of processing and indirection at the top of raycasting.