### PR TITLE
Bounds containment fix

### DIFF
--- a/src/MeshBVHDebug.js
+++ b/src/MeshBVHDebug.js
@@ -47,7 +47,7 @@ export class MeshBVHDebug {
 					let isContained = true;
 
 					vec.fromBufferAttribute( position, i0 );
-					isContained = isContained && box1.containsPoint( vec );
+					isContained = box1.containsPoint( vec );
 
 					vec.fromBufferAttribute( position, i1 );
 					isContained = isContained && box1.containsPoint( vec );

--- a/src/MeshBVHDebug.js
+++ b/src/MeshBVHDebug.js
@@ -44,7 +44,7 @@ export class MeshBVHDebug {
 					const i1 = index.getX( i + 1 );
 					const i2 = index.getX( i + 2 );
 
-					let isContained = true;
+					let isContained;
 
 					vec.fromBufferAttribute( position, i0 );
 					isContained = box1.containsPoint( vec );

--- a/src/MeshBVHDebug.js
+++ b/src/MeshBVHDebug.js
@@ -1,0 +1,70 @@
+import { Box3, Vector3 } from 'three';
+import { arrayToBox } from './Utils/ArrayBoxUtilities.js';
+const box1 = new Box3();
+const box2 = new Box3();
+const vec = new Vector3();
+
+export class MeshBVHDebug {
+
+	constructor( bvh, geometry ) {
+
+		this.bvh = bvh;
+		this.geometry = geometry;
+
+	}
+
+	validateBounds() {
+
+		const { bvh, geometry } = this;
+		const depthStack = [];
+		const index = geometry.index;
+		const position = geometry.getAttribute( 'position' );
+
+		bvh.traverse( ( depth, isLeaf, boundingData, offset, count ) => {
+			const info = {
+				depth,
+				isLeaf,
+				boundingData,
+				offset,
+				count,
+			};
+			depthStack[ depth ] = info;
+
+			arrayToBox( boundingData, box1 );
+			const parent = depthStack[ depth - 1 ];
+
+			if ( isLeaf ) {
+
+				// check triangles
+				for ( let i = offset * 3, l = ( offset + count ) * 3; i < l; i += 3 ) {
+
+					const i0 = index.getX( i );
+					const i1 = index.getX( i + 1 );
+					const i2 = index.getX( i + 2 );
+
+					vec.fromBufferAttribute( position, i0 );
+					console.assert( box1.containsPoint( vec ), 'Leaf bounds does not fully contain triangle.' );
+
+					vec.fromBufferAttribute( position, i1 );
+					console.assert( box1.containsPoint( vec ), 'Leaf bounds does not fully contain triangle.' );
+
+					vec.fromBufferAttribute( position, i2 );
+					console.assert( box1.containsPoint( vec ), 'Leaf bounds does not fully contain triangle.' );
+
+				}
+
+			}
+
+			if ( parent ) {
+
+				// check if my bounds fit in my parents
+				arrayToBox( boundingData, box2 );
+				console.assert( box2.containsBox( box1 ), 'Parent bounds does not fully contain child.' );
+
+			}
+
+		} );
+
+	}
+
+}

--- a/src/MeshBVHDebug.js
+++ b/src/MeshBVHDebug.js
@@ -22,6 +22,7 @@ export class MeshBVHDebug {
 		let passes = true;
 
 		bvh.traverse( ( depth, isLeaf, boundingData, offset, count ) => {
+
 			const info = {
 				depth,
 				isLeaf,

--- a/src/MeshBVHDebug.js
+++ b/src/MeshBVHDebug.js
@@ -19,6 +19,7 @@ export class MeshBVHDebug {
 		const depthStack = [];
 		const index = geometry.index;
 		const position = geometry.getAttribute( 'position' );
+		let passes = true;
 
 		bvh.traverse( ( depth, isLeaf, boundingData, offset, count ) => {
 			const info = {
@@ -42,14 +43,19 @@ export class MeshBVHDebug {
 					const i1 = index.getX( i + 1 );
 					const i2 = index.getX( i + 2 );
 
+					let isContained = true;
+
 					vec.fromBufferAttribute( position, i0 );
-					console.assert( box1.containsPoint( vec ), 'Leaf bounds does not fully contain triangle.' );
+					isContained = isContained && box1.containsPoint( vec );
 
 					vec.fromBufferAttribute( position, i1 );
-					console.assert( box1.containsPoint( vec ), 'Leaf bounds does not fully contain triangle.' );
+					isContained = isContained && box1.containsPoint( vec );
 
 					vec.fromBufferAttribute( position, i2 );
-					console.assert( box1.containsPoint( vec ), 'Leaf bounds does not fully contain triangle.' );
+					isContained = isContained && box1.containsPoint( vec );
+
+					console.assert( isContained, 'Leaf bounds does not fully contain triangle.' );
+					passes = passes && isContained;
 
 				}
 
@@ -59,11 +65,16 @@ export class MeshBVHDebug {
 
 				// check if my bounds fit in my parents
 				arrayToBox( boundingData, box2 );
-				console.assert( box2.containsBox( box1 ), 'Parent bounds does not fully contain child.' );
+
+				const isContained = box2.containsBox( box1 );
+				console.assert( isContained, 'Parent bounds does not fully contain child.' );
+				passes = passes && isContained;
 
 			}
 
 		} );
+
+		return passes;
 
 	}
 

--- a/src/buildFunctions.js
+++ b/src/buildFunctions.js
@@ -4,7 +4,7 @@ import { arrayToBox, boxToArray, getLongestEdgeIndex } from './Utils/ArrayBoxUti
 import { CENTER, AVERAGE, SAH } from './Constants.js';
 
 // https://en.wikipedia.org/wiki/Machine_epsilon#Values_for_standard_hardware_floating_point_arithmetics
-const FLOAT32_EPSILON = Math.pow( 2, - 17 );
+const FLOAT32_EPSILON = Math.pow( 2, - 24 );
 const xyzFields = [ 'x', 'y', 'z' ];
 const boxTemp = new Box3();
 
@@ -480,12 +480,13 @@ function computeTriangleBounds( geo ) {
 			if ( b > max ) max = b;
 			if ( c > max ) max = c;
 
-			// Increase the bounds size by float32 epsilon to avoid precision errors
-			// when converting to 32 bit float.
+			// Increase the bounds size by float32 epsilon to avoid precision errors when
+			// converting to 32 bit float. Scale the epsilon by the size of the numbers being
+			// worked with.
 			const halfExtents = ( max - min ) / 2;
 			const el2 = el * 2;
 			triangleBounds[ tri6 + el2 + 0 ] = min + halfExtents;
-			triangleBounds[ tri6 + el2 + 1 ] = halfExtents + FLOAT32_EPSILON;
+			triangleBounds[ tri6 + el2 + 1 ] = halfExtents + ( Math.abs( min ) + halfExtents ) * FLOAT32_EPSILON;
 
 		}
 

--- a/src/buildFunctions.js
+++ b/src/buildFunctions.js
@@ -480,8 +480,26 @@ function computeTriangleBounds( geo ) {
 
 			const halfExtents = ( max - min ) / 2;
 			const el2 = el * 2;
-			triangleBounds[ tri6 + el2 + 0 ] = min + halfExtents;
-			triangleBounds[ tri6 + el2 + 1 ] = halfExtents;
+			const center = min + halfExtents;
+
+			const centerIndex = tri6 + el2 + 0;
+			const extentsIndex = tri6 + el2 + 1;
+			triangleBounds[ centerIndex ] = center;
+			triangleBounds[ extentsIndex ] = halfExtents;
+
+			// Check if the float 32 conversion shrunk the bounds at all due
+			// to precision loss. If so then expand the bounds by that amount.
+			const halfExtents32 = triangleBounds[ extentsIndex ];
+			const center32 = triangleBounds[ centerIndex ];
+
+			const halfExtentsDelta = halfExtents32 - halfExtents;
+			const centerDelta = Math.abs( center32 - center );
+			if ( centerDelta > halfExtentsDelta ) {
+
+				const difference = centerDelta - halfExtentsDelta;
+				triangleBounds[ extentsIndex ] = halfExtents + difference;
+
+			}
 
 		}
 

--- a/src/buildFunctions.js
+++ b/src/buildFunctions.js
@@ -478,19 +478,17 @@ function computeTriangleBounds( geo ) {
 			if ( b > max ) max = b;
 			if ( c > max ) max = c;
 
-			const halfExtents = ( max - min ) / 2;
-			const el2 = el * 2;
-			const center = min + halfExtents;
+			let halfExtents = ( max - min ) / 2;
+			let center = min + halfExtents;
 
+			const el2 = el * 2;
 			const centerIndex = tri6 + el2 + 0;
 			const extentsIndex = tri6 + el2 + 1;
-			triangleBounds[ centerIndex ] = center;
-			triangleBounds[ extentsIndex ] = halfExtents;
 
 			// Check if the float 32 conversion shrunk the bounds at all due
 			// to precision loss. If so then expand the bounds by that amount.
-			const halfExtents32 = triangleBounds[ extentsIndex ];
-			const center32 = triangleBounds[ centerIndex ];
+			const halfExtents32 = Math.fround( halfExtents );
+			const center32 = Math.fround( center );
 
 			const halfExtentsDelta = halfExtents32 - halfExtents;
 			const centerDelta = Math.abs( center32 - center );
@@ -499,7 +497,13 @@ function computeTriangleBounds( geo ) {
 				const difference = centerDelta - halfExtentsDelta;
 				triangleBounds[ extentsIndex ] = halfExtents + difference;
 
+			} else {
+
+				triangleBounds[ extentsIndex ] = halfExtents;
+
 			}
+
+			triangleBounds[ centerIndex ] = center;
 
 		}
 

--- a/src/buildFunctions.js
+++ b/src/buildFunctions.js
@@ -3,6 +3,8 @@ import MeshBVHNode from './MeshBVHNode.js';
 import { arrayToBox, boxToArray, getLongestEdgeIndex } from './Utils/ArrayBoxUtilities.js';
 import { CENTER, AVERAGE, SAH } from './Constants.js';
 
+// https://en.wikipedia.org/wiki/Machine_epsilon#Values_for_standard_hardware_floating_point_arithmetics
+const FLOAT32_EPSILON = Math.pow( 2, - 23 );
 const xyzFields = [ 'x', 'y', 'z' ];
 const boxTemp = new Box3();
 
@@ -478,32 +480,12 @@ function computeTriangleBounds( geo ) {
 			if ( b > max ) max = b;
 			if ( c > max ) max = c;
 
-			let halfExtents = ( max - min ) / 2;
-			let center = min + halfExtents;
-
+			// Increase the bounds size by float32 epsilon to avoid precision errors
+			// when converting to 32 bit float.
+			const halfExtents = ( max - min ) / 2;
 			const el2 = el * 2;
-			const centerIndex = tri6 + el2 + 0;
-			const extentsIndex = tri6 + el2 + 1;
-
-			// Check if the float 32 conversion shrunk the bounds at all due
-			// to precision loss. If so then expand the bounds by that amount.
-			const halfExtents32 = Math.fround( halfExtents );
-			const center32 = Math.fround( center );
-
-			const halfExtentsDelta = halfExtents32 - halfExtents;
-			const centerDelta = Math.abs( center32 - center );
-			if ( centerDelta > halfExtentsDelta ) {
-
-				const difference = centerDelta - halfExtentsDelta;
-				triangleBounds[ extentsIndex ] = halfExtents + difference;
-
-			} else {
-
-				triangleBounds[ extentsIndex ] = halfExtents;
-
-			}
-
-			triangleBounds[ centerIndex ] = center;
+			triangleBounds[ tri6 + el2 + 0 ] = min + halfExtents;
+			triangleBounds[ tri6 + el2 + 1 ] = halfExtents + FLOAT32_EPSILON;
 
 		}
 

--- a/src/buildFunctions.js
+++ b/src/buildFunctions.js
@@ -4,7 +4,7 @@ import { arrayToBox, boxToArray, getLongestEdgeIndex } from './Utils/ArrayBoxUti
 import { CENTER, AVERAGE, SAH } from './Constants.js';
 
 // https://en.wikipedia.org/wiki/Machine_epsilon#Values_for_standard_hardware_floating_point_arithmetics
-const FLOAT32_EPSILON = Math.pow( 2, - 23 );
+const FLOAT32_EPSILON = Math.pow( 2, - 17 );
 const xyzFields = [ 'x', 'y', 'z' ];
 const boxTemp = new Box3();
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import MeshBVH from './MeshBVH.js';
 import Visualizer from './MeshBVHVisualizer.js';
 import { CENTER, AVERAGE, SAH } from './Constants.js';
 import { getBVHExtremes, estimateMemoryInBytes } from './Utils/Debug.js';
+import { MeshBVHDebug } from './MeshBVHDebug.js';
 
 const ray = new Ray();
 const tmpInverseMatrix = new Matrix4();
@@ -50,7 +51,7 @@ function disposeBoundsTree() {
 }
 
 export {
-	MeshBVH, Visualizer, Visualizer as MeshBVHVisualizer,
+	MeshBVH, Visualizer, Visualizer as MeshBVHVisualizer, MeshBVHDebug,
 	acceleratedRaycast, computeBoundsTree, disposeBoundsTree,
 	CENTER, AVERAGE, SAH,
 	estimateMemoryInBytes, getBVHExtremes

--- a/test/MeshBVH.test.js
+++ b/test/MeshBVH.test.js
@@ -11,7 +11,7 @@ import {
 	TorusBufferGeometry,
 	BufferAttribute
 } from 'three';
-import { MeshBVH, acceleratedRaycast, computeBoundsTree, disposeBoundsTree, getBVHExtremes } from '../src/index.js';
+import { MeshBVH, acceleratedRaycast, computeBoundsTree, disposeBoundsTree, getBVHExtremes, MeshBVHDebug } from '../src/index.js';
 
 Mesh.prototype.raycast = acceleratedRaycast;
 BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
@@ -25,6 +25,16 @@ function getMaxDepth( bvh ) {
 }
 
 describe( 'Bounds Tree', () => {
+
+	it( 'should properly encapsulate all triangles and bounds.', () => {
+
+		const geom = new SphereBufferGeometry( 500, 50, 50 );
+		const bvh = new MeshBVH( geom, { lazyGeneration: false } );
+		const debug = new MeshBVHDebug( bvh, geom );
+
+		expect( debug.validateBounds() ).toBeTruthy();
+
+	} );
 
 	it( 'should be generated when calling BufferGeometry.computeBoundsTree', () => {
 


### PR DESCRIPTION
Fix #169

~PR expands the leaf bounds by the amount of floating point precision loss when converting the bounds' center and half extents to 32 bit floats. At most the difference seems to be `0.00001526`.~

~The other option is to store the min and max bounds rather than the center and half extents which would  prevent an precision issues all together. The center value is used in a variety of functions, though, so performance would have to be compared.~

~Benchmark for creating a BVH goes up by \~10ms from `~144ms` to `~157ms`.~

Adds an epsilon value to the half extents to ensure the new bounds still encapsulates all contents after float32 conversion.

### TODO
- [ ] Benchmark
- [x] Add test that runs the debug validate bounds