### PR TITLE
Add serialization and deserialization of bvh

### DIFF
--- a/benchmark/run-benchmark.js
+++ b/benchmark/run-benchmark.js
@@ -26,11 +26,14 @@ raycaster.ray.direction.set( 0, 0, 1 );
 
 function logExtremes( bvh ) {
 
-	const bvhSize = estimateMemoryInBytes( bvh );
+	const bvhSize = estimateMemoryInBytes( bvh._roots );
+	const serializedSize = estimateMemoryInBytes( bvh.serialize().roots );
+
 	const extremes = getBVHExtremes( bvh )[ 0 ];
 	console.log(
 		`\tExtremes:\n` +
 		`\t\tmemory: ${ bvhSize / 1000 } kb\n` +
+		`\t\tserialized: ${ serializedSize / 1000 } kb\n` +
 		`\t\ttris: ${extremes.tris.min}, ${extremes.tris.max}\n` +
 		`\t\tdepth: ${extremes.depth.min}, ${extremes.depth.max}\n` +
 		`\t\tsplits: ${extremes.splits[ 0 ]}, ${extremes.splits[ 1 ]}, ${extremes.splits[ 2 ]}\n`
@@ -50,6 +53,34 @@ function runSuite( strategy ) {
 
 			geometry.computeBoundsTree( { strategy: strategy } );
 			geometry.boundsTree = null;
+
+		},
+		3000,
+		50
+
+	);
+
+	geometry.computeBoundsTree( { strategy: strategy } );
+	runBenchmark(
+
+		'Serialize',
+		() => {
+
+			geometry.boundsTree.serialize();
+
+		},
+		3000,
+		50
+
+	);
+
+	const serialized = geometry.boundsTree.serialize();
+	runBenchmark(
+
+		'Deserialize',
+		() => {
+
+			geometry.boundsTree.deserialize( serialized );
 
 		},
 		3000,

--- a/benchmark/run-benchmark.js
+++ b/benchmark/run-benchmark.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { runBenchmark } from './utils.js';
-import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CENTER, AVERAGE, SAH, estimateMemoryInBytes, getBVHExtremes } from '../src/index.js';
+import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CENTER, AVERAGE, SAH, estimateMemoryInBytes, getBVHExtremes, MeshBVH } from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
@@ -24,10 +24,10 @@ const raycaster = new THREE.Raycaster();
 raycaster.ray.origin.set( 0, 0, - 10 );
 raycaster.ray.direction.set( 0, 0, 1 );
 
-function logExtremes( bvh ) {
+function logExtremes( bvh, geometry ) {
 
 	const bvhSize = estimateMemoryInBytes( bvh._roots );
-	const serializedSize = estimateMemoryInBytes( bvh.serialize().roots );
+	const serializedSize = estimateMemoryInBytes( MeshBVH.serialize( bvh, geometry ).roots );
 
 	const extremes = getBVHExtremes( bvh )[ 0 ];
 	console.log(
@@ -44,7 +44,7 @@ function logExtremes( bvh ) {
 function runSuite( strategy ) {
 
 	geometry.computeBoundsTree( { strategy: strategy } );
-	logExtremes( geometry.boundsTree );
+	logExtremes( geometry.boundsTree, geometry );
 
 	runBenchmark(
 
@@ -66,7 +66,7 @@ function runSuite( strategy ) {
 		'Serialize',
 		() => {
 
-			geometry.boundsTree.serialize();
+			MeshBVH.serialize( geometry.boundsTree, geometry );
 
 		},
 		3000,
@@ -74,13 +74,13 @@ function runSuite( strategy ) {
 
 	);
 
-	const serialized = geometry.boundsTree.serialize();
+	const serialized = MeshBVH.serialize( geometry.boundsTree, geometry );
 	runBenchmark(
 
 		'Deserialize',
 		() => {
 
-			geometry.boundsTree.deserialize( serialized );
+			MeshBVH.deserialize( serialized, geometry );
 
 		},
 		3000,
@@ -225,7 +225,7 @@ runBenchmark(
 	3000
 
 );
-logExtremes( towerGeometry.boundsTree );
+logExtremes( towerGeometry.boundsTree, towerGeometry );
 
 towerGeometry.computeBoundsTree( { strategy: AVERAGE } );
 runBenchmark(
@@ -235,7 +235,7 @@ runBenchmark(
 	3000
 
 );
-logExtremes( towerGeometry.boundsTree );
+logExtremes( towerGeometry.boundsTree, towerGeometry );
 
 towerGeometry.computeBoundsTree( { strategy: SAH } );
 runBenchmark(
@@ -245,4 +245,4 @@ runBenchmark(
 	3000
 
 );
-logExtremes( towerGeometry.boundsTree );
+logExtremes( towerGeometry.boundsTree, towerGeometry );

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -14,10 +14,10 @@ const SKIP_GENERATION = Symbol( 'skip tree generation' );
 
 export default class MeshBVH {
 
-	static deserialize( geo, data ) {
+	static deserialize( geo, data, setIndex ) {
 
 		const bvh = new MeshBVH( geo, { [ SKIP_GENERATION ]: true } );
-		bvh.deserialize( data );
+		bvh.deserialize( data, setIndex );
 		return bvh;
 
 	}

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -4,7 +4,23 @@ import BVHConstructionContext from './BVHConstructionContext.js';
 import { arrayToBox, boxToArray } from './Utils/ArrayBoxUtilities.js';
 import { CENTER } from './Constants.js';
 
+// boundingData  		: 6 float32
+// left / offset 		: 1 uint32
+// right / count 		: 1 uint32
+// splitAxis / isLeaf 	: 1 uint32
+const BYTES_PER_NODE = 6 * 4 + 4 + 4 + 4;
+const IS_LEAFNODE_FLAG = 0xFFFFFFFF;
+const SKIP_GENERATION = Symbol( 'skip tree generation' );
+
 export default class MeshBVH {
+
+	static deserialize( geo, data ) {
+
+		const bvh = new MeshBVH( geo, { [ SKIP_GENERATION ]: true } );
+		bvh.deserialize( data );
+		return bvh;
+
+	}
 
 	constructor( geo, options = {} ) {
 
@@ -28,18 +44,26 @@ export default class MeshBVH {
 			strategy: CENTER,
 			maxDepth: 40,
 			maxLeafTris: 10,
-			verbose: true
+			verbose: true,
+			[ SKIP_GENERATION ]: false
 
 		}, options );
 		options.strategy = Math.max( 0, Math.min( 2, options.strategy ) );
 
-		this._roots = this._buildTree( geo, options );
+		this.geometry = geo;
+		if ( options[ SKIP_GENERATION ] ) {
 
+			this._roots = null;
+
+		} else {
+
+			this._roots = this._buildTree( geo, options );
+
+		}
 
 	}
 
 	/* Private Functions */
-
 	_ensureIndex( geo ) {
 
 		if ( ! geo.index ) {
@@ -235,6 +259,7 @@ export default class MeshBVH {
 
 	}
 
+	/* Public Functions */
 	raycast( mesh, raycaster, ray, intersects ) {
 
 		for ( const root of this._roots ) {
@@ -351,6 +376,150 @@ export default class MeshBVH {
 	distanceToPoint( mesh, point, minThreshold, maxThreshold ) {
 
 		return this.closestPointToPoint( mesh, point, null, minThreshold, maxThreshold );
+
+	}
+
+	serialize( copyIndexBuffer = true ) {
+
+		function countNodes( node ) {
+
+			if ( node.count ) {
+
+				return 1;
+
+			} else {
+
+				return 1 + countNodes( node.left ) + countNodes( node.right );
+
+			}
+
+		}
+
+		function populateBuffer( arrayOffset, float32Array, uint32Array, node ) {
+
+			const isLeaf = ! ! node.count;
+			const boundingData = node.boundingData;
+			for ( let i = 0; i < 6; i ++ ) {
+
+				float32Array[ arrayOffset + i ] = boundingData[ i ];
+
+			}
+
+			if ( isLeaf ) {
+
+				const offset = node.offset;
+				const count = node.count;
+				uint32Array[ arrayOffset + 6 ] = offset;
+				uint32Array[ arrayOffset + 7 ] = count;
+				uint32Array[ arrayOffset + 8 ] = IS_LEAFNODE_FLAG;
+				return arrayOffset + BYTES_PER_NODE / 4;
+
+			} else {
+
+				const left = node.left;
+				const right = node.right;
+				const splitAxis = node.splitAxis;
+
+				let nextUnusedPointer;
+
+				uint32Array[ arrayOffset + 6 ] = arrayOffset + BYTES_PER_NODE / 4;
+				nextUnusedPointer = populateBuffer( arrayOffset + BYTES_PER_NODE / 4, float32Array, uint32Array, left );
+
+				uint32Array[ arrayOffset + 7 ] = nextUnusedPointer;
+				nextUnusedPointer = populateBuffer( nextUnusedPointer, float32Array, uint32Array, right );
+
+				uint32Array[ arrayOffset + 8 ] = splitAxis;
+				return nextUnusedPointer;
+
+			}
+
+		}
+
+		const roots = this._roots;
+		const rootData = [];
+		for ( let i = 0; i < roots.length; i ++ ) {
+
+			const root = roots[ i ];
+			let nodeCount = countNodes( root );
+
+			const buffer = new ArrayBuffer( BYTES_PER_NODE * nodeCount );
+			const float32Array = new Float32Array( buffer );
+			const uint32Array = new Uint32Array( buffer );
+			rootData.push( buffer );
+			populateBuffer( 0, float32Array, uint32Array, root );
+
+		}
+
+		const geometry = this.geometry;
+		const indexAttribute = geometry.getIndex();
+		const result = {
+			roots: rootData,
+			index: copyIndexBuffer ? indexAttribute.array.slice() : indexAttribute.array,
+		};
+
+		return result;
+
+	}
+
+	deserialize( data, setIndex = true ) {
+
+		function setData( arrayOffset, float32Array, uint32Array, node ) {
+
+			const boundingData = new Float32Array( 6 );
+			for ( let i = 0; i < 6; i ++ ) {
+
+				boundingData[ i ] = float32Array[ arrayOffset + i ];
+
+			}
+			node.boundingData = boundingData;
+
+			const isLeaf = uint32Array[ arrayOffset + 8 ] === IS_LEAFNODE_FLAG;
+			if ( isLeaf ) {
+
+				node.offset = uint32Array[ arrayOffset + 6 ];
+				node.count = uint32Array[ arrayOffset + 7 ];
+
+			} else {
+
+				const left = new MeshBVHNode();
+				const right = new MeshBVHNode();
+				const leftOffset = uint32Array[ arrayOffset + 6 ];
+				const rightOffset = uint32Array[ arrayOffset + 7 ];
+
+				setData( leftOffset, float32Array, uint32Array, left );
+				setData( rightOffset, float32Array, uint32Array, right );
+
+				node.left = left;
+				node.right = right;
+				node.splitAxis = uint32Array[ arrayOffset + 8 ];
+
+			}
+
+		}
+
+		const { index, roots } = data;
+		this._roots = roots.map( buffer => {
+
+			const float32Array = new Float32Array( buffer );
+			const uint32Array = new Uint32Array( buffer );
+
+			const root = new MeshBVHNode();
+			setData( 0, float32Array, uint32Array, root );
+			return root;
+
+		} );
+
+		if ( setIndex ) {
+
+			const geometry = this.geometry;
+			const indexAttribute = geometry.getIndex();
+			if ( indexAttribute.array !== index ) {
+
+				indexAttribute.set( index );
+
+			}
+
+		}
 
 	}
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -515,7 +515,8 @@ export default class MeshBVH {
 			const indexAttribute = geometry.getIndex();
 			if ( indexAttribute.array !== index ) {
 
-				indexAttribute.set( index );
+				indexAttribute.array.set( index );
+				indexAttribute.needsUpdate = true;
 
 			}
 

--- a/src/MeshBVHNode.js
+++ b/src/MeshBVHNode.js
@@ -53,13 +53,23 @@ class MeshBVHNode {
 
 	raycast( mesh, raycaster, ray, intersects ) {
 
-		if ( this.count ) intersectTris( mesh, mesh.geometry, raycaster, ray, this.offset, this.count, intersects );
-		else {
+		if ( this.count ) {
 
-			if ( this.left.intersectRay( ray, boxIntersection ) )
+			intersectTris( mesh, mesh.geometry, raycaster, ray, this.offset, this.count, intersects );
+
+		} else {
+
+			if ( this.left.intersectRay( ray, boxIntersection ) ) {
+
 				this.left.raycast( mesh, raycaster, ray, intersects );
-			if ( this.right.intersectRay( ray, boxIntersection ) )
+
+			}
+
+			if ( this.right.intersectRay( ray, boxIntersection ) ) {
+
 				this.right.raycast( mesh, raycaster, ray, intersects );
+
+			}
 
 		}
 

--- a/src/Utils/Debug.js
+++ b/src/Utils/Debug.js
@@ -67,19 +67,27 @@ function getBVHExtremes( bvh ) {
 
 function estimateMemoryInBytes( obj ) {
 
-	const traversed = [ ];
+	const traversed = new Set();
 	const stack = [ obj ];
 	let bytes = 0;
 
 	while ( stack.length ) {
 
 		const curr = stack.pop();
-		if ( traversed.includes( curr ) ) continue;
-		traversed.push( curr );
+		if ( traversed.has( curr ) ) {
+
+			continue;
+
+		}
+		traversed.add( curr );
 
 		for ( let key in curr ) {
 
-			if ( ! curr.hasOwnProperty( key ) ) continue;
+			if ( ! curr.hasOwnProperty( key ) ) {
+
+				continue;
+
+			}
 
 			bytes += getPrimitiveSize( key );
 
@@ -87,6 +95,10 @@ function estimateMemoryInBytes( obj ) {
 			if ( value && ( typeof value === 'object' || typeof value === 'function' ) ) {
 
 				if ( isTypedArray( value ) ) {
+
+					bytes += value.byteLength;
+
+				} else if ( value instanceof ArrayBuffer ) {
 
 					bytes += value.byteLength;
 

--- a/test/MeshBVH.test.js
+++ b/test/MeshBVH.test.js
@@ -172,6 +172,50 @@ describe( 'Bounds Tree', () => {
 
 } );
 
+describe( 'Serialization', () => {
+
+	it( 'should serialize then deserialize to the same structure.', () => {
+
+		const geom = new THREE.SphereBufferGeometry( 1, 10, 10 );
+		const bvh = new MeshBVH( geom );
+		const serialized = bvh.serialize();
+
+		const deserializedBVH = MeshBVH.deserialize( geom, serialized );
+		expect( deserializedBVH ).toEqual( bvh );
+
+	} );
+
+	it( 'should copy the index buffer from the target geometry unless copyIndex is set to false', () => {
+
+		const geom = new THREE.SphereBufferGeometry( 1, 10, 10 );
+		const bvh = new MeshBVH( geom );
+
+		expect( geom.index.array ).not.toBe( bvh.serialize().index );
+		expect( geom.index.array ).toBe( bvh.serialize( false ).index );
+
+	} );
+
+	it( 'should copy the index buffer onto the target geometry unless setIndex is set to false.', () => {
+
+		const geom1 = new THREE.SphereBufferGeometry( 1, 10, 10 );
+		const geom2 = new THREE.SphereBufferGeometry( 1, 10, 10 );
+		const bvh = new MeshBVH( geom1 );
+		const serialized = bvh.serialize();
+
+		expect( geom2.index.array ).not.toBe( serialized.index );
+		expect( geom2.index.array ).not.toEqual( serialized.index );
+		MeshBVH.deserialize( geom2, serialized, false );
+
+		expect( geom2.index.array ).not.toBe( serialized.index );
+		expect( geom2.index.array ).not.toEqual( serialized.index );
+		MeshBVH.deserialize( geom2, serialized, true );
+
+		expect( geom2.index.array ).not.toBe( serialized.index );
+		expect( geom2.index.array ).toEqual( serialized.index );
+
+	} );
+
+} );
 
 describe( 'IntersectsGeometry with BVH', () => {
 

--- a/test/MeshBVH.test.js
+++ b/test/MeshBVH.test.js
@@ -178,9 +178,9 @@ describe( 'Serialization', () => {
 
 		const geom = new THREE.SphereBufferGeometry( 1, 10, 10 );
 		const bvh = new MeshBVH( geom );
-		const serialized = bvh.serialize();
+		const serialized = MeshBVH.serialize( bvh, geom );
 
-		const deserializedBVH = MeshBVH.deserialize( geom, serialized );
+		const deserializedBVH = MeshBVH.deserialize( serialized, geom );
 		expect( deserializedBVH ).toEqual( bvh );
 
 	} );
@@ -190,8 +190,8 @@ describe( 'Serialization', () => {
 		const geom = new THREE.SphereBufferGeometry( 1, 10, 10 );
 		const bvh = new MeshBVH( geom );
 
-		expect( geom.index.array ).not.toBe( bvh.serialize().index );
-		expect( geom.index.array ).toBe( bvh.serialize( false ).index );
+		expect( geom.index.array ).not.toBe( MeshBVH.serialize( bvh, geom ).index );
+		expect( geom.index.array ).toBe( MeshBVH.serialize( bvh, geom, false ).index );
 
 	} );
 
@@ -200,15 +200,15 @@ describe( 'Serialization', () => {
 		const geom1 = new THREE.SphereBufferGeometry( 1, 10, 10 );
 		const geom2 = new THREE.SphereBufferGeometry( 1, 10, 10 );
 		const bvh = new MeshBVH( geom1 );
-		const serialized = bvh.serialize();
+		const serialized = MeshBVH.serialize( bvh, geom1 );
 
 		expect( geom2.index.array ).not.toBe( serialized.index );
 		expect( geom2.index.array ).not.toEqual( serialized.index );
-		MeshBVH.deserialize( geom2, serialized, false );
+		MeshBVH.deserialize( serialized, geom2, false );
 
 		expect( geom2.index.array ).not.toBe( serialized.index );
 		expect( geom2.index.array ).not.toEqual( serialized.index );
-		MeshBVH.deserialize( geom2, serialized, true );
+		MeshBVH.deserialize( serialized, geom2, true );
 
 		expect( geom2.index.array ).not.toBe( serialized.index );
 		expect( geom2.index.array ).toEqual( serialized.index );


### PR DESCRIPTION
Fix #7 
Related to #42

Adds a serialization and deserialization function to the BVH which should allow it to be generated in a webworker. The serialized data is currently formatted as follows with 36 bytes per node:

```js
{
  roots: Array<ArrayBuffer>,
  index: UInt32Array
}
```

## Benchmarks

```
Extremes:
    memory: 10517.93 kb
    serialized: 4254.446 kb
    tris: 1, 10
    depth: 11, 22
    splits: 24087, 24086, 10916

Compute BVH              : 123.16 ms
Serialize                : 14.88 ms
Deserialize              : 34.68 ms
```

## TODO
- [x] Add tests.
- [x] Consider requiring the gometry to be passed to the serialize function instead of saving it. It should be better for garbage collection in the long run in case the original geometry is discarded but the bvh is reused on a copy.
- [ ] Consider just using the array for traversal thought it's maybe in conflict with lazy construction (#128)