### PR TITLE
Fix created index array, visualizer

### DIFF
--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -44,11 +44,10 @@ export default class MeshBVH {
 		if ( ! geo.index ) {
 
 			const vertexCount = geo.attributes.position.count;
-			const indexCount = vertexCount;
-			const index = new ( vertexCount > 65535 ? Uint32Array : Uint16Array )( indexCount );
+			const index = new ( vertexCount > 65535 ? Uint32Array : Uint16Array )( vertexCount );
 			geo.setIndex( new THREE.BufferAttribute( index, 1 ) );
 
-			for ( let i = 0; i < indexCount; i ++ ) {
+			for ( let i = 0; i < vertexCount; i ++ ) {
 
 				index[ i ] = i;
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -43,9 +43,9 @@ export default class MeshBVH {
 
 		if ( ! geo.index ) {
 
-			const triCount = geo.attributes.position.count / 3;
-			const indexCount = triCount * 3;
-			const index = new ( triCount > 65535 ? Uint32Array : Uint16Array )( indexCount );
+			const vertexCount = geo.attributes.position.count;
+			const indexCount = vertexCount;
+			const index = new ( vertexCount > 65535 ? Uint32Array : Uint16Array )( indexCount );
 			geo.setIndex( new THREE.BufferAttribute( index, 1 ) );
 
 			for ( let i = 0; i < indexCount; i ++ ) {

--- a/src/MeshBVHVisualizer.js
+++ b/src/MeshBVHVisualizer.js
@@ -75,10 +75,6 @@ class MeshBVHRootVisualizer extends THREE.Object3D {
 
 		}
 
-		this.position.copy( this._mesh.position );
-		this.rotation.copy( this._mesh.rotation );
-		this.scale.copy( this._mesh.scale );
-
 	}
 
 }
@@ -93,11 +89,13 @@ class MeshBVHVisualizer extends THREE.Object3D {
 		this._mesh = mesh;
 		this._roots = [];
 
+		this.update();
+
 	}
 
 	update() {
 
-		const bvh = this._mesh.boundsTree;
+		const bvh = this._mesh.geometry.boundsTree;
 		const totalRoots = bvh ? bvh._roots.length : 0;
 		while ( this._roots.length > totalRoots ) {
 
@@ -110,6 +108,7 @@ class MeshBVHVisualizer extends THREE.Object3D {
 			if ( i >= this._roots.length ) {
 
 				const root = new MeshBVHRootVisualizer( this._mesh, this.depth, i );
+				this.add( root );
 				this._roots.push( root );
 
 			} else {
@@ -121,6 +120,10 @@ class MeshBVHVisualizer extends THREE.Object3D {
 			}
 
 		}
+
+		this.position.copy( this._mesh.position );
+		this.rotation.copy( this._mesh.rotation );
+		this.scale.copy( this._mesh.scale );
 
 	}
 

--- a/src/MeshBVHVisualizer.js
+++ b/src/MeshBVHVisualizer.js
@@ -5,16 +5,17 @@ const wiremat = new THREE.LineBasicMaterial( { color: 0x00FF88, transparent: tru
 const boxGeom = new THREE.Box3Helper().geometry;
 let boundingBox = new THREE.Box3();
 
-class MeshBVHVisualizer extends THREE.Object3D {
+class MeshBVHRootVisualizer extends THREE.Object3D {
 
-	constructor( mesh, depth = 10 ) {
+	constructor( mesh, depth = 10, group = 0 ) {
 
-		super();
+		super( 'MeshBVHRootVisualizer' );
 
 		this.depth = depth;
 		this._oldDepth = - 1;
 		this._mesh = mesh;
 		this._boundsTree = null;
+		this._group = group;
 
 		this.update();
 
@@ -66,8 +67,7 @@ class MeshBVHVisualizer extends THREE.Object3D {
 
 				};
 
-				// TODO: Fix this so it visualizes all the roots
-				recurse( this._boundsTree._roots[ 0 ], 0 );
+				recurse( this._boundsTree._roots[ this._group ], 0 );
 
 			}
 
@@ -82,5 +82,49 @@ class MeshBVHVisualizer extends THREE.Object3D {
 	}
 
 }
+
+class MeshBVHVisualizer extends THREE.Object3D {
+
+	constructor( mesh, depth = 10 ) {
+
+		super( 'MeshBVHVisualizer' );
+
+		this.depth = depth;
+		this._mesh = mesh;
+		this._roots = [];
+
+	}
+
+	update() {
+
+		const bvh = this._mesh.boundsTree;
+		const totalRoots = bvh ? bvh._roots.length : 0;
+		while ( this._roots.length > totalRoots ) {
+
+			this._roots.pop();
+
+		}
+
+		for ( let i = 0; i < totalRoots; i ++ ) {
+
+			if ( i >= this._roots.length ) {
+
+				const root = new MeshBVHRootVisualizer( this._mesh, this.depth, i );
+				this._roots.push( root );
+
+			} else {
+
+				let root = this._roots[ i ];
+				root.depth = this.depth;
+				root.update();
+
+			}
+
+		}
+
+	}
+
+}
+
 
 export default MeshBVHVisualizer;

--- a/test/MeshBVH.test.js
+++ b/test/MeshBVH.test.js
@@ -147,6 +147,29 @@ describe( 'Bounds Tree', () => {
 
 	} );
 
+	it( 'should create a correctly sized and typed index if one does not exist', () => {
+
+		const geom = new THREE.BufferGeometry();
+		const smallPosAttr = new THREE.BufferAttribute( new Float32Array( 3 * Math.pow( 2, 16 ) - 3 ), 3, false );
+		const largePosAttr = new THREE.BufferAttribute( new Float32Array( 3 * Math.pow( 2, 16 ) + 3 ), 3, false );
+
+		geom.addAttribute( 'position', smallPosAttr );
+
+		expect( geom.index ).toBe( null );
+		new MeshBVH( geom );
+		expect( geom.index ).not.toBe( null );
+		expect( geom.index.count ).toBe( smallPosAttr.count );
+		expect( geom.index.array.BYTES_PER_ELEMENT ).toBe( 2 );
+
+		geom.index = null;
+		geom.addAttribute( 'position', largePosAttr );
+		new MeshBVH( geom );
+		expect( geom.index ).not.toBe( null );
+		expect( geom.index.count ).toBe( largePosAttr.count );
+		expect( geom.index.array.BYTES_PER_ELEMENT ).toBe( 4 );
+
+	} );
+
 } );
 
 


### PR DESCRIPTION
Fix #75
Fix #94
Related to #93 

- Add a test to verify that the correct array type is used for the index buffer
- Fix case where the index buffer would be instantiated with the wrong type
- Make the MeshBVHVisualizer work with multiple BVH roots