### PR TITLE
Improve Benchmark Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,32 @@ If the raycaster object being used has a property `firstHitOnly` set to `true`, 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 ```
 
+## Debug Functions
+
+### .estimateMemoryInBytes
+
+```js
+estimateMemoryInBytes( bvh : MeshBVH ) : Number
+```
+
+Roughly estimates the amount of memory in bytes a BVH is using.
+
+### .getBVHExtremes
+
+```js
+getBVHExtremes( bvh : MeshBVH ) : Array< Object >
+```
+
+Measures the min and max extremes of the tree including node depth, leaf triangle count, and number of splits on different axes to show how well a tree is structured. Returns an array of extremes for each group root for the bvh. The objects are structured like so:
+
+```js
+{
+	depth: { min: Number, max: Number },
+	tris: { min: Number, max: Number },
+	splits: [ Number, Number, Number ]
+}
+```
+
 ## Gotchas
 
 - This is intended to be used with complicated, high-poly meshes. With less complex meshes, the benefits are negligible.

--- a/benchmark/run-benchmark.js
+++ b/benchmark/run-benchmark.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
-import { getSize, pad, runBenchmark, getExtremes } from './utils.js';
-import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CENTER, AVERAGE, SAH } from '../src/index.js';
+import { runBenchmark } from './utils.js';
+import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CENTER, AVERAGE, SAH, estimateMemoryInBytes, getBVHExtremes } from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
@@ -24,53 +24,132 @@ const raycaster = new THREE.Raycaster();
 raycaster.ray.origin.set( 0, 0, - 10 );
 raycaster.ray.direction.set( 0, 0, 1 );
 
-runBenchmark(
+function logExtremes( bvh ) {
 
-	'Compute BVH (CENTER)',
-	() => {
+	const bvhSize = estimateMemoryInBytes( bvh );
+	const extremes = getBVHExtremes( bvh )[ 0 ];
+	console.log(
+		`\tExtremes:\n` +
+		`\t\tmemory: ${ bvhSize / 1000 } kb\n` +
+		`\t\ttris: ${extremes.tris.min}, ${extremes.tris.max}\n` +
+		`\t\tdepth: ${extremes.depth.min}, ${extremes.depth.max}\n` +
+		`\t\tsplits: ${extremes.splits[ 0 ]}, ${extremes.splits[ 1 ]}, ${extremes.splits[ 2 ]}\n`
+	);
 
-		geometry.computeBoundsTree( { strategy: CENTER } );
-		geometry.boundsTree = null;
+}
 
-	},
-	3000,
-	50
+function runSuite( strategy ) {
 
-);
+	geometry.computeBoundsTree( { strategy: strategy } );
+	logExtremes( geometry.boundsTree );
 
-geometry.computeBoundsTree( { strategy: CENTER } );
-console.log( getExtremes( geometry.boundsTree._roots[ 0 ] ) );
+	runBenchmark(
+
+		'Compute BVH',
+		() => {
+
+			geometry.computeBoundsTree( { strategy: strategy } );
+			geometry.boundsTree = null;
+
+		},
+		3000,
+		50
+
+	);
+
+	geometry.computeBoundsTree( { strategy: strategy } );
+	raycaster.firstHitOnly = false;
+	runBenchmark(
+
+		'BVH Raycast',
+		() => mesh.raycast( raycaster, [] ),
+		3000
+
+	);
+
+	raycaster.firstHitOnly = true;
+	runBenchmark(
+
+		'First Hit Raycast',
+		() => mesh.raycast( raycaster, [] ),
+		3000
+
+	);
+
+	console.log( '' );
+
+	runBenchmark(
+
+		'IntersectsSphere',
+		() => mesh.geometry.boundsTree.intersectsSphere( mesh, sphere ),
+		3000
+
+	);
+
+	runBenchmark(
+
+		'IntersectsBox',
+		() => mesh.geometry.boundsTree.intersectsBox( mesh, box, boxMat ),
+		3000
+
+	);
+
+	runBenchmark(
+
+		'DistanceToGeometry',
+		() => mesh.geometry.boundsTree.closestPointToGeometry( mesh, intersectGeometry, geomMat, target1, target2 ),
+		3000
+
+	);
+
+	const vec = new THREE.Vector3();
+	runBenchmark(
+
+		'DistanceToPoint',
+		() => mesh.geometry.boundsTree.closestPointToPoint( mesh, vec, target1 ),
+		3000
+
+	);
+
+	console.log( '' );
+
+	intersectGeometry.computeBoundsTree( { strategy: strategy } );
+	runBenchmark(
+
+		'IntersectsGeometry with BVH',
+		() => mesh.geometry.boundsTree.intersectsGeometry( mesh, intersectGeometry, geomMat ),
+		3000
+
+	);
 
 
-runBenchmark(
+	intersectGeometry.disposeBoundsTree();
+	runBenchmark(
 
-	'Compute BVH (AVERAGE)',
-	() => {
+		'IntersectsGeometry without BVH',
+		() => mesh.geometry.boundsTree.intersectsGeometry( mesh, intersectGeometry, geomMat ),
+		3000
 
-		geometry.computeBoundsTree( { strategy: AVERAGE } );
-		geometry.boundsTree = null;
+	);
 
-	},
-	3000,
-	50
+}
 
-);
 
-runBenchmark(
-
-	'Compute BVH (SAH)',
-	() => {
-
-		geometry.computeBoundsTree( { strategy: SAH } );
-		geometry.boundsTree = null;
-
-	},
-	3000,
-	50
-
-);
+console.log( '*Strategy: CENTER*' );
+runSuite( CENTER );
 
 console.log( '' );
+console.log( '*Strategy: AVERAGE*' );
+runSuite( AVERAGE );
+
+console.log( '' );
+console.log( '*Strategy: SAH*' );
+runSuite( SAH );
+
+//
+
+console.log( '' );
+console.log( '*Strategy: NONE*' );
 
 geometry.boundsTree = null;
 raycaster.firstHitOnly = false;
@@ -82,95 +161,10 @@ runBenchmark(
 
 );
 
-geometry.computeBoundsTree();
-raycaster.firstHitOnly = false;
-runBenchmark(
-
-	'BVH Raycast',
-	() => mesh.raycast( raycaster, [] ),
-	3000
-
-);
-
-
-geometry.computeBoundsTree();
-raycaster.firstHitOnly = true;
-runBenchmark(
-
-	'First Hit Raycast',
-	() => mesh.raycast( raycaster, [] ),
-	3000
-
-);
 
 console.log( '' );
 
-geometry.computeBoundsTree();
-runBenchmark(
-
-	'IntersectsSphere',
-	() => mesh.geometry.boundsTree.intersectsSphere( mesh, sphere ),
-	3000
-
-);
-
-
-geometry.computeBoundsTree();
-runBenchmark(
-
-	'IntersectsBox',
-	() => mesh.geometry.boundsTree.intersectsBox( mesh, box, boxMat ),
-	3000
-
-);
-
-
-geometry.computeBoundsTree();
-intersectGeometry.disposeBoundsTree();
-runBenchmark(
-
-	'IntersectsGeometry without BVH',
-	() => mesh.geometry.boundsTree.intersectsGeometry( mesh, intersectGeometry, geomMat ),
-	3000
-
-);
-
-
-geometry.computeBoundsTree();
-intersectGeometry.computeBoundsTree();
-runBenchmark(
-
-	'IntersectsGeometry with BVH',
-	() => mesh.geometry.boundsTree.intersectsGeometry( mesh, intersectGeometry, geomMat ),
-	3000
-
-);
-
-
-geometry.computeBoundsTree();
-intersectGeometry.computeBoundsTree();
-runBenchmark(
-
-	'DistanceToGeometry',
-	() => mesh.geometry.boundsTree.closestPointToGeometry( mesh, intersectGeometry, geomMat, target1, target2 ),
-	3000
-
-);
-
-const vec = new THREE.Vector3();
-geometry.computeBoundsTree();
-intersectGeometry.computeBoundsTree();
-runBenchmark(
-
-	'DistanceToPoint',
-	() => mesh.geometry.boundsTree.closestPointToPoint( mesh, vec, target1 ),
-	3000
-
-);
-
-console.log( '' );
-
-console.log( 'Extreme Case: Tower Geometry' );
+console.log( 'Extreme Case Tower Geometry' );
 
 const towerGeometry = new THREE.PlaneBufferGeometry( 10, 10, 400, 400 );
 const posAttr = towerGeometry.getAttribute( 'position' );
@@ -186,27 +180,38 @@ for ( let x = 0; x <= 100; x ++ ) {
 	}
 
 }
-towerGeometry.computeBoundsTree();
 
 raycaster.firstHitOnly = false;
 raycaster.ray.origin.set( 100, 100, 100 );
 raycaster.ray.direction.set( - 1, - 1, - 1 );
 mesh.geometry = towerGeometry;
+
+towerGeometry.computeBoundsTree( { strategy: CENTER } );
 runBenchmark(
 
-	'raycast',
+	'CENTER raycast',
 	() => mesh.raycast( raycaster ),
 	3000
 
 );
+logExtremes( towerGeometry.boundsTree );
 
-const towerExtremes = getExtremes( towerGeometry.boundsTree._roots[ 0 ] );
-console.log( towerExtremes );
+towerGeometry.computeBoundsTree( { strategy: AVERAGE } );
+runBenchmark(
 
+	'AVERAGE raycast',
+	() => mesh.raycast( raycaster ),
+	3000
 
-console.log( '' );
+);
+logExtremes( towerGeometry.boundsTree );
 
-geometry.computeBoundsTree();
+towerGeometry.computeBoundsTree( { strategy: SAH } );
+runBenchmark(
 
-const bvhSize = getSize( geometry.boundsTree );
-console.log( `${ pad( 'BVH Memory Usage', 25 ) }: ${ bvhSize / 1000 } kb` );
+	'SAH raycast',
+	() => mesh.raycast( raycaster ),
+	3000
+
+);
+logExtremes( towerGeometry.boundsTree );

--- a/benchmark/run-benchmark.js
+++ b/benchmark/run-benchmark.js
@@ -38,6 +38,10 @@ runBenchmark(
 
 );
 
+geometry.computeBoundsTree( { strategy: CENTER } );
+console.log( getExtremes( geometry.boundsTree._roots[ 0 ] ) );
+
+
 runBenchmark(
 
 	'Compute BVH (AVERAGE)',
@@ -197,8 +201,7 @@ runBenchmark(
 );
 
 const towerExtremes = getExtremes( towerGeometry.boundsTree._roots[ 0 ] );
-console.log( towerExtremes.splits );
-console.log( towerExtremes.depth );
+console.log( towerExtremes );
 
 
 console.log( '' );

--- a/benchmark/run-benchmark.js
+++ b/benchmark/run-benchmark.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { getSize, pad, runBenchmark } from './utils.js';
+import { getSize, pad, runBenchmark, getExtremes } from './utils.js';
 import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CENTER, AVERAGE, SAH } from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
@@ -66,6 +66,8 @@ runBenchmark(
 
 );
 
+console.log( '' );
+
 geometry.boundsTree = null;
 raycaster.firstHitOnly = false;
 runBenchmark(
@@ -97,6 +99,7 @@ runBenchmark(
 
 );
 
+console.log( '' );
 
 geometry.computeBoundsTree();
 runBenchmark(
@@ -160,6 +163,42 @@ runBenchmark(
 	3000
 
 );
+
+console.log( '' );
+
+console.log( 'Extreme Case: Tower Geometry' );
+
+const towerGeometry = new THREE.PlaneBufferGeometry( 10, 10, 400, 400 );
+const posAttr = towerGeometry.getAttribute( 'position' );
+for ( let x = 0; x <= 100; x ++ ) {
+
+	for ( let y = 0; y <= 100; y ++ ) {
+
+		const inCenter = x > 100 && x < 300 && y > 100 && y < 300;
+		const i = x * 100 + y;
+		const z = inCenter ? 50 : - 50;
+		posAttr.setZ( i, z + x * 0.01 );
+
+	}
+
+}
+towerGeometry.computeBoundsTree();
+
+raycaster.firstHitOnly = false;
+raycaster.ray.origin.set( 100, 100, 100 );
+raycaster.ray.direction.set( - 1, - 1, - 1 );
+mesh.geometry = towerGeometry;
+runBenchmark(
+
+	'raycast',
+	() => mesh.raycast( raycaster ),
+	3000
+
+);
+
+const towerExtremes = getExtremes( towerGeometry.boundsTree._roots[ 0 ] );
+console.log( towerExtremes.splits );
+console.log( towerExtremes.depth );
 
 
 console.log( '' );

--- a/benchmark/utils.js
+++ b/benchmark/utils.js
@@ -1,74 +1,3 @@
-// https://stackoverflow.com/questions/1248302/how-to-get-the-size-of-a-javascript-object
-function getPrimitiveSize( el ) {
-
-	switch ( typeof el ) {
-
-		case 'number':
-			return 8;
-		case 'string':
-			return el.length * 2;
-		case 'boolean':
-			return 4;
-		default:
-			return 0;
-
-	}
-
-}
-
-function isTypedArray( arr ) {
-
-	const regex = /(Uint|Int|Float)(8|16|32)Array/;
-	return regex.test( arr.constructor.name );
-
-}
-
-function getSize( obj ) {
-
-	const traversed = [ ];
-	const stack = [ obj ];
-	let bytes = 0;
-
-	while ( stack.length ) {
-
-		const curr = stack.pop();
-		if ( traversed.includes( curr ) ) continue;
-		traversed.push( curr );
-
-		for ( let key in curr ) {
-
-			if ( ! curr.hasOwnProperty( key ) ) continue;
-
-			bytes += getPrimitiveSize( key );
-
-			const value = curr[ key ];
-			if ( value && ( typeof value === 'object' || typeof value === 'function' ) ) {
-
-				if ( isTypedArray( value ) ) {
-
-					bytes += value.byteLength;
-
-				} else {
-
-					stack.push( value );
-
-				}
-
-			} else {
-
-				bytes += getPrimitiveSize( value );
-
-			}
-
-
-		}
-
-	}
-
-	return bytes;
-
-}
-
 function pad( str, len ) {
 
 	let res = str;
@@ -79,42 +8,6 @@ function pad( str, len ) {
 	}
 
 	return res;
-
-}
-
-function getExtremes( node, depth = 0, result = null ) {
-
-	if ( ! result ) {
-
-		result = {
-			depth: {
-				min: Infinity, max: - Infinity
-			},
-			tris: {
-				min: Infinity, max: - Infinity
-			},
-			splits: [ 0, 0, 0 ]
-		};
-
-	}
-
-	if ( ! node.left && ! node.right ) {
-
-		result.depth.min = Math.min( depth, result.depth.min );
-		result.depth.max = Math.max( depth, result.depth.max );
-
-		result.tris.min = Math.min( node.count, result.tris.min );
-		result.tris.max = Math.max( node.count, result.tris.max );
-
-	} else {
-
-		result.splits[ node.splitAxis ] ++;
-		getExtremes( node.left, depth + 1, result );
-		getExtremes( node.right, depth + 1, result );
-
-	}
-
-	return result;
 
 }
 
@@ -131,8 +24,8 @@ function runBenchmark( name, func, maxTime, maxIterations = Infinity ) {
 	}
 	const elapsed = Date.now() - start;
 
-	console.log( `${ pad( name, 25 ) }: ${ parseFloat( ( elapsed / iterations ).toFixed( 6 ) ) } ms` );
+	console.log( `\t${ pad( name, 25 ) }: ${ parseFloat( ( elapsed / iterations ).toFixed( 6 ) ) } ms` );
 
 }
 
-export { getSize, pad, runBenchmark, getExtremes };
+export { pad, runBenchmark };

--- a/benchmark/utils.js
+++ b/benchmark/utils.js
@@ -92,12 +92,13 @@ function getExtremes( node, depth = 0, result = null ) {
 			},
 			tris: {
 				min: Infinity, max: - Infinity
-			}
+			},
+			splits: [ 0, 0, 0 ]
 		};
 
 	}
 
-	if ( ! node.children ) {
+	if ( ! node.left && ! node.right ) {
 
 		result.depth.min = Math.min( depth, result.depth.min );
 		result.depth.max = Math.max( depth, result.depth.max );
@@ -107,7 +108,9 @@ function getExtremes( node, depth = 0, result = null ) {
 
 	} else {
 
-		node.children.forEach( c => getExtremes( c, depth + 1, result ) );
+		result.splits[ node.splitAxis ] ++;
+		getExtremes( node.left, depth + 1, result );
+		getExtremes( node.right, depth + 1, result );
 
 	}
 

--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -207,7 +207,43 @@ export default class BVHConstructionContext {
 		// Center
 		if ( strategy === CENTER ) {
 
-			axis = getLongestEdgeIndex( bounds );
+			// axis = getLongestEdgeIndex( bounds );
+			// if ( axis !== - 1 ) {
+
+			// 	pos = ( bounds[ axis + 3 ] + bounds[ axis ] ) / 2;
+
+			// }
+
+			const triBounds = this.bounds;
+			const minSpread = new Array( 3 ).fill( Infinity );
+			const maxSpread = new Array( 3 ).fill( - Infinity );
+
+			for ( let n = 0; n < 3; n ++ ) {
+
+				for ( let i = offset * 6, l = ( offset + count ) * 6; i < l; i += 6 ) {
+
+					const axisBound = triBounds[ i + n * 2 ];
+					minSpread[ n ] = Math.min( minSpread[ n ], axisBound );
+					maxSpread[ n ] = Math.max( maxSpread[ n ], axisBound );
+
+				}
+
+			}
+
+			let curr = - Infinity;
+			for ( let i = 0; i < 3; i ++ ) {
+
+				let dist = maxSpread[ i ] - minSpread[ i ];
+				dist = dist / ( ( bounds[ i ] + bounds[ i + 3 ] ) / 2 );
+				if ( dist > curr ) {
+
+					curr = dist;
+					axis = i;
+
+				}
+
+			}
+
 			if ( axis !== - 1 ) {
 
 				pos = ( bounds[ axis + 3 ] + bounds[ axis ] ) / 2;

--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -208,46 +208,9 @@ export default class BVHConstructionContext {
 		if ( strategy === CENTER ) {
 
 			axis = getLongestEdgeIndex( bounds );
-
 			if ( axis !== - 1 ) {
 
 				pos = ( bounds[ axis + 3 ] + bounds[ axis ] ) / 2;
-
-			}
-
-			const triBounds = this.bounds;
-			const minSpread = new Array( 3 ).fill( Infinity );
-			const maxSpread = new Array( 3 ).fill( - Infinity );
-
-			for ( let n = 0; n < 3; n ++ ) {
-
-				for ( let i = offset * 6, l = ( offset + count ) * 6; i < l; i += 6 ) {
-
-					const axisBound = triBounds[ i + n * 2 ];
-					minSpread[ n ] = Math.min( minSpread[ n ], axisBound );
-					maxSpread[ n ] = Math.max( maxSpread[ n ], axisBound );
-
-				}
-
-			}
-
-			let curr = - Infinity;
-			for ( let i = 0; i < 3; i ++ ) {
-
-				let dist = maxSpread[ i ] - minSpread[ i ];
-				// dist = dist / ( ( bounds[ i ] + bounds[ i + 3 ] ) / 2 );
-				if ( dist > curr ) {
-
-					curr = dist;
-					axis = i;
-
-				}
-
-			}
-
-			if ( axis !== - 1 ) {
-
-				pos = ( maxSpread[ axis ] + minSpread[ axis ] ) / 2;
 
 			}
 

--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -207,12 +207,13 @@ export default class BVHConstructionContext {
 		// Center
 		if ( strategy === CENTER ) {
 
-			// axis = getLongestEdgeIndex( bounds );
-			// if ( axis !== - 1 ) {
+			axis = getLongestEdgeIndex( bounds );
 
-			// 	pos = ( bounds[ axis + 3 ] + bounds[ axis ] ) / 2;
+			if ( axis !== - 1 ) {
 
-			// }
+				pos = ( bounds[ axis + 3 ] + bounds[ axis ] ) / 2;
+
+			}
 
 			const triBounds = this.bounds;
 			const minSpread = new Array( 3 ).fill( Infinity );
@@ -234,7 +235,7 @@ export default class BVHConstructionContext {
 			for ( let i = 0; i < 3; i ++ ) {
 
 				let dist = maxSpread[ i ] - minSpread[ i ];
-				dist = dist / ( ( bounds[ i ] + bounds[ i + 3 ] ) / 2 );
+				// dist = dist / ( ( bounds[ i ] + bounds[ i + 3 ] ) / 2 );
 				if ( dist > curr ) {
 
 					curr = dist;
@@ -246,7 +247,7 @@ export default class BVHConstructionContext {
 
 			if ( axis !== - 1 ) {
 
-				pos = ( bounds[ axis + 3 ] + bounds[ axis ] ) / 2;
+				pos = ( maxSpread[ axis ] + minSpread[ axis ] ) / 2;
 
 			}
 

--- a/src/Utils/Debug.js
+++ b/src/Utils/Debug.js
@@ -1,0 +1,114 @@
+// https://stackoverflow.com/questions/1248302/how-to-get-the-size-of-a-javascript-object
+function getPrimitiveSize( el ) {
+
+	switch ( typeof el ) {
+
+		case 'number':
+			return 8;
+		case 'string':
+			return el.length * 2;
+		case 'boolean':
+			return 4;
+		default:
+			return 0;
+
+	}
+
+}
+
+function isTypedArray( arr ) {
+
+	const regex = /(Uint|Int|Float)(8|16|32)Array/;
+	return regex.test( arr.constructor.name );
+
+}
+
+function getNodeExtremes( node, depth = 0, result = null ) {
+
+	if ( ! result ) {
+
+		result = {
+			depth: {
+				min: Infinity, max: - Infinity
+			},
+			tris: {
+				min: Infinity, max: - Infinity
+			},
+			splits: [ 0, 0, 0 ]
+		};
+
+	}
+
+	if ( ! node.left && ! node.right ) {
+
+		result.depth.min = Math.min( depth, result.depth.min );
+		result.depth.max = Math.max( depth, result.depth.max );
+
+		result.tris.min = Math.min( node.count, result.tris.min );
+		result.tris.max = Math.max( node.count, result.tris.max );
+
+	} else {
+
+		result.splits[ node.splitAxis ] ++;
+		getNodeExtremes( node.left, depth + 1, result );
+		getNodeExtremes( node.right, depth + 1, result );
+
+	}
+
+	return result;
+
+}
+
+function getBVHExtremes( bvh ) {
+
+	return bvh._roots.map( root => getNodeExtremes( root ) );
+
+}
+
+function estimateMemoryInBytes( obj ) {
+
+	const traversed = [ ];
+	const stack = [ obj ];
+	let bytes = 0;
+
+	while ( stack.length ) {
+
+		const curr = stack.pop();
+		if ( traversed.includes( curr ) ) continue;
+		traversed.push( curr );
+
+		for ( let key in curr ) {
+
+			if ( ! curr.hasOwnProperty( key ) ) continue;
+
+			bytes += getPrimitiveSize( key );
+
+			const value = curr[ key ];
+			if ( value && ( typeof value === 'object' || typeof value === 'function' ) ) {
+
+				if ( isTypedArray( value ) ) {
+
+					bytes += value.byteLength;
+
+				} else {
+
+					stack.push( value );
+
+				}
+
+			} else {
+
+				bytes += getPrimitiveSize( value );
+
+			}
+
+
+		}
+
+	}
+
+	return bytes;
+
+}
+
+export { estimateMemoryInBytes, getBVHExtremes };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import MeshBVH from './MeshBVH.js';
 import Visualizer from './MeshBVHVisualizer.js';
 import { CENTER, AVERAGE, SAH } from './Constants.js';
+import { getBVHExtremes, estimateMemoryInBytes } from './Utils/Debug.js';
 
 const ray = new THREE.Ray();
 const tmpInverseMatrix = new THREE.Matrix4();
@@ -51,5 +52,6 @@ function disposeBoundsTree() {
 export {
 	MeshBVH, Visualizer,
 	acceleratedRaycast, computeBoundsTree, disposeBoundsTree,
-	CENTER, AVERAGE, SAH
+	CENTER, AVERAGE, SAH,
+	estimateMemoryInBytes, getBVHExtremes
 };


### PR DESCRIPTION
Improve the benchmark output to better show the performance differences between strategies and move some util benchmark functions into the library exports for debugging. Related to #121 to understand the behavior.

New benchmark output looks like

```
*Strategy: CENTER*
        Extremes:
                memory: 9755.746 kb
                tris: 1, 151
                depth: 11, 22
                splits: 20697, 21638, 12472

        Compute BVH              : 108.785714 ms
        BVH Raycast              : 0.687916 ms
        First Hit Raycast        : 0.100817 ms

        IntersectsSphere         : 0.013736 ms
        IntersectsBox            : 0.00089 ms
        DistanceToGeometry       : 2529 ms
        DistanceToPoint          : 0.203555 ms

        IntersectsGeometry with BVH: 16.347826 ms
        IntersectsGeometry without BVH: 895.5 ms

*Strategy: AVERAGE*
        Extremes:
                memory: 9362.722 kb
                tris: 1, 151
                depth: 11, 18
                splits: 21259, 21048, 10292

        Compute BVH              : 112.296296 ms
        BVH Raycast              : 0.661084 ms
        First Hit Raycast        : 0.10019 ms

        IntersectsSphere         : 0.002955 ms
        IntersectsBox            : 0.000843 ms
        DistanceToGeometry       : 2490 ms
        DistanceToPoint          : 0.19622 ms

        IntersectsGeometry with BVH: 15.73822 ms
        IntersectsGeometry without BVH: 867.25 ms

*Strategy: SAH*
        Extremes:
                memory: 9457.418 kb
                tris: 1, 301
                depth: 11, 19
                splits: 22088, 21560, 9483

        Compute BVH              : 3492 ms
        BVH Raycast              : 0.803859 ms
        First Hit Raycast        : 0.133073 ms

        IntersectsSphere         : 0.002068 ms
        IntersectsBox            : 0.000883 ms
        DistanceToGeometry       : 2847.5 ms
        DistanceToPoint          : 0.283019 ms

        IntersectsGeometry with BVH: 42.041667 ms
        IntersectsGeometry without BVH: 962.25 ms

*Strategy: NONE*
        Default Raycast          : 12.824786 ms

Extreme Case Tower Geometry
        CENTER raycast           : 9.708738 ms
        Extremes:
                memory: 548.162 kb
                tris: 4, 300649
                depth: 1, 13
                splits: 832, 0, 2247

        AVERAGE raycast          : 0.002921 ms
        Extremes:
                memory: 9426.802 kb
                tris: 4, 200
                depth: 4, 17
                splits: 23628, 27079, 2252

        SAH raycast              : 0.058328 ms
        Extremes:
                memory: 579.312 kb
                tris: 1, 1500
                depth: 4, 18
                splits: 1588, 372, 1294
```