### PR TITLE
Add 'packData' option to improve memory footprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "main": "umd/index.js",
   "scripts": {
     "start": "concurrently \"parcel watch ./example/*.html --out-dir ./example/bundle/ --public-url . --no-cache\" \"rollup -w -c\" \"static-server\"",
-    "build": "rollup -c & parcel build ./example/*.html --out-dir ./example/bundle/ --public-url . --no-cache --no-source-maps --no-content-hash",
-    "test": "jest",
-    "lint": "eslint ./src/*.js ./test/*.js",
-    "benchmark": "node benchmark/index.js"
+    "generate-cast-functions": "node ./scripts/generate-cast-functions.js",
+    "build": "npm run generate-cast-functions && rollup -c & parcel build ./example/*.html --out-dir ./example/bundle/ --public-url . --no-cache --no-source-maps --no-content-hash",
+    "test": "npm run generate-cast-functions && jest",
+    "lint": "npm run generate-cast-functions && eslint ./src/*.js ./test/*.js",
+    "benchmark": "npm run generate-cast-functions && node benchmark/index.js"
   },
   "files": [
     "src/*",

--- a/scripts/generate-cast-functions.js
+++ b/scripts/generate-cast-functions.js
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+const fs = require( 'fs' );
+const path = require( 'path' );
 
 // Replace unneeded function definitions and checks. The `continueGeneration` block is always at the top of
 // a function definition so we can replace that with local variable definitions we need.
@@ -53,47 +53,47 @@ function replaceNodeNames( str ) {
 
 	str = str.replace(
 		new RegExp( `(${ names })\\.boundingData\\[(.*)\\]\\[(.*)\\]`, 'g' ),
-		( match, name, index, index2 ) => `float32Array[ ${ convertName( name ) } +${ index }+${ index2 }]`
+		( match, name, index, index2 ) => `/* ${ name } boundingData */ float32Array[ ${ convertName( name ) } +${ index }+${ index2 }]`
 	);
 
 	str = str.replace(
 		new RegExp( `(${ names })\\.boundingData\\[(.*)\\]`, 'g' ),
-		( match, name, index ) => `float32Array[ ${ convertName( name ) } +${ index }]`
+		( match, name, index ) => `/* ${ name } boundingData */ float32Array[ ${ convertName( name ) } +${ index }]`
 	);
 
 	str = str.replace(
 		new RegExp( `(${ names })\\.boundingData`, 'g' ),
-		( match, name ) => convertName( name )
+		( match, name ) => `/* ${ name } boundingData */ ${ convertName( name ) }`
 	);
 
 	str = str.replace(
 		new RegExp( `(${ names })\\.offset`, 'g' ),
-		( match, name ) => `uint32Array[ ${ convertName( name ) } + 6 ]`
+		( match, name ) => `/* ${ name } offset */ uint32Array[ ${ convertName( name ) } + 6 ]`
 	);
 
 	str = str.replace(
 		new RegExp( `! ! (${ names })\\.count`, 'g' ),
-		( match, name ) => `uint16Array[ ${ convertName( name, 2 ) } + 15 ] === 0xffff`
+		( match, name ) => `/* ${ name } count */ uint16Array[ ${ convertName( name, 2 ) } + 15 ] === 0xffff`
 	);
 
 	str = str.replace(
 		new RegExp( `(${ names })\\.count`, 'g' ),
-		( match, name ) => `uint16Array[ ${ convertName( name, 2 ) } + 14 ]`
+		( match, name ) => `/* ${ name } count */ uint16Array[ ${ convertName( name, 2 ) } + 14 ]`
 	);
 
 	str = str.replace(
 		new RegExp( `(${ names })\\.left`, 'g' ),
-		( match, name ) => `${ convertName( name ) } + 8`
+		( match, name ) => `/* ${ name } left */ ${ convertName( name ) } + 8`
 	);
 
 	str = str.replace(
 		new RegExp( `(${ names })\\.right`, 'g' ),
-		( match, name ) => `uint32Array[ ${ convertName( name ) } + 6 ]`
+		( match, name ) => `/* ${ name } right */ uint32Array[ ${ convertName( name ) } + 6 ]`
 	);
 
 	str = str.replace(
 		new RegExp( `(${ names })\\.splitAxis`, 'g' ),
-		( match, name ) => `uint32Array[ ${ convertName( name ) } + 7 ]`
+		( match, name ) => `/* ${ name } splitAxis */ uint32Array[ ${ convertName( name ) } + 7 ]`
 	);
 
 	return str;

--- a/scripts/generate-cast-functions.mjs
+++ b/scripts/generate-cast-functions.mjs
@@ -56,23 +56,21 @@ function replaceFunctionNames( str ) {
 
 	const arr = [
 
-		'raycast',
-		'raycastFirst',
-		'shapecast',
-		'intersectsGeometry',
-		'intersectsBox',
-		'closestPointToPoint',
-		'closestPointToGeometry',
+		'\\sraycast',
+		'\\sraycastFirst',
+		'\\sshapecast',
+		'\\sintersectsGeometry'
 
 	];
 
 	const defRegexp = new RegExp( '(' + arr.join( '|' ) + ')\\((\\s|\\n)?node', 'gm' );
 	const callRegexp = new RegExp( '(' + arr.join( '|' ) + ')\\(', 'gm' );
-	const constRegexp = new RegExp( 'const (' + arr.join( '|' ) + ')', 'gm' );
+	const constRegexp = new RegExp( 'const(' + arr.join( '|' ) + ')', 'gm' );
+
 	return str
 		.replace( defRegexp, ( match, funcName ) => `${ funcName }Buffer( stride4Offset` )
 		.replace( callRegexp, ( match, funcName ) => `${ funcName }Buffer(` )
-		.replace( constRegexp, ( match, funcName ) => `const ${ funcName }Buffer` );
+		.replace( constRegexp, ( match, funcName ) => `const${ funcName }Buffer` );
 
 }
 

--- a/scripts/generate-cast-functions.mjs
+++ b/scripts/generate-cast-functions.mjs
@@ -1,0 +1,162 @@
+import fs from 'fs';
+import path from 'path';
+
+function addHeaderComment( str ) {
+
+	return `
+/**************************************************************************************************
+ *
+ * This file is generated from castFunctions.js and scripts/generate-cast-function.mjs. Do not edit.
+ *
+ *************************************************************************************************/
+` + str;
+
+}
+
+function replaceNodeNames( str ) {
+
+	const coerce = ( name, count = 4 ) => {
+
+		return name === 'node' ? `stride${ count }Offset` : name;
+
+	};
+
+	const map = {
+
+		'(\\w+)\\.boundingData': name => `float32Array[ ${ coerce( name ) } ]`,
+		'(\\w+)\\.offset': name => `uint32Array[ ${ coerce( name ) } + 6 ]`,
+
+		'! ! (\\w+)\\.count': name => `uint16Array[ ${ coerce( name, 2 ) } ] === 0xffff`,
+		'(\\w+)\\.count': name => `uint16Array[ ${ coerce( name, 2 ) } + 14 ]`,
+
+		'(\\w+)\\.left': name => `${ coerce( name ) } + 8`,
+		'(\\w+)\\.right': name => `uint32Array[ ${ coerce( name ) } + 6 ]`,
+		'(\\w+)\\.splitAxis': name => `uint32Array[ ${ coerce( name ) } + 7 ]`,
+
+	};
+
+	Object.entries( map ).forEach( ( [ key, value ] ) => {
+
+		str = str.replace(
+			new RegExp( key, 'g' ),
+			( match, name ) => {
+
+				return `/* ${ match.replace( '.', ' ' ) } */ ` + value( name );
+
+			}
+		);
+
+	} );
+
+	return str;
+
+}
+
+function replaceFunctionNames( str ) {
+
+	const arr = [
+
+		'raycast',
+		'raycastFirst',
+		'shapecast',
+		'intersectsGeometry',
+		'intersectsBox',
+		'closestPointToPoint',
+		'closestPointToGeometry',
+
+	];
+
+	const defRegexp = new RegExp( '(' + arr.join( '|' ) + ')\\((\\s|\\n)?node', 'gm' );
+	const callRegexp = new RegExp( '(' + arr.join( '|' ) + ')\\(', 'gm' );
+	const constRegexp = new RegExp( 'const (' + arr.join( '|' ) + ')', 'gm' );
+	return str
+		.replace( defRegexp, ( match, funcName ) => `${ funcName }Buffer( stride4Offset` )
+		.replace( callRegexp, ( match, funcName ) => `${ funcName }Buffer(` )
+		.replace( constRegexp, ( match, funcName ) => `const ${ funcName }Buffer` );
+
+}
+
+function replaceFunctionCalls( str ) {
+
+	return str
+		.replace( /arrayToBox\(/g, 'arrayToBoxBuffer(' )
+		.replace( /intersectRay\(/g, 'intersectRayBuffer(' );
+
+}
+
+function removeUnneededCode( str ) {
+
+	const continueGenerationRegexp = new RegExp( 'if \\( node.continueGeneration \\)(.|\n)*?}\n', 'mg' );
+	const intersectRayRegexp = new RegExp( 'function intersectRay\\((.|\n)*?}\n', 'mg' );
+	return str
+		.replace( continueGenerationRegexp, 'const stride2Offset = stride4Offset * 2;' )
+		.replace( intersectRayRegexp, '' );
+
+}
+
+function addFunctions( str ) {
+
+	const instersectsRayBuffer =
+`
+function intersectRayBuffer( stride4Offset, ray, target ) {
+
+	arrayToBoxBuffer( stride4Offset, boundingBox );
+	return ray.intersectBox( boundingBox, target );
+
+}`;
+
+	const setBuffer =
+`
+let float32Array;
+let uint16Array;
+let uint32Array;
+export function setBuffer( buffer ) {
+
+	float32Array = new Float32Array( buffer );
+	uint16Array = new Uint16Array( buffer );
+	uint32Array = new Uint32Array( buffer );
+
+}
+
+export function clearBuffer() {
+
+	float32Array = null;
+	uint16Array = null;
+	uint32Array = null;
+
+}
+`;
+
+	const arrayToBoxBuffer =
+`
+function arrayToBoxBuffer( stride4Offset, target ) {
+
+	target.min.x = float32Array[ stride4Offset ];
+	target.min.y = float32Array[ stride4Offset + 1 ];
+	target.min.z = float32Array[ stride4Offset + 2 ];
+
+	target.max.x = float32Array[ stride4Offset + 3 ];
+	target.max.y = float32Array[ stride4Offset + 4 ];
+	target.max.z = float32Array[ stride4Offset + 5 ];
+
+}
+`;
+
+	return str + arrayToBoxBuffer + instersectsRayBuffer + setBuffer;
+
+
+}
+
+
+const templatePath = path.resolve( './src/castFunctions.js' );
+const bufferFilePath = path.resolve( './src/castFunctionsBuffer.js' );
+const str = fs.readFileSync( templatePath, { encoding: 'utf8' } );
+
+let result = str;
+result = replaceNodeNames( result );
+result = removeUnneededCode( result );
+result = replaceFunctionNames( result );
+result = addFunctions( result );
+result = replaceFunctionCalls( result );
+result = addHeaderComment( result );
+fs.writeFileSync( bufferFilePath, result );

--- a/scripts/generate-cast-functions.mjs
+++ b/scripts/generate-cast-functions.mjs
@@ -34,10 +34,19 @@ function replaceNodeNames( str ) {
 		'(\\w+)\\.splitAxis': name => `uint32Array[ ${ coerce( name ) } + 7 ]`,
 
 	};
+	const validNames = [ 'c1', 'c2', 'left', 'right', 'node' ];
 
 	str = str.replace( /(\w+)\.boundingData\[(.*)\]/g, ( match, name, index ) => {
 
-		return `float32Array[ ${ name } +${ index }]`;
+		if ( validNames.includes( name ) ) {
+
+			return `float32Array[ ${ name } +${ index }]`;
+
+		} else {
+
+			return match;
+
+		}
 
 	} );
 
@@ -47,7 +56,15 @@ function replaceNodeNames( str ) {
 			new RegExp( key, 'g' ),
 			( match, name ) => {
 
-				return `/* ${ match.replace( '.', ' ' ) } */ ` + value( name );
+				if ( validNames.includes( name ) ) {
+
+					return `/* ${ match.replace( '.', ' ' ) } */ ` + value( name );
+
+				} else {
+
+					return match;
+
+				}
 
 			}
 		);

--- a/scripts/generate-cast-functions.mjs
+++ b/scripts/generate-cast-functions.mjs
@@ -35,6 +35,12 @@ function replaceNodeNames( str ) {
 
 	};
 
+	str = str.replace( /(\w+)\.boundingData\[(.*)\]/g, ( match, name, index ) => {
+
+		return `float32Array[ ${ name } +${ index }]`;
+
+	} );
+
 	Object.entries( map ).forEach( ( [ key, value ] ) => {
 
 		str = str.replace(

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -4,13 +4,13 @@ import { CENTER } from './Constants.js';
 import { buildTree } from './buildFunctions.js';
 import { OrientedBox } from './Utils/OrientedBox.js';
 import { SeparatingAxisTriangle } from './Utils/SeparatingAxisTriangle.js';
+import { setTriangle } from './Utils/TriangleUtils.js';
 import { sphereIntersectTriangle } from './Utils/MathUtilities.js';
 import {
 	raycast,
 	raycastFirst,
 	shapecast,
 	intersectsGeometry,
-	setTriangle,
 } from './castFunctions.js';
 
 import {

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -225,18 +225,23 @@ export default class MeshBVH {
 			maxLeafTris: 10,
 			verbose: true,
 			lazyGeneration: false,
+			packData: false,
 			[ SKIP_GENERATION ]: false
 
 		}, options );
 		options.strategy = Math.max( 0, Math.min( 2, options.strategy ) );
 
-		if ( options[ SKIP_GENERATION ] ) {
-
-			this._roots = null;
-
-		} else {
+		this._isPacked = false;
+		this._roots = null;
+		if ( ! options[ SKIP_GENERATION ] ) {
 
 			this._roots = buildTree( geo, options );
+			if ( options.packData ) {
+
+				this._roots = MeshBVH.serialize( this, geo, false ).roots;
+				this._isPacked = true;
+
+			}
 
 		}
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -82,8 +82,6 @@ export default class MeshBVH {
 				const splitAxis = node.splitAxis;
 
 				let nextUnusedPointer;
-
-				// uint32Array[ stride4Offset + 6 ] = stride4Offset + BYTES_PER_NODE / 4;
 				nextUnusedPointer = populateBuffer( byteOffset + BYTES_PER_NODE, left );
 
 				uint32Array[ stride4Offset + 6 ] = nextUnusedPointer / 4;

--- a/src/MeshBVHVisualizer.js
+++ b/src/MeshBVHVisualizer.js
@@ -29,13 +29,13 @@ class MeshBVHRootVisualizer extends THREE.Group {
 		let requiredChildren = 0;
 		if ( this._boundsTree ) {
 
-			const recurse = ( n, d ) => {
+			this._boundsTree.traverse( ( depth, isLeaf, boundingData, offsetOrSplit, countOrIsUnfinished ) => {
 
-				let isLeaf = 'count' in n || 'continueGeneration' in n;
+				let isTerminal = isLeaf || countOrIsUnfinished;
 
-				if ( d === this.depth ) return;
+				if ( depth >= this.depth ) return;
 
-				if ( d === this.depth - 1 || isLeaf ) {
+				if ( depth === this.depth - 1 || isTerminal ) {
 
 					let m = requiredChildren < this.children.length ? this.children[ requiredChildren ] : null;
 					if ( ! m ) {
@@ -46,7 +46,7 @@ class MeshBVHRootVisualizer extends THREE.Group {
 
 					}
 					requiredChildren ++;
-					arrayToBox( n.boundingData, boundingBox );
+					arrayToBox( boundingData, boundingBox );
 					boundingBox.getCenter( m.position );
 					m.scale.subVectors( boundingBox.max, boundingBox.min ).multiplyScalar( 0.5 );
 
@@ -56,16 +56,7 @@ class MeshBVHRootVisualizer extends THREE.Group {
 
 				}
 
-				if ( ! isLeaf ) {
-
-					recurse( n.left, d + 1 );
-					recurse( n.right, d + 1 );
-
-				}
-
-			};
-
-			recurse( this._boundsTree._roots[ this._group ], 0 );
+			} );
 
 		}
 

--- a/src/Utils/Debug.js
+++ b/src/Utils/Debug.js
@@ -23,42 +23,37 @@ function isTypedArray( arr ) {
 
 }
 
-function getNodeExtremes( node, depth = 0, result = null ) {
+function getRootExtremes( bvh, group ) {
 
-	if ( ! result ) {
+	const result = {
+		total: 0,
+		depth: {
+			min: Infinity, max: - Infinity
+		},
+		tris: {
+			min: Infinity, max: - Infinity
+		},
+		splits: [ 0, 0, 0 ]
+	};
 
-		result = {
-			total: 0,
-			depth: {
-				min: Infinity, max: - Infinity
-			},
-			tris: {
-				min: Infinity, max: - Infinity
-			},
-			splits: [ 0, 0, 0 ]
-		};
+	bvh.traverse( ( depth, isLeaf, boundingData, offsetOrSplit, countOrIsUnfinished ) => {
 
-	}
+		result.total ++;
+		if ( isLeaf ) {
 
-	// we need to check if the node is a leaf and if it has "left" or "right"
-	// because we now have a state where it's in an intermediate state during
-	// lazy generation.
-	result.total ++;
-	if ( node.count ) {
+			result.depth.min = Math.min( depth, result.depth.min );
+			result.depth.max = Math.max( depth, result.depth.max );
 
-		result.depth.min = Math.min( depth, result.depth.min );
-		result.depth.max = Math.max( depth, result.depth.max );
+			result.tris.min = Math.min( countOrIsUnfinished, result.tris.min );
+			result.tris.max = Math.max( countOrIsUnfinished, result.tris.max );
 
-		result.tris.min = Math.min( node.count, result.tris.min );
-		result.tris.max = Math.max( node.count, result.tris.max );
+		} else {
 
-	} else if ( node.left && node.right ) {
+			result.splits[ offsetOrSplit ] ++;
 
-		result.splits[ node.splitAxis ] ++;
-		getNodeExtremes( node.left, depth + 1, result );
-		getNodeExtremes( node.right, depth + 1, result );
+		}
 
-	}
+	}, group );
 
 	// If there are no leaf nodes because the tree hasn't finished generating yet.
 	if ( result.tris.min === Infinity ) {
@@ -81,7 +76,7 @@ function getNodeExtremes( node, depth = 0, result = null ) {
 
 function getBVHExtremes( bvh ) {
 
-	return bvh._roots.map( root => getNodeExtremes( root ) );
+	return bvh._roots.map( ( root, i ) => getRootExtremes( bvh, i ) );
 
 }
 

--- a/src/Utils/ThreeIntersectionUtilities.js
+++ b/src/Utils/ThreeIntersectionUtilities.js
@@ -73,7 +73,6 @@ function checkBufferGeometryIntersection( object, raycaster, ray, position, uv, 
 
 }
 
-
 // https://github.com/mrdoob/three.js/blob/0aa87c999fe61e216c1133fba7a95772b503eddf/src/objects/Mesh.js#L258
 function intersectTri( mesh, geo, raycaster, ray, tri, intersections ) {
 
@@ -94,6 +93,6 @@ function intersectTri( mesh, geo, raycaster, ray, tri, intersections ) {
 
 	return null;
 
-};
+}
 
 export { intersectTri };

--- a/src/Utils/TriangleUtils.js
+++ b/src/Utils/TriangleUtils.js
@@ -1,0 +1,22 @@
+export function setTriangle( tri, i, index, pos ) {
+
+	const ta = tri.a;
+	const tb = tri.b;
+	const tc = tri.c;
+
+	let i3 = index.getX( i );
+	ta.x = pos.getX( i3 );
+	ta.y = pos.getY( i3 );
+	ta.z = pos.getZ( i3 );
+
+	i3 = index.getX( i + 1 );
+	tb.x = pos.getX( i3 );
+	tb.y = pos.getY( i3 );
+	tb.z = pos.getZ( i3 );
+
+	i3 = index.getX( i + 2 );
+	tc.x = pos.getX( i3 );
+	tc.y = pos.getY( i3 );
+	tc.z = pos.getZ( i3 );
+
+}

--- a/src/Utils/TriangleUtils.js
+++ b/src/Utils/TriangleUtils.js
@@ -1,3 +1,4 @@
+// sets the vertices of triangle `tri` with the 3 vertices after i
 export function setTriangle( tri, i, index, pos ) {
 
 	const ta = tri.a;

--- a/src/buildFunctions.js
+++ b/src/buildFunctions.js
@@ -64,7 +64,6 @@ function getRootIndexRanges( geo ) {
 
 }
 
-
 // computes the union of the bounds of all of the given triangles and puts the resulting box in target. If
 // centroidTarget is provided then a bounding box is computed for the centroids of the triangles, as well.
 // These are computed together to avoid redundant accesses to bounds array.

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -3,34 +3,12 @@ import * as THREE from 'three';
 import { intersectTris, intersectClosestTri } from './Utils/RayIntersectTriUtlities.js';
 import { arrayToBox } from './Utils/ArrayBoxUtilities.js';
 import { OrientedBox } from './Utils/OrientedBox.js';
+import { setTriangle } from './Utils/TriangleUtils.js';
 import { SeparatingAxisTriangle } from './Utils/SeparatingAxisTriangle.js';
 
 const boundingBox = new THREE.Box3();
 const boxIntersection = new THREE.Vector3();
 const xyzFields = [ 'x', 'y', 'z' ];
-
-export function setTriangle( tri, i, index, pos ) {
-
-	const ta = tri.a;
-	const tb = tri.b;
-	const tc = tri.c;
-
-	let i3 = index.getX( i );
-	ta.x = pos.getX( i3 );
-	ta.y = pos.getY( i3 );
-	ta.z = pos.getZ( i3 );
-
-	i3 = index.getX( i + 1 );
-	tb.x = pos.getX( i3 );
-	tb.y = pos.getY( i3 );
-	tb.z = pos.getZ( i3 );
-
-	i3 = index.getX( i + 2 );
-	tc.x = pos.getX( i3 );
-	tc.y = pos.getY( i3 );
-	tc.z = pos.getZ( i3 );
-
-}
 
 function intersectRay( node, ray, target ) {
 

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -140,7 +140,8 @@ export const shapecast = ( function () {
 
 		}
 
-		if ( node.count && intersectsTriangleFunc ) {
+		const isLeaf = ! ! node.count;
+		if ( isLeaf && intersectsTriangleFunc ) {
 
 			const geometry = mesh.geometry;
 			const index = geometry.index;
@@ -209,7 +210,7 @@ export const shapecast = ( function () {
 
 			const isC1Leaf = ! ! c1.count;
 			const c1Intersection =
-				intersectsBoundsFunc( box1, isC1Leaf, score1, c1 ) &&
+				intersectsBoundsFunc( box1, isC1Leaf, score1 ) &&
 				shapecast( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc );
 
 			if ( c1Intersection ) return true;
@@ -224,7 +225,7 @@ export const shapecast = ( function () {
 
 			const isC2Leaf = ! ! c2.count;
 			const c2Intersection =
-				intersectsBoundsFunc( box2, isC2Leaf, score2, c2 ) &&
+				intersectsBoundsFunc( box2, isC2Leaf, score2 ) &&
 				shapecast( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc );
 
 			if ( c2Intersection ) return true;

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -49,7 +49,8 @@ export function raycast( node, mesh, raycaster, ray, intersects ) {
 
 	}
 
-	if ( node.count ) {
+	const isLeaf = ! ! node.count;
+	if ( isLeaf ) {
 
 		intersectTris( mesh, mesh.geometry, raycaster, ray, node.offset, node.count, intersects );
 
@@ -79,7 +80,8 @@ export function raycastFirst( node, mesh, raycaster, ray ) {
 
 	}
 
-	if ( node.count ) {
+	const isLeaf = ! ! node.count;
+	if ( isLeaf ) {
 
 		return intersectClosestTri( mesh, mesh.geometry, raycaster, ray, node.offset, node.count );
 
@@ -290,7 +292,8 @@ export const intersectsGeometry = ( function () {
 
 		}
 
-		if ( node.count ) {
+		const isLeaf = ! ! node.count;
+		if ( isLeaf ) {
 
 			const thisGeometry = mesh.geometry;
 			const thisIndex = thisGeometry.index;

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -85,8 +85,8 @@ export function raycastFirstBuffer( stride4Offset, mesh, raycaster, ray ) {
 			// check only along the split axis
 			const rayOrig = ray.origin[ xyzAxis ];
 			const toPoint = rayOrig - c1Result.point[ xyzAxis ];
-			const toChild1 = rayOrig - /* c2 boundingData */ c2[ splitAxis ];
-			const toChild2 = rayOrig - /* c2 boundingData */ c2[ splitAxis + 3 ];
+			const toChild1 = rayOrig - float32Array[ c2 + splitAxis ];
+			const toChild2 = rayOrig - float32Array[ c2 + splitAxis + 3 ];
 
 			const toPointSq = toPoint * toPoint;
 			if ( toPointSq <= toChild1 * toChild1 && toPointSq <= toChild2 * toChild2 ) {

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -312,7 +312,7 @@ export const intersectsGeometryBuffer = ( function () {
 					triangle.c.applyMatrix4( invertedMat );
 					triangle.update();
 
-					for ( let i2 = 0, l2 = /* index count */ uint16Array[ index + 14 ]; i2 < l2; i2 += 3 ) {
+					for ( let i2 = 0, l2 = index.count; i2 < l2; i2 += 3 ) {
 
 						setTriangle( triangle2, i2, index, pos );
 						triangle2.update();

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -1,0 +1,411 @@
+
+/**************************************************************************************************
+ *
+ * This file is generated from castFunctions.js and scripts/generate-cast-function.mjs. Do not edit.
+ *
+ *************************************************************************************************/
+
+import * as THREE from 'three';
+import { intersectTris, intersectClosestTri } from './Utils/RayIntersectTriUtlities.js';
+import { arrayToBox } from './Utils/ArrayBoxUtilities.js';
+import { OrientedBox } from './Utils/OrientedBox.js';
+import { setTriangle } from './Utils/TriangleUtils.js';
+import { SeparatingAxisTriangle } from './Utils/SeparatingAxisTriangle.js';
+
+const boundingBox = new THREE.Box3();
+const boxIntersection = new THREE.Vector3();
+const xyzFields = [ 'x', 'y', 'z' ];
+
+
+export function raycastBuffer( stride4Offset, mesh, raycaster, ray, intersects ) {
+
+	const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+	const isLeaf = /* ! ! node count */ uint16Array[ stride2Offset + 15 ] === 0xffff;
+	if ( isLeaf ) {
+
+		intersectTris( mesh, mesh.geometry, raycaster, ray, /* node offset */ uint32Array[ stride4Offset + 6 ], /* node count */ uint16Array[ stride2Offset + 14 ], intersects );
+
+	} else {
+
+		if ( intersectRayBuffer( /* node left */ stride4Offset + 8, float32Array, ray, boxIntersection ) ) {
+
+			raycastBuffer( /* node left */ stride4Offset + 8, mesh, raycaster, ray, intersects );
+
+		}
+
+		if ( intersectRayBuffer( /* node right */ uint32Array[ stride4Offset + 6 ], float32Array, ray, boxIntersection ) ) {
+
+			raycastBuffer( /* node right */ uint32Array[ stride4Offset + 6 ], mesh, raycaster, ray, intersects );
+
+		}
+
+	}
+
+}
+
+export function raycastFirstBuffer( stride4Offset, mesh, raycaster, ray ) {
+
+	const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+	const isLeaf = /* ! ! node count */ uint16Array[ stride2Offset + 15 ] === 0xffff;
+	if ( isLeaf ) {
+
+		return intersectClosestTri( mesh, mesh.geometry, raycaster, ray, /* node offset */ uint32Array[ stride4Offset + 6 ], /* node count */ uint16Array[ stride2Offset + 14 ] );
+
+	} else {
+
+
+		// consider the position of the split plane with respect to the oncoming ray; whichever direction
+		// the ray is coming from, look for an intersection among that side of the tree first
+		const splitAxis = /* node splitAxis */ uint32Array[ stride4Offset + 7 ];
+		const xyzAxis = xyzFields[ splitAxis ];
+		const rayDir = ray.direction[ xyzAxis ];
+		const leftToRight = rayDir >= 0;
+
+		// c1 is the child to check first
+		let c1, c2;
+		if ( leftToRight ) {
+
+			c1 = /* node left */ stride4Offset + 8;
+			c2 = /* node right */ uint32Array[ stride4Offset + 6 ];
+
+		} else {
+
+			c1 = /* node right */ uint32Array[ stride4Offset + 6 ];
+			c2 = /* node left */ stride4Offset + 8;
+
+		}
+
+		const c1Intersection = intersectRayBuffer( c1, float32Array, ray, boxIntersection );
+		const c1Result = c1Intersection ? raycastFirstBuffer( c1, mesh, raycaster, ray ) : null;
+
+		// if we got an intersection in the first node and it's closer than the second node's bounding
+		// box, we don't need to consider the second node because it couldn't possibly be a better result
+		if ( c1Result ) {
+
+			// check only along the split axis
+			const rayOrig = ray.origin[ xyzAxis ];
+			const toPoint = rayOrig - c1Result.point[ xyzAxis ];
+			const toChild1 = rayOrig - /* c2 boundingData */ c2[ splitAxis ];
+			const toChild2 = rayOrig - /* c2 boundingData */ c2[ splitAxis + 3 ];
+
+			const toPointSq = toPoint * toPoint;
+			if ( toPointSq <= toChild1 * toChild1 && toPointSq <= toChild2 * toChild2 ) {
+
+				return c1Result;
+
+			}
+
+		}
+
+		// either there was no intersection in the first node, or there could still be a closer
+		// intersection in the second, so check the second node and then take the better of the two
+		const c2Intersection = intersectRayBuffer( c2, float32Array, ray, boxIntersection );
+		const c2Result = c2Intersection ? raycastFirstBuffer( c2, mesh, raycaster, ray ) : null;
+
+		if ( c1Result && c2Result ) {
+
+			return c1Result.distance <= c2Result.distance ? c1Result : c2Result;
+
+		} else {
+
+			return c1Result || c2Result || null;
+
+		}
+
+	}
+
+}
+
+export const shapecastBuffer = ( function () {
+
+	const triangle = new SeparatingAxisTriangle();
+	const cachedBox1 = new THREE.Box3();
+	const cachedBox2 = new THREE.Box3();
+	return function shapecastBuffer( stride4Offset, mesh, intersectsBoundsFunc, intersectsTriangleFunc = null, nodeScoreFunc = null ) {
+
+		const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+		const isLeaf = /* ! ! node count */ uint16Array[ stride2Offset + 15 ] === 0xffff;
+		if ( isLeaf && intersectsTriangleFunc ) {
+
+			const geometry = mesh.geometry;
+			const index = geometry.index;
+			const pos = geometry.attributes.position;
+			const offset = /* node offset */ uint32Array[ stride4Offset + 6 ];
+			const count = /* node count */ uint16Array[ stride2Offset + 14 ];
+
+			for ( let i = offset * 3, l = ( count + offset ) * 3; i < l; i += 3 ) {
+
+				setTriangle( triangle, i, index, pos );
+				triangle.update();
+
+				if ( intersectsTriangleFunc( triangle, i, i + 1, i + 2 ) ) {
+
+					return true;
+
+				}
+
+			}
+
+			return false;
+
+		} else {
+
+			const left = /* node left */ stride4Offset + 8;
+			const right = /* node right */ uint32Array[ stride4Offset + 6 ];
+			let c1 = left;
+			let c2 = right;
+
+			let score1, score2;
+			let box1, box2;
+			if ( nodeScoreFunc ) {
+
+				box1 = cachedBox1;
+				box2 = cachedBox2;
+
+				arrayToBoxBuffer( /* c1 boundingData */ c1, float32Array, box1 );
+				arrayToBoxBuffer( /* c2 boundingData */ c2, float32Array, box2 );
+
+				score1 = nodeScoreFunc( box1 );
+				score2 = nodeScoreFunc( box2 );
+
+				if ( score2 < score1 ) {
+
+					c1 = right;
+					c2 = left;
+
+					const temp = score1;
+					score1 = score2;
+					score2 = temp;
+
+					const tempBox = box1;
+					box1 = box2;
+					box2 = tempBox;
+
+				}
+
+			}
+
+			if ( ! box1 ) {
+
+				box1 = cachedBox1;
+				arrayToBoxBuffer( /* c1 boundingData */ c1, float32Array, box1 );
+
+			}
+
+			const isC1Leaf = /* ! ! c1 count */ uint16Array[ c1 + 15 ] === 0xffff;
+			const c1Intersection =
+				intersectsBoundsFunc( box1, isC1Leaf, score1 ) &&
+				shapecastBuffer( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc );
+
+			if ( c1Intersection ) return true;
+
+
+			if ( ! box2 ) {
+
+				box2 = cachedBox2;
+				arrayToBoxBuffer( /* c2 boundingData */ c2, float32Array, box2 );
+
+			}
+
+			const isC2Leaf = /* ! ! c2 count */ uint16Array[ c2 + 15 ] === 0xffff;
+			const c2Intersection =
+				intersectsBoundsFunc( box2, isC2Leaf, score2 ) &&
+				shapecastBuffer( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc );
+
+			if ( c2Intersection ) return true;
+
+			return false;
+
+		}
+
+	};
+
+} )();
+
+export const intersectsGeometryBuffer = ( function () {
+
+	const triangle = new SeparatingAxisTriangle();
+	const triangle2 = new SeparatingAxisTriangle();
+	const cachedMesh = new THREE.Mesh();
+	const invertedMat = new THREE.Matrix4();
+
+	const obb = new OrientedBox();
+	const obb2 = new OrientedBox();
+
+	return function intersectsGeometryBuffer( stride4Offset, mesh, geometry, geometryToBvh, cachedObb = null ) {
+
+		const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+		if ( cachedObb === null ) {
+
+			if ( ! geometry.boundingBox ) {
+
+				geometry.computeBoundingBox();
+
+			}
+
+			obb.set( geometry.boundingBox.min, geometry.boundingBox.max, geometryToBvh );
+			obb.update();
+			cachedObb = obb;
+
+		}
+
+		const isLeaf = /* ! ! node count */ uint16Array[ stride2Offset + 15 ] === 0xffff;
+		if ( isLeaf ) {
+
+			const thisGeometry = mesh.geometry;
+			const thisIndex = thisGeometry.index;
+			const thisPos = thisGeometry.attributes.position;
+
+			const index = geometry.index;
+			const pos = geometry.attributes.position;
+
+			const offset = /* node offset */ uint32Array[ stride4Offset + 6 ];
+			const count = /* node count */ uint16Array[ stride2Offset + 14 ];
+
+			// get the inverse of the geometry matrix so we can transform our triangles into the
+			// geometry space we're trying to test. We assume there are fewer triangles being checked
+			// here.
+			invertedMat.getInverse( geometryToBvh );
+
+			if ( geometry.boundsTree ) {
+
+				arrayToBoxBuffer( /* node boundingData */ stride4Offset, float32Array, obb2 );
+				obb2.matrix.copy( invertedMat );
+				obb2.update();
+
+				cachedMesh.geometry = geometry;
+				const res = geometry.boundsTree.shapecast( cachedMesh, box => obb2.intersectsBox( box ), function ( tri ) {
+
+					tri.a.applyMatrix4( geometryToBvh );
+					tri.b.applyMatrix4( geometryToBvh );
+					tri.c.applyMatrix4( geometryToBvh );
+					tri.update();
+
+					for ( let i = offset * 3, l = ( count + offset ) * 3; i < l; i += 3 ) {
+
+						// this triangle needs to be transformed into the current BVH coordinate frame
+						setTriangle( triangle2, i, thisIndex, thisPos );
+						triangle2.update();
+						if ( tri.intersectsTriangle( triangle2 ) ) {
+
+							return true;
+
+						}
+
+					}
+
+					return false;
+
+				} );
+				cachedMesh.geometry = null;
+
+				return res;
+
+			} else {
+
+				for ( let i = offset * 3, l = ( count + offset * 3 ); i < l; i += 3 ) {
+
+					// this triangle needs to be transformed into the current BVH coordinate frame
+					setTriangle( triangle, i, thisIndex, thisPos );
+					triangle.a.applyMatrix4( invertedMat );
+					triangle.b.applyMatrix4( invertedMat );
+					triangle.c.applyMatrix4( invertedMat );
+					triangle.update();
+
+					for ( let i2 = 0, l2 = /* index count */ uint16Array[ index + 14 ]; i2 < l2; i2 += 3 ) {
+
+						setTriangle( triangle2, i2, index, pos );
+						triangle2.update();
+
+						if ( triangle.intersectsTriangle( triangle2 ) ) {
+
+							return true;
+
+						}
+
+					}
+
+				}
+
+			}
+
+		} else {
+
+			const left = /* node left */ stride4Offset + 8;
+			const right = /* node right */ uint32Array[ stride4Offset + 6 ];
+
+			arrayToBoxBuffer( /* left boundingData */ left, float32Array, boundingBox );
+			const leftIntersection =
+				cachedObb.intersectsBox( boundingBox ) &&
+				intersectsGeometryBuffer( left, mesh, geometry, geometryToBvh, cachedObb );
+
+			if ( leftIntersection ) return true;
+
+
+			arrayToBoxBuffer( /* right boundingData */ right, float32Array, boundingBox );
+			const rightIntersection =
+				cachedObb.intersectsBox( boundingBox ) &&
+				intersectsGeometryBuffer( right, mesh, geometry, geometryToBvh, cachedObb );
+
+			if ( rightIntersection ) return true;
+
+			return false;
+
+		}
+
+	};
+
+} )();
+
+function arrayToBoxBuffer( stride4Offset, array, target ) {
+
+	target.min.x = array[ stride4Offset ];
+	target.min.y = array[ stride4Offset + 1 ];
+	target.min.z = array[ stride4Offset + 2 ];
+
+	target.max.x = array[ stride4Offset + 3 ];
+	target.max.y = array[ stride4Offset + 4 ];
+	target.max.z = array[ stride4Offset + 5 ];
+
+}
+
+function intersectRayBuffer( stride4Offset, array, ray, target ) {
+
+	arrayToBoxBuffer( stride4Offset, array, boundingBox );
+	return ray.intersectBox( boundingBox, target );
+
+}
+const bufferStack = [];
+let _prevBuffer;
+let _float32Array;
+let _uint16Array;
+let _uint32Array;
+export function setBuffer( buffer ) {
+
+	if ( _prevBuffer ) {
+
+		bufferStack.push( _prevBuffer );
+
+	}
+
+	_prevBuffer = buffer;
+	_float32Array = new Float32Array( buffer );
+	_uint16Array = new Uint16Array( buffer );
+	_uint32Array = new Uint32Array( buffer );
+
+}
+
+export function clearBuffer() {
+
+	_prevBuffer = null;
+	_float32Array = null;
+	_uint16Array = null;
+	_uint32Array = null;
+
+	if ( bufferStack.length ) {
+
+		setBuffer( bufferStack.pop() );
+
+	}
+
+}

--- a/test/IntersectionUtils.test.js
+++ b/test/IntersectionUtils.test.js
@@ -1,5 +1,5 @@
 /* global
-    describe it beforeAll beforeEach afterEach expect
+    describe it beforeEach expect
 */
 
 import * as THREE from 'three';
@@ -343,9 +343,6 @@ describe( 'Sphere Intersections', () => {
 } );
 
 describe( 'Box Intersections', () => {
-
-	const obbPlanes = new Array( 6 ).fill().map( () => new THREE.Plane() );
-	const obbPoints = new Array( 8 ).fill().map( () => new THREE.Vector3() );
 
 	let box, center;
 	beforeEach( () => {

--- a/test/MeshBVH.test.js
+++ b/test/MeshBVH.test.js
@@ -3,7 +3,7 @@
 */
 
 import * as THREE from 'three';
-import { MeshBVH, acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CENTER, SAH, AVERAGE, getBVHExtremes } from '../src/index.js';
+import { MeshBVH, acceleratedRaycast, computeBoundsTree, disposeBoundsTree, getBVHExtremes } from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
@@ -791,101 +791,5 @@ describe( 'Raycaster', () => {
 describe( 'BoundsTree API', () => {
 
 	it.skip( 'test bounds tree and node apis directly', () => {} );
-
-} );
-
-describe( 'Random intersections comparison', () => {
-
-	let scene = null;
-	let raycaster = null;
-	let ungroupedGeometry = null;
-	let ungroupedBvh = null;
-	let groupedGeometry = null;
-	let groupedBvh = null;
-
-	describe( 'CENTER split', () => runRandomTests( { strategy: CENTER } ) );
-	describe( 'Lazy CENTER split', () => runRandomTests( { strategy: CENTER, lazyGeneration: true } ) );
-
-	describe( 'AVERAGE split', () => runRandomTests( { strategy: AVERAGE } ) );
-	describe( 'Lazy AVERAGE split', () => runRandomTests( { strategy: AVERAGE, lazyGeneration: true } ) );
-
-	describe( 'SAH split', () => runRandomTests( { strategy: SAH } ) );
-	describe( 'Lazy SAH split', () => runRandomTests( { strategy: SAH, lazyGeneration: true } ) );
-
-	function runRandomTests( options ) {
-
-		beforeAll( () => {
-
-			ungroupedGeometry = new THREE.TorusBufferGeometry( 1, 1, 40, 10 );
-			groupedGeometry = new THREE.TorusBufferGeometry( 1, 1, 40, 10 );
-			const groupCount = 10;
-			const groupSize = groupedGeometry.index.array.length / groupCount;
-
-			for ( let g = 0; g < groupCount; g ++ ) {
-
-				const groupStart = g * groupSize;
-				groupedGeometry.addGroup( groupStart, groupSize, 0 );
-
-			}
-
-			groupedGeometry.computeBoundsTree( options );
-			ungroupedGeometry.computeBoundsTree( options );
-
-			ungroupedBvh = ungroupedGeometry.boundsTree;
-			groupedBvh = groupedGeometry.boundsTree;
-
-			scene = new THREE.Scene();
-			raycaster = new THREE.Raycaster();
-
-			for ( var i = 0; i < 10; i ++ ) {
-
-				let geo = i % 2 ? groupedGeometry : ungroupedGeometry;
-				let mesh = new THREE.Mesh( geo, new THREE.MeshBasicMaterial() );
-				mesh.rotation.x = Math.random() * 10;
-				mesh.rotation.y = Math.random() * 10;
-				mesh.rotation.z = Math.random() * 10;
-
-				mesh.position.x = Math.random() * 1;
-				mesh.position.y = Math.random() * 1;
-				mesh.position.z = Math.random() * 1;
-
-				scene.add( mesh );
-				mesh.updateMatrix( true );
-				mesh.updateMatrixWorld( true );
-
-			}
-
-		} );
-
-		for ( let i = 0; i < 100; i ++ ) {
-
-			it( 'cast ' + i, () => {
-
-				raycaster.firstHitOnly = false;
-				raycaster.ray.origin.set( Math.random() * 10, Math.random() * 10, Math.random() * 10 );
-				raycaster.ray.direction.copy( raycaster.ray.origin ).multiplyScalar( - 1 ).normalize();
-
-				ungroupedGeometry.boundsTree = ungroupedBvh;
-				groupedGeometry.boundsTree = groupedBvh;
-				const bvhHits = raycaster.intersectObject( scene, true );
-
-				raycaster.firstHitOnly = true;
-				const firstHit = raycaster.intersectObject( scene, true );
-
-				// run the og hits _after_ because in the lazy generation case
-				// the indices will be changing as the tree is generated and make
-				// the results will look different.
-				ungroupedGeometry.boundsTree = null;
-				groupedGeometry.boundsTree = null;
-				const ogHits = raycaster.intersectObject( scene, true );
-
-				expect( ogHits ).toEqual( bvhHits );
-				expect( firstHit[ 0 ] ).toEqual( ogHits[ 0 ] );
-
-			} );
-
-		}
-
-	}
 
 } );

--- a/test/MeshBVH.test.js
+++ b/test/MeshBVH.test.js
@@ -3,7 +3,7 @@
 */
 
 import * as THREE from 'three';
-import { MeshBVH, acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CENTER, SAH, AVERAGE } from '../src/index.js';
+import { MeshBVH, acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CENTER, SAH, AVERAGE, getBVHExtremes } from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
@@ -646,20 +646,7 @@ describe( 'Options', () => {
 		// Returns the max tree depth of the BVH
 		function getMaxDepth( bvh ) {
 
-			function getMaxDepthFrom( node ) {
-
-				const isLeaf = 'count' in node;
-
-				if ( isLeaf ) return 0;
-
-				return 1 + Math.max(
-					getMaxDepthFrom( node.left ),
-					getMaxDepthFrom( node.right )
-				);
-
-			}
-
-			return Math.max.apply( null, bvh._roots.map( getMaxDepthFrom ) );
+			return getBVHExtremes( bvh )[ 0 ].depth.max;
 
 		}
 

--- a/test/RandomRaycasts.test.js
+++ b/test/RandomRaycasts.test.js
@@ -1,0 +1,106 @@
+/* global
+    describe it beforeAll expect
+*/
+
+import * as THREE from 'three';
+import { CENTER, SAH, AVERAGE } from '../src/index.js';
+
+
+function runRandomTests( options ) {
+
+	let scene = null;
+	let raycaster = null;
+	let ungroupedGeometry = null;
+	let ungroupedBvh = null;
+	let groupedGeometry = null;
+	let groupedBvh = null;
+
+	beforeAll( () => {
+
+		ungroupedGeometry = new THREE.TorusBufferGeometry( 1, 1, 40, 10 );
+		groupedGeometry = new THREE.TorusBufferGeometry( 1, 1, 40, 10 );
+		const groupCount = 10;
+		const groupSize = groupedGeometry.index.array.length / groupCount;
+
+		for ( let g = 0; g < groupCount; g ++ ) {
+
+			const groupStart = g * groupSize;
+			groupedGeometry.addGroup( groupStart, groupSize, 0 );
+
+		}
+
+		groupedGeometry.computeBoundsTree( options );
+		ungroupedGeometry.computeBoundsTree( options );
+
+		ungroupedBvh = ungroupedGeometry.boundsTree;
+		groupedBvh = groupedGeometry.boundsTree;
+
+		scene = new THREE.Scene();
+		raycaster = new THREE.Raycaster();
+
+		for ( var i = 0; i < 10; i ++ ) {
+
+			let geo = i % 2 ? groupedGeometry : ungroupedGeometry;
+			let mesh = new THREE.Mesh( geo, new THREE.MeshBasicMaterial() );
+			mesh.rotation.x = Math.random() * 10;
+			mesh.rotation.y = Math.random() * 10;
+			mesh.rotation.z = Math.random() * 10;
+
+			mesh.position.x = Math.random() * 1;
+			mesh.position.y = Math.random() * 1;
+			mesh.position.z = Math.random() * 1;
+
+			scene.add( mesh );
+			mesh.updateMatrix( true );
+			mesh.updateMatrixWorld( true );
+
+		}
+
+	} );
+
+	for ( let i = 0; i < 100; i ++ ) {
+
+		it( 'cast ' + i, () => {
+
+			raycaster.firstHitOnly = false;
+			raycaster.ray.origin.set( Math.random() * 10, Math.random() * 10, Math.random() * 10 );
+			raycaster.ray.direction.copy( raycaster.ray.origin ).multiplyScalar( - 1 ).normalize();
+
+			ungroupedGeometry.boundsTree = ungroupedBvh;
+			groupedGeometry.boundsTree = groupedBvh;
+			const bvhHits = raycaster.intersectObject( scene, true );
+
+			raycaster.firstHitOnly = true;
+			const firstHit = raycaster.intersectObject( scene, true );
+
+			// run the og hits _after_ because in the lazy generation case
+			// the indices will be changing as the tree is generated and make
+			// the results will look different.
+			ungroupedGeometry.boundsTree = null;
+			groupedGeometry.boundsTree = null;
+			const ogHits = raycaster.intersectObject( scene, true );
+
+			expect( ogHits ).toEqual( bvhHits );
+			expect( firstHit[ 0 ] ).toEqual( ogHits[ 0 ] );
+
+		} );
+
+	}
+
+}
+
+describe( 'Random intersections comparison', () => {
+
+	describe( 'CENTER split', () => runRandomTests( { strategy: CENTER, packData: false } ) );
+	describe( 'Lazy CENTER split', () => runRandomTests( { strategy: CENTER, lazyGeneration: true } ) );
+	describe( 'Packed CENTER split', () => runRandomTests( { strategy: CENTER } ) );
+
+	describe( 'AVERAGE split', () => runRandomTests( { strategy: AVERAGE, packData: false } ) );
+	describe( 'Lazy AVERAGE split', () => runRandomTests( { strategy: AVERAGE, lazyGeneration: true } ) );
+	describe( 'Packed CENTER split', () => runRandomTests( { strategy: AVERAGE } ) );
+
+	describe( 'SAH split', () => runRandomTests( { strategy: SAH, packData: false } ) );
+	describe( 'Lazy SAH split', () => runRandomTests( { strategy: SAH, lazyGeneration: true } ) );
+	describe( 'Packed SAH split', () => runRandomTests( { strategy: SAH } ) );
+
+} );

--- a/test/RandomRaycasts.test.js
+++ b/test/RandomRaycasts.test.js
@@ -3,8 +3,11 @@
 */
 
 import * as THREE from 'three';
-import { CENTER, SAH, AVERAGE } from '../src/index.js';
+import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CENTER, SAH, AVERAGE } from '../src/index.js';
 
+THREE.Mesh.prototype.raycast = acceleratedRaycast;
+THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
+THREE.BufferGeometry.prototype.disposeBoundsTree = disposeBoundsTree;
 
 function runRandomTests( options ) {
 
@@ -89,18 +92,26 @@ function runRandomTests( options ) {
 
 }
 
-describe( 'Random intersections comparison', () => {
+describe( 'Random CENTER intersections', () => {
 
-	describe( 'CENTER split', () => runRandomTests( { strategy: CENTER, packData: false } ) );
-	describe( 'Lazy CENTER split', () => runRandomTests( { strategy: CENTER, lazyGeneration: true } ) );
-	describe( 'Packed CENTER split', () => runRandomTests( { strategy: CENTER } ) );
+	describe( 'split', () => runRandomTests( { strategy: CENTER, packData: false } ) );
+	describe( 'Lazy split', () => runRandomTests( { strategy: CENTER, lazyGeneration: true } ) );
+	describe( 'Packed split', () => runRandomTests( { strategy: CENTER } ) );
 
-	describe( 'AVERAGE split', () => runRandomTests( { strategy: AVERAGE, packData: false } ) );
-	describe( 'Lazy AVERAGE split', () => runRandomTests( { strategy: AVERAGE, lazyGeneration: true } ) );
-	describe( 'Packed CENTER split', () => runRandomTests( { strategy: AVERAGE } ) );
+} );
 
-	describe( 'SAH split', () => runRandomTests( { strategy: SAH, packData: false } ) );
-	describe( 'Lazy SAH split', () => runRandomTests( { strategy: SAH, lazyGeneration: true } ) );
-	describe( 'Packed SAH split', () => runRandomTests( { strategy: SAH } ) );
+describe( 'Random AVERAGE intersections', () => {
+
+	describe( 'split', () => runRandomTests( { strategy: AVERAGE, packData: false } ) );
+	describe( 'Lazy split', () => runRandomTests( { strategy: AVERAGE, lazyGeneration: true } ) );
+	describe( 'Packed split', () => runRandomTests( { strategy: AVERAGE } ) );
+
+} );
+
+describe( 'Random SAH intersections', () => {
+
+	describe( 'split', () => runRandomTests( { strategy: SAH, packData: false } ) );
+	describe( 'Lazy split', () => runRandomTests( { strategy: SAH, lazyGeneration: true } ) );
+	describe( 'Packed split', () => runRandomTests( { strategy: SAH } ) );
 
 } );


### PR DESCRIPTION
Fix #42

- Move `intersectsBox`, `intersectsSphere`, `closestPointToPoint`, `closestPointToGeometry` logic to `MeshBVH`.
- Clean up `castFunctions` to make it more processable.
- Add generation script to convert `castFunctions.js` into packed buffer variants.
- Add buffer branch in the cast functions.

**TODO**
- [x] Abstract away traversal because _roots no longer works like it did before (they're arraybuffers)
- [x] Fix seralization
- [x] Fix tests, benchmarks
- [x] Clean up the generation script to make it more readable
- [x] Decide if packed data should be the default option.
- [ ] Run _all_ tests with lazy, packed, and normal options
- [ ] Add log indicating that lazy generation and packed buffers can't work together.
- [ ] Consider adding a function to "complete" the tree and pack it for the lazy case.
