### PR TITLE
Add index option

### DIFF
--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -13,10 +13,10 @@ const xyzFields = [ 'x', 'y', 'z' ];
 // - centroids: an array of size tris.length * 3 where triangle i maps to an [x, y, z] triplet
 //   starting at index i * 3, representing the centroid of triangle i
 //
-function computeTriangleData( geo ) {
+function computeTriangleData( geo, indexAttr ) {
 
 	const verts = geo.attributes.position.array;
-	const index = geo.index.array;
+	const index = indexAttr.array;
 	const triCount = index.length / 3;
 	const bounds = new Float32Array( triCount * 6 );
 	const centroids = new Float32Array( triCount * 3 );
@@ -53,7 +53,7 @@ export default class BVHConstructionContext {
 		this.geo = geo;
 		this.options = options;
 
-		const data = computeTriangleData( geo );
+		const data = computeTriangleData( geo, options.index );
 		this.centroids = data.centroids;
 		this.bounds = data.bounds;
 
@@ -61,7 +61,7 @@ export default class BVHConstructionContext {
 		this.sahplanes = null;
 		if ( options.strategy === SAH ) {
 
-			const triCount = geo.index.count / 3;
+			const triCount = options.index.count / 3;
 			this.sahplanes = [ new Array( triCount ), new Array( triCount ), new Array( triCount ) ];
 			for ( let tri = 0; tri < triCount; tri ++ ) {
 
@@ -136,7 +136,7 @@ export default class BVHConstructionContext {
 		let right = offset + count - 1;
 		const pos = split.pos;
 		const axis = split.axis;
-		const index = this.geo.index.array;
+		const index = this.options.index.array;
 		const centroids = this.centroids;
 		const bounds = this.bounds;
 		const sahplanes = this.sahplanes;

--- a/src/GeometryUtilities.js
+++ b/src/GeometryUtilities.js
@@ -3,12 +3,12 @@ import { checkBufferGeometryIntersection } from './IntersectionUtilities.js';
 // For BVH code specifically. Does not check morph targets
 // Copied from mesh raycasting
 // Ripped an modified from the THREE.js source in Mesh.CS
-const intersectTri = ( mesh, geo, raycaster, ray, tri, intersections ) => {
+const intersectTri = ( mesh, geo, raycaster, ray, tri, index, intersections = null ) => {
 
 	const triOffset = tri * 3;
-	const a = geo.index.getX( triOffset );
-	const b = geo.index.getX( triOffset + 1 );
-	const c = geo.index.getX( triOffset + 2 );
+	const a = index.getX( triOffset );
+	const b = index.getX( triOffset + 1 );
+	const c = index.getX( triOffset + 2 );
 
 	const intersection = checkBufferGeometryIntersection( mesh, raycaster, ray, geo.attributes.position, geo.attributes.uv, a, b, c );
 
@@ -24,23 +24,23 @@ const intersectTri = ( mesh, geo, raycaster, ray, tri, intersections ) => {
 
 };
 
-const intersectTris = ( mesh, geo, raycaster, ray, offset, count, intersections ) => {
+const intersectTris = ( mesh, geo, raycaster, ray, offset, count, index, intersections ) => {
 
 	for ( let i = offset, end = offset + count; i < end; i ++ ) {
 
-		intersectTri( mesh, geo, raycaster, ray, i, intersections );
+		intersectTri( mesh, geo, raycaster, ray, i, index, intersections );
 
 	}
 
 };
 
-const intersectClosestTri = ( mesh, geo, raycaster, ray, offset, count ) => {
+const intersectClosestTri = ( mesh, geo, raycaster, ray, offset, count, index ) => {
 
 	let dist = Infinity;
 	let res = null;
 	for ( let i = offset, end = offset + count; i < end; i ++ ) {
 
-		const intersection = intersectTri( mesh, geo, raycaster, ray, i );
+		const intersection = intersectTri( mesh, geo, raycaster, ray, i, index );
 		if ( intersection && intersection.distance < dist ) {
 
 			res = intersection;

--- a/src/MeshBVHNode.js
+++ b/src/MeshBVHNode.js
@@ -25,25 +25,25 @@ class MeshBVHNode {
 
 	}
 
-	raycast( mesh, raycaster, ray, intersects ) {
+	raycast( mesh, index, raycaster, ray, intersects ) {
 
-		if ( this.count ) intersectTris( mesh, mesh.geometry, raycaster, ray, this.offset, this.count, intersects );
+		if ( this.count ) intersectTris( mesh, mesh.geometry, raycaster, ray, this.offset, this.count, index, intersects );
 		else {
 
 			if ( this.left.intersectRay( ray, boxIntersection ) )
-				this.left.raycast( mesh, raycaster, ray, intersects );
+				this.left.raycast( mesh, index, raycaster, ray, intersects );
 			if ( this.right.intersectRay( ray, boxIntersection ) )
-				this.right.raycast( mesh, raycaster, ray, intersects );
+				this.right.raycast( mesh, index, raycaster, ray, intersects );
 
 		}
 
 	}
 
-	raycastFirst( mesh, raycaster, ray ) {
+	raycastFirst( mesh, index, raycaster, ray ) {
 
 		if ( this.count ) {
 
-			return intersectClosestTri( mesh, mesh.geometry, raycaster, ray, this.offset, this.count );
+			return intersectClosestTri( mesh, mesh.geometry, raycaster, ray, this.offset, this.count, index );
 
 		} else {
 
@@ -70,7 +70,7 @@ class MeshBVHNode {
 			}
 
 			const c1Intersection = c1.intersectRay( ray, boxIntersection );
-			const c1Result = c1Intersection ? c1.raycastFirst( mesh, raycaster, ray ) : null;
+			const c1Result = c1Intersection ? c1.raycastFirst( mesh, index, raycaster, ray ) : null;
 
 			// if we got an intersection in the first node and it's closer than the second node's bounding
 			// box, we don't need to consider the second node because it couldn't possibly be a better result
@@ -94,7 +94,7 @@ class MeshBVHNode {
 			// either there was no intersection in the first node, or there could still be a closer
 			// intersection in the second, so check the second node and then take the better of the two
 			const c2Intersection = c2.intersectRay( ray, boxIntersection );
-			const c2Result = c2Intersection ? c2.raycastFirst( mesh, raycaster, ray ) : null;
+			const c2Result = c2Intersection ? c2.raycastFirst( mesh, index, raycaster, ray ) : null;
 
 			if ( c1Result && c2Result ) {
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,13 @@ function acceleratedRaycast( raycaster, intersects ) {
 
 function computeBoundsTree( options ) {
 
+	options = Object.assign( {
+		index: this.getIndex()
+	}, options );
+
 	this.boundsTree = new MeshBVH( this, options );
+	this.setIndex( this.boundsTree.index, 1, false );
+
 	return this.boundsTree;
 
 }

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function computeBoundsTree( options ) {
 	}, options );
 
 	this.boundsTree = new MeshBVH( this, options );
-	this.setIndex( this.boundsTree.index, 1, false );
+	this.setIndex( this.boundsTree.index );
 
 	return this.boundsTree;
 

--- a/test/test.js
+++ b/test/test.js
@@ -172,6 +172,26 @@ describe( 'Options', () => {
 
 	} );
 
+	describe( 'index', () => {
+
+		it( 'should create a new index buffer by default', () => {
+
+			const bvh = new MeshBVH( mesh.geometry, { index: null, maxDepth: 3, verbose: false } );
+			expect( bvh.index ).toBeTruthy();
+			expect( bvh.index ).not.toBe( mesh.geometry.index );
+
+		} );
+
+		it( 'should use the index buffer provided', () => {
+
+			const bvh = new MeshBVH( mesh.geometry, { index: mesh.geometry.index, maxDepth: 3, verbose: false } );
+			expect( bvh.index ).toBeTruthy();
+			expect( bvh.index ).toBe( mesh.geometry.index );
+
+		} );
+
+	} );
+
 	afterEach( () => {
 
 		mesh.geometry.boundsTree = null;

--- a/test/test.js
+++ b/test/test.js
@@ -150,7 +150,7 @@ describe( 'Options', () => {
 			raycaster.ray.origin.set( 0, 0, 10 );
 			raycaster.ray.direction.set( 0, 0, - 1 );
 
-			const bvh = new MeshBVH( mesh.geometry, { maxDepth: 3, verbose: false } );
+			const bvh = new MeshBVH( mesh.geometry, { index: mesh.geometry.index, maxDepth: 3, verbose: false } );
 			const ogHits = raycaster.intersectObject( mesh, true );
 
 			mesh.geometry.boundsTree = bvh;
@@ -245,7 +245,7 @@ describe( 'Raycaster', () => {
 
 		it( 'should yield closest hit only with a bounds tree', () => {
 
-			const bvh = new MeshBVH( geometry );
+			const bvh = new MeshBVH( geometry, { index: geometry.index } );
 			raycaster.firstHitOnly = false;
 			const allHits = raycaster.intersectObject( mesh, true );
 


### PR DESCRIPTION
Fix #67 

I added the `index` option so an index attribute buffer can be provided instead of automatically overriding the geometry's index buffer. The index is supposed to be provided as a `BufferAttribute` type so creating a bvh on geometry will look like this if you want to guarantee the index is used on the geometry when the index is originally null:

```js
geometry.boundsTree = new MeshBVH( geometry, { index: geometry.index } );
geometry.setIndex( geometry.boundsTree.index );
```

Originally I was going to just pass the index array in but the raycasting uses functions from `BufferAttribute` and it seemed cleaner to use that class.