### PR TITLE
Add Error Conditions and Update Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Error conditions when using `InterleavedAttributeBuffers` for both index and position geometry attributes.
+- The geometry index attribute is modified when building the `MeshBVH`. And index attribute is created on geometry if it does not exist.
+
+### Fixed
+- Fix the bounds tree not respecting groups
+
 ## [0.0.2] - 2019-01-05
 ### Added
 - Add included files array to package.json.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Constructs the bounds tree for the given geometry and produces a new index attri
 }
 ```
 
+*NOTE: The geometry's index attribute array is modified in order to build the bounds tree. If the geometry has no index then one is added.*
+
 #### raycast(mesh : Mesh, raycaster : Raycaster, ray : Ray, intersects : Array)
 
 Adds all raycast triangle hits in unsorted order to the `intersects` array. It is expected that `ray` is in the frame of the mesh being raycast against and that the geometry on `mesh` is the same as the one used to generate the bvh.
@@ -146,4 +148,7 @@ THREE.Mesh.prototype.raycast = acceleratedRaycast;
 - A bounds tree can be generated for either an indexed or non-indexed `BufferGeometry`, but an index will
   be produced and retained as a side effect of the construction.
 - The bounds hierarchy is _not_ dynamic, so geometry that uses morph targets cannot be used.
-- If the geometry is changed, then a call to `computedBoundsTree()` is required to update the bounds tree.
+- If the geometry is changed then a new bounds tree will need to be generated.
+- Only BufferGeometry (not [Geometry](https://threejs.org/docs/#api/en/core/Geometry)) is supported when building a bounds tree.
+- [InterleavedBufferAttributes](https://threejs.org/docs/#api/en/core/InterleavedBufferAttribute) are not supported on the geometry index or position attributes.
+- A separate bounds tree is generated for each [geometry group](https://threejs.org/docs/#api/en/objects/Group), which could result in poorer raycast performance on geometry with lots of groups.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ THREE.Mesh.prototype.raycast = acceleratedRaycast;
 
 // Generate the BVH and use the newly generated index
 geom.boundsTree = new MeshBVH(geom);
-geom.setIndex(geom.boundsTree.index);
 ```
 
 ## Exports

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -7,6 +7,20 @@ export default class MeshBVH {
 
 	constructor( geo, options = {} ) {
 
+		if ( ! geo.isBufferGeometry ) {
+
+			throw new Error( 'MeshBVH: Only BufferGeometries are supported.' );
+
+		} else if ( geo.attributes.position.isInterleavedBufferAttribute ) {
+
+			throw new Error( 'MeshBVH: InterleavedBufferAttribute is not supported for the position attribute.' );
+
+		} else if ( geo.index && geo.index.isInterleavedBufferAttribute ) {
+
+			throw new Error( 'MeshBVH: InterleavedBufferAttribute is not supported for the index attribute.' );
+
+		}
+
 		// default options
 		options = Object.assign( {
 
@@ -18,15 +32,8 @@ export default class MeshBVH {
 		}, options );
 		options.strategy = Math.max( 0, Math.min( 2, options.strategy ) );
 
-		if ( geo.isBufferGeometry ) {
+		this._roots = this._buildTree( geo, options );
 
-			this._roots = this._buildTree( geo, options );
-
-		} else {
-
-			throw new Error( 'MeshBVH: Only BufferGeometries are supported.' );
-
-		}
 
 	}
 

--- a/test/test.js
+++ b/test/test.js
@@ -21,6 +21,61 @@ describe( 'Bounds Tree', () => {
 
 	} );
 
+	it( 'should throw an error if THREE.Geometry is used', () => {
+
+		const geom = new THREE.SphereGeometry( 1, 1, 1 );
+		let errorThrown = false;
+		try {
+		
+			new MeshBVH( geom, { verbose: false } );
+		
+		} catch {
+		
+			errorThrown = true;
+		
+		}
+
+		expect( errorThrown ).toBe( true );
+
+	} );
+
+	it( 'should throw an error if InterleavedBufferAttributes are used', () => {
+
+		const indexAttr = new THREE.InterleavedBufferAttribute( new THREE.InterleavedBuffer( new Uint32Array( [ 1, 2, 3 ] ), 1 ), 4, 0, false );
+		const posAttr = new THREE.InterleavedBufferAttribute( new THREE.InterleavedBuffer( new Float32Array( [ 1, 2, 3 ] ), 3 ), 4, 0, false );
+
+		let geometry;
+		let posErrorThrown = false;
+		let indexErrorThrown = false;
+
+		geometry = new THREE.BoxBufferGeometry();
+		geometry.addAttribute( 'position', posAttr );
+		try {
+
+			new MeshBVH( geom, { verbose: false } );
+
+		} catch {
+
+			posErrorThrown = true;
+
+		}
+		expect( posErrorThrown ).toBe( true );
+
+		geometry = new THREE.BoxBufferGeometry();
+		geometry.setIndex( indexAttr );
+		try {
+
+			new MeshBVH( geom, { verbose: false } );
+
+		} catch {
+
+			indexErrorThrown = true;
+
+		}
+		expect( indexErrorThrown ).toBe( true );
+
+	} );
+
 	it( 'should use the boundsTree when raycasting if available', () => {
 
 		const geom = new THREE.SphereBufferGeometry( 1, 1, 1 );

--- a/test/test.js
+++ b/test/test.js
@@ -26,13 +26,13 @@ describe( 'Bounds Tree', () => {
 		const geom = new THREE.SphereGeometry( 1, 1, 1 );
 		let errorThrown = false;
 		try {
-		
+
 			new MeshBVH( geom, { verbose: false } );
-		
-		} catch {
-		
+
+		} catch ( e ) {
+
 			errorThrown = true;
-		
+
 		}
 
 		expect( errorThrown ).toBe( true );
@@ -52,9 +52,9 @@ describe( 'Bounds Tree', () => {
 		geometry.addAttribute( 'position', posAttr );
 		try {
 
-			new MeshBVH( geom, { verbose: false } );
+			new MeshBVH( geometry, { verbose: false } );
 
-		} catch {
+		} catch ( e ) {
 
 			posErrorThrown = true;
 
@@ -65,9 +65,9 @@ describe( 'Bounds Tree', () => {
 		geometry.setIndex( indexAttr );
 		try {
 
-			new MeshBVH( geom, { verbose: false } );
+			new MeshBVH( geometry, { verbose: false } );
 
-		} catch {
+		} catch ( e ) {
 
 			indexErrorThrown = true;
 


### PR DESCRIPTION
Fix #72.

Pretty basic PR that adds errors if `InterleavedAttributeBuffers` are used and updates the docs. If all looks good I'll plan to push `v0.1.0`. I think I'll leave #71 until there's a better use case for its inclusion.