### PR TITLE
Improve CENTER split raycast performance

### DIFF
--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -87,7 +87,7 @@ export default class BVHConstructionContext {
 	}
 
 	// computes the union of the bounds of all of the given triangles and puts the resulting box in target
-	getBounds( offset, count, target ) {
+	getBounds( offset, count, target, centroidTarget = null ) {
 
 		let minx = Infinity;
 		let miny = Infinity;
@@ -95,8 +95,16 @@ export default class BVHConstructionContext {
 		let maxx = - Infinity;
 		let maxy = - Infinity;
 		let maxz = - Infinity;
-		const bounds = this.bounds;
 
+		let cminx = Infinity;
+		let cminy = Infinity;
+		let cminz = Infinity;
+		let cmaxx = - Infinity;
+		let cmaxy = - Infinity;
+		let cmaxz = - Infinity;
+
+		const bounds = this.bounds;
+		const includeCentroids = centroidTarget !== null;
 		for ( let i = offset * 6, end = ( offset + count ) * 6; i < end; i += 6 ) {
 
 			const cx = bounds[ i + 0 ];
@@ -105,6 +113,8 @@ export default class BVHConstructionContext {
 			const rx = cx + hx;
 			if ( lx < minx ) minx = lx;
 			if ( rx > maxx ) maxx = rx;
+			if ( includeCentroids && cx < cminx ) cminx = cx;
+			if ( includeCentroids && cx > cmaxx ) cmaxx = cx;
 
 			const cy = bounds[ i + 2 ];
 			const hy = bounds[ i + 3 ];
@@ -112,6 +122,8 @@ export default class BVHConstructionContext {
 			const ry = cy + hy;
 			if ( ly < miny ) miny = ly;
 			if ( ry > maxy ) maxy = ry;
+			if ( includeCentroids && cy < cminy ) cminy = cy;
+			if ( includeCentroids && cy > cmaxy ) cmaxy = cy;
 
 			const cz = bounds[ i + 4 ];
 			const hz = bounds[ i + 5 ];
@@ -119,6 +131,8 @@ export default class BVHConstructionContext {
 			const rz = cz + hz;
 			if ( lz < minz ) minz = lz;
 			if ( rz > maxz ) maxz = rz;
+			if ( includeCentroids && cz < cminz ) cminz = cz;
+			if ( includeCentroids && cz > cmaxz ) cmaxz = cz;
 
 		}
 
@@ -129,6 +143,18 @@ export default class BVHConstructionContext {
 		target[ 3 ] = maxx;
 		target[ 4 ] = maxy;
 		target[ 5 ] = maxz;
+
+		if ( includeCentroids ) {
+
+			centroidTarget[ 0 ] = cminx;
+			centroidTarget[ 1 ] = cminy;
+			centroidTarget[ 2 ] = cminz;
+
+			centroidTarget[ 3 ] = cmaxx;
+			centroidTarget[ 4 ] = cmaxy;
+			centroidTarget[ 5 ] = cmaxz;
+
+		}
 
 	}
 

--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -216,8 +216,12 @@ export default class BVHConstructionContext {
 		if ( strategy === CENTER ) {
 
 			const triBounds = this.bounds;
-			const minSpread = new Float32Array( 3 ).fill( Infinity );
-			const maxSpread = new Float32Array( 3 ).fill( - Infinity );
+			let minx = Infinity;
+			let miny = Infinity;
+			let minz = Infinity;
+			let maxx = - Infinity;
+			let maxy = - Infinity;
+			let maxz = - Infinity;
 
 			for ( let i = offset * 6, l = ( offset + count ) * 6; i < l; i += 6 ) {
 
@@ -225,33 +229,37 @@ export default class BVHConstructionContext {
 				const cy = triBounds[ i + 2 ];
 				const cz = triBounds[ i + 4 ];
 
-				if ( cx < minSpread[ 0 ] ) minSpread[ 0 ] = cx;
-				if ( cx > maxSpread[ 0 ] ) maxSpread[ 0 ] = cx;
+				if ( cx < minx ) minx = cx;
+				if ( cx > maxx ) maxx = cx;
 
-				if ( cy < minSpread[ 1 ] ) minSpread[ 1 ] = cy;
-				if ( cy > maxSpread[ 1 ] ) maxSpread[ 1 ] = cy;
+				if ( cy < miny ) miny = cy;
+				if ( cy > maxy ) maxy = cy;
 
-				if ( cz < minSpread[ 2 ] ) minSpread[ 2 ] = cz;
-				if ( cz > maxSpread[ 2 ] ) maxSpread[ 2 ] = cz;
-
-			}
-
-			let curr = - Infinity;
-			for ( let i = 0; i < 3; i ++ ) {
-
-				let dist = maxSpread[ i ] - minSpread[ i ];
-				if ( dist > curr ) {
-
-					curr = dist;
-					axis = i;
-
-				}
+				if ( cz < minz ) minz = cz;
+				if ( cz > maxz ) maxz = cz;
 
 			}
 
-			if ( axis !== - 1 ) {
+			const widthx = maxx - minx;
+			const widthy = maxy - miny;
+			const widthz = maxz - minz;
+			let curr = widthx;
+			axis = 0;
+			pos = ( maxx + minx ) / 2;
 
-				pos = ( maxSpread[ axis ] + minSpread[ axis ] ) / 2;
+			if ( widthy > curr ) {
+
+				curr = widthy;
+				axis = 1;
+				pos = ( maxy + miny ) / 2;
+
+			}
+
+			if ( widthz > curr ) {
+
+				curr = widthz;
+				axis = 2;
+				pos = ( maxz + minz ) / 2;
 
 			}
 

--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -130,8 +130,6 @@ export default class BVHConstructionContext {
 		target[ 4 ] = maxy;
 		target[ 5 ] = maxz;
 
-		return target;
-
 	}
 
 	// reorders `tris` such that for `count` elements after `offset`, elements on the left side of the split

--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -278,33 +278,10 @@ export default class BVHConstructionContext {
 		// Center
 		if ( strategy === CENTER ) {
 
-			const minx = centroidBounds[ 0 ];
-			const miny = centroidBounds[ 1 ];
-			const minz = centroidBounds[ 2 ];
-			const maxx = centroidBounds[ 3 ];
-			const maxy = centroidBounds[ 4 ];
-			const maxz = centroidBounds[ 5 ];
+			axis = getLongestEdgeIndex( centroidBounds );
+			if ( axis !== - 1 ) {
 
-			const widthx = maxx - minx;
-			const widthy = maxy - miny;
-			const widthz = maxz - minz;
-			let curr = widthx;
-			axis = 0;
-			pos = ( maxx + minx ) / 2;
-
-			if ( widthy > curr ) {
-
-				curr = widthy;
-				axis = 1;
-				pos = ( maxy + miny ) / 2;
-
-			}
-
-			if ( widthz > curr ) {
-
-				curr = widthz;
-				axis = 2;
-				pos = ( maxz + minz ) / 2;
+				pos = ( centroidBounds[ axis ] + centroidBounds[ axis + 3 ] ) / 2;
 
 			}
 

--- a/src/BVHConstructionContext.js
+++ b/src/BVHConstructionContext.js
@@ -207,10 +207,43 @@ export default class BVHConstructionContext {
 		// Center
 		if ( strategy === CENTER ) {
 
-			axis = getLongestEdgeIndex( bounds );
+			const triBounds = this.bounds;
+			const minSpread = new Float32Array( 3 ).fill( Infinity );
+			const maxSpread = new Float32Array( 3 ).fill( - Infinity );
+
+			for ( let i = offset * 6, l = ( offset + count ) * 6; i < l; i += 6 ) {
+
+				const cx = triBounds[ i ];
+				const cy = triBounds[ i + 2 ];
+				const cz = triBounds[ i + 4 ];
+
+				if ( cx < minSpread[ 0 ] ) minSpread[ 0 ] = cx;
+				if ( cx > maxSpread[ 0 ] ) maxSpread[ 0 ] = cx;
+
+				if ( cy < minSpread[ 1 ] ) minSpread[ 1 ] = cy;
+				if ( cy > maxSpread[ 1 ] ) maxSpread[ 1 ] = cy;
+
+				if ( cz < minSpread[ 2 ] ) minSpread[ 2 ] = cz;
+				if ( cz > maxSpread[ 2 ] ) maxSpread[ 2 ] = cz;
+
+			}
+
+			let curr = - Infinity;
+			for ( let i = 0; i < 3; i ++ ) {
+
+				let dist = maxSpread[ i ] - minSpread[ i ];
+				if ( dist > curr ) {
+
+					curr = dist;
+					axis = i;
+
+				}
+
+			}
+
 			if ( axis !== - 1 ) {
 
-				pos = ( bounds[ axis + 3 ] + bounds[ axis ] ) / 2;
+				pos = ( maxSpread[ axis ] + minSpread[ axis ] ) / 2;
 
 			}
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -150,13 +150,17 @@ export default class MeshBVH {
 				// create the left child and compute its bounding box
 				const left = node.left = new MeshBVHNode();
 				const lstart = offset, lcount = splitOffset - offset;
-				left.boundingData = ctx.getBounds( lstart, lcount, new Float32Array( 6 ) );
+				left.boundingData = new Float32Array( 6 );
+				ctx.getBounds( lstart, lcount, left.boundingData );
+
 				splitNode( left, lstart, lcount, depth + 1 );
 
 				// repeat for right
 				const right = node.right = new MeshBVHNode();
 				const rstart = splitOffset, rcount = count - lcount;
-				right.boundingData = ctx.getBounds( rstart, rcount, new Float32Array( 6 ) );
+				right.boundingData = new Float32Array( 6 );
+				ctx.getBounds( rstart, rcount, right.boundingData );
+
 				splitNode( right, rstart, rcount, depth + 1 );
 
 			}
@@ -179,7 +183,8 @@ export default class MeshBVH {
 
 			} else {
 
-				root.boundingData = ctx.getBounds( range.offset, range.count, new Float32Array( 6 ) );
+				root.boundingData = new Float32Array( 6 );
+				ctx.getBounds( range.offset, range.count, root.boundingData );
 
 			}
 
@@ -191,7 +196,9 @@ export default class MeshBVH {
 			for ( let range of ranges ) {
 
 				const root = new MeshBVHNode();
-				root.boundingData = ctx.getBounds( range.offset, range.count, new Float32Array( 6 ) );
+				root.boundingData = new Float32Array( 6 );
+				ctx.getBounds( range.offset, range.count, root.boundingData );
+
 				splitNode( root, range.offset, range.count );
 				roots.push( root );
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -104,11 +104,12 @@ export default class MeshBVH {
 		this._ensureIndex( geo );
 
 		const ctx = new BVHConstructionContext( geo, options );
+		const cacheCentroidBounds = new Float32Array( 6 );
 		let reachedMaxDepth = false;
 
 		// either recursively splits the given node, creating left and right subtrees for it, or makes it a leaf node,
 		// recording the offset and count of its triangles and writing them into the reordered geometry index.
-		const splitNode = ( node, offset, count, depth = 0 ) => {
+		const splitNode = ( node, offset, count, centroidBounds = null, depth = 0 ) => {
 
 			if ( depth >= options.maxDepth ) {
 
@@ -126,7 +127,7 @@ export default class MeshBVH {
 			}
 
 			// Find where to split the volume
-			const split = ctx.getOptimalSplit( node.boundingData, offset, count, options.strategy );
+			const split = ctx.getOptimalSplit( node.boundingData, centroidBounds, offset, count, options.strategy );
 			if ( split.axis === - 1 ) {
 
 				node.offset = offset;
@@ -151,17 +152,17 @@ export default class MeshBVH {
 				const left = node.left = new MeshBVHNode();
 				const lstart = offset, lcount = splitOffset - offset;
 				left.boundingData = new Float32Array( 6 );
-				ctx.getBounds( lstart, lcount, left.boundingData );
+				ctx.getBounds( lstart, lcount, left.boundingData, cacheCentroidBounds );
 
-				splitNode( left, lstart, lcount, depth + 1 );
+				splitNode( left, lstart, lcount, cacheCentroidBounds, depth + 1 );
 
 				// repeat for right
 				const right = node.right = new MeshBVHNode();
 				const rstart = splitOffset, rcount = count - lcount;
 				right.boundingData = new Float32Array( 6 );
-				ctx.getBounds( rstart, rcount, right.boundingData );
+				ctx.getBounds( rstart, rcount, right.boundingData, cacheCentroidBounds );
 
-				splitNode( right, rstart, rcount, depth + 1 );
+				splitNode( right, rstart, rcount, cacheCentroidBounds, depth + 1 );
 
 			}
 
@@ -180,15 +181,16 @@ export default class MeshBVH {
 			if ( geo.boundingBox != null ) {
 
 				root.boundingData = boxToArray( geo.boundingBox );
+				ctx.getCentroidBounds( range.offset, range.count, cacheCentroidBounds );
 
 			} else {
 
 				root.boundingData = new Float32Array( 6 );
-				ctx.getBounds( range.offset, range.count, root.boundingData );
+				ctx.getBounds( range.offset, range.count, root.boundingData, cacheCentroidBounds );
 
 			}
 
-			splitNode( root, range.offset, range.count );
+			splitNode( root, range.offset, range.count, cacheCentroidBounds );
 			roots.push( root );
 
 		} else {
@@ -197,9 +199,9 @@ export default class MeshBVH {
 
 				const root = new MeshBVHNode();
 				root.boundingData = new Float32Array( 6 );
-				ctx.getBounds( range.offset, range.count, root.boundingData );
+				ctx.getBounds( range.offset, range.count, root.boundingData, cacheCentroidBounds );
 
-				splitNode( root, range.offset, range.count );
+				splitNode( root, range.offset, range.count, cacheCentroidBounds );
 				roots.push( root );
 
 			}


### PR DESCRIPTION
Fix #121

Improves the CENTER split method by picking the center of the centroid bounds along the longest axis rather than the center of the node bounds to partition against. This fixes cases like in #121 where you might have a node that winds up containing tens of thousands of triangles because a naive CENTER split of the node doesn't effectively divide the triangles and quit traversing.

The triangle centroid bounds are computed in the same pass as the node bounding box to avoid redundant array accesses. This minimizes the overhead of generating the centroid bounds and along with the improvements from #126 there is basically no performance degradation in computing the BVH compared to the last v0.1.5 release.

#### Benchmarks

Here are the significant benchmark comparisions relative to master (including #126).

*Nominal Case*
```
memory                   : 9755.746 kb  -> 10517.942 kb
Compute BVH              : 93.272 ms    -> 103.724 ms
BVH Raycast              : 0.650 ms     -> 0.138 ms
First Hit Raycast        : 0.097 ms     -> 0.004 ms
IntersectsSphere         : 0.013 ms     -> 0.001 ms
```

And in the *Extreme Tower Geometry* case
```
memory                   : 548.162 kb -> memory: 9449.764 kb
tris min                 : 4          -> 3
tris max                 : 300649     -> 9
CENTER raycast           : 10.117 ms  -> 0.003 ms
```

---

@mqp I'm not sure if you're still interested in reviewing changes to this but I figured since you're using for a project it would be good to get your feedback. I think it results in a generally better tree structure that avoids corner cases with some geometry like mentioned above. There's also a pretty significant run time raycast performance improvement which is great but I know you mentioned in the past that you were more interested in improving the build time performance.

#42 may be the next thing I take a look at tackling which would enable the bounds to be generated a web worker.