### PR TITLE
Fix three peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/gkjohnson/three-mesh-bvh#readme",
   "peerDependencies": {
-    "three": "^0.102.1"
+    "three": ">= 0.102.1"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",


### PR DESCRIPTION
I've been getting this warning message for a while now:

```
warning " > three-mesh-bvh@0.1.3" has incorrect peer dependency "three@^0.102.1"
```

So I figured I'd update the peer dependency version for three. Let me know if it should be something else.