### PR TITLE
Add shapecast contains optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ Option to use a Surface Area Heuristic to split the bounds optimally.
 
 This is the slowest construction option.
 
+## Shapecast Intersection Constants
+
+### NOT_INTERSECTED
+
+Indicates the shape did not intersect the given bounding box.
+
+### INTERSECTED
+
+Indicates the shape did intersect the given bounding box.
+
+### CONTAINED
+
+Indicate the shape entirely contains the given bounding box.
+
 ## MeshBVH
 
 The MeshBVH generation process modifies the geometry's index bufferAttribute in place to save memory. The BVH construction will use the geometry's boundingBox if it exists or set it if it does not. The BVH will no longer work correctly if the index buffer is modified.
@@ -311,7 +325,7 @@ shapecast(
 		box : Box3,
 		isLeaf : Boolean,
 		score : Number | undefined
-	) => Boolean,
+	) => NOT_INTERSECTED | INTERSECTED | CONTAINED,
 
 	intersectsTriangleFunc : (
 		triangle : Triangle,
@@ -331,7 +345,7 @@ A generalized cast function that can be used to implement intersection logic for
 
 `mesh` is the is the object this BVH is representing.
 
-`intersectsBoundsFunc` takes the axis aligned bounding box representing an internal node local to the bvh, whether or not the node is a leaf, and the score calculated by `orderNodesFunc` and returns a boolean indicating whether or not the bounds is intersected and traversal should continue.
+`intersectsBoundsFunc` takes the axis aligned bounding box representing an internal node local to the bvh, whether or not the node is a leaf, and the score calculated by `orderNodesFunc` and returns a constant indicating whether or not the bounds is intersected or contained and traversal should continue. If `CONTAINED` is returned then and optimization is triggered allowing all child triangles to be checked immediately rather than traversing the rest of the child bounds.
 
 `intersectsTriangleFunc` takes a triangle and the vertex indices used by the triangle from the geometry and returns whether or not the triangle has been intersected with. If the triangle is reported to be intersected the traversal ends and the `shapecast` function completes. If multiple triangles need to be collected or intersected return false here and push results onto an array.
 

--- a/scripts/generate-cast-functions.js
+++ b/scripts/generate-cast-functions.js
@@ -244,4 +244,5 @@ result = replaceNodeNames( result );
 result = replaceFunctionNames( result );
 result = addFunctions( result );
 result = addHeaderComment( result );
+result = result.replace( /^\s+$/gm, '' );
 fs.writeFileSync( bufferFilePath, result );

--- a/scripts/generate-cast-functions.js
+++ b/scripts/generate-cast-functions.js
@@ -50,7 +50,6 @@ function replaceNodeNames( str ) {
 
 	const names = 'c1|c2|left|right|node';
 
-
 	str = str.replace(
 		new RegExp( `(${ names })\\.boundingData\\[(.*)\\]\\[(.*)\\]`, 'g' ),
 		( match, name, index, index2 ) => `/* ${ name } boundingData */ float32Array[ ${ convertName( name ) } +${ index }+${ index2 }]`
@@ -96,13 +95,18 @@ function replaceNodeNames( str ) {
 		( match, name ) => `/* ${ name } splitAxis */ uint32Array[ ${ convertName( name ) } + 7 ]`
 	);
 
+	str = str.replace(
+		new RegExp( `(node)\\s*=`, 'g' ),
+		( match, name ) => `/* ${ name } */ ${ convertName( name ) } =`
+	);
+
 	return str;
 
 }
 
 function replaceFunctionNames( str ) {
 
-	const orNames = '\\s(raycast|raycastFirst|shapecast|intersectsGeometry)';
+	const orNames = '\\s(raycast|raycastFirst|shapecast|intersectsGeometry|getLeftOffset|getRightEndOffset)';
 
 	str = str.replace(
 		new RegExp( `(${ orNames })\\((\\s|[\\r|\\n])?node`, 'gm' ),

--- a/scripts/generate-cast-functions.js
+++ b/scripts/generate-cast-functions.js
@@ -6,11 +6,24 @@ const path = require( 'path' );
 function replaceUnneededCode( str ) {
 
 	str = str.replace(
-		/if \( node.continueGeneration \)(.|\n|\r)*?}[\r|\n]/mg,
-		'const stride2Offset = stride4Offset * 2, ' +
-		'float32Array = _float32Array, ' +
-		'uint16Array = _uint16Array, ' +
-		'uint32Array = _uint32Array;'
+		/if \( [^)]*node.continueGeneration \)(.|\n|\r)*?}[\r|\n]/mg,
+		match => {
+
+			if ( match.indexOf( '/* skip */' ) !== - 1 ) {
+
+				return '';
+
+			} else {
+
+				return 'const stride2Offset = stride4Offset * 2, ' +
+					'float32Array = _float32Array, ' +
+					'uint16Array = _uint16Array, ' +
+					'uint32Array = _uint32Array;\n'
+
+			}
+
+		}
+
 	);
 
 	str = str.replace( /function intersectRay\((.|[\r\n])*?}[\r|\n]/mg, '' );
@@ -96,8 +109,12 @@ function replaceNodeNames( str ) {
 	);
 
 	str = str.replace(
-		new RegExp( `(node)\\s*=`, 'g' ),
-		( match, name ) => `/* ${ name } */ ${ convertName( name ) } =`
+		new RegExp( `(node)\\s*=([^;]*);`, 'g' ),
+		( match, name, content ) => {
+
+			return `/* ${ name } */ stride4Offset =${ content }, stride2Offset = stride4Offset * 2;`;
+
+		}
 	);
 
 	return str;

--- a/scripts/generate-cast-functions.js
+++ b/scripts/generate-cast-functions.js
@@ -15,10 +15,10 @@ function replaceUnneededCode( str ) {
 
 			} else {
 
-				return 'const stride2Offset = stride4Offset * 2, ' +
+				return 'let stride2Offset = stride4Offset * 2, ' +
 					'float32Array = _float32Array, ' +
 					'uint16Array = _uint16Array, ' +
-					'uint32Array = _uint32Array;\n'
+					'uint32Array = _uint32Array;\n';
 
 			}
 
@@ -84,8 +84,8 @@ function replaceNodeNames( str ) {
 	);
 
 	str = str.replace(
-		new RegExp( `! ! (${ names })\\.count`, 'g' ),
-		( match, name ) => `/* ${ name } count */ uint16Array[ ${ convertName( name, 2 ) } + 15 ] === 0xffff`
+		new RegExp( `! (${ names })\\.count`, 'g' ),
+		( match, name ) => `/* ${ name } count */ ( uint16Array[ ${ convertName( name, 2 ) } + 15 ] !== 0xffff )`
 	);
 
 	str = str.replace(

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -2,3 +2,7 @@
 export const CENTER = 0;
 export const AVERAGE = 1;
 export const SAH = 2;
+
+export const NOT_INTERSECTED = 0;
+export const INTERSECTED = 1;
+export const CONTAINED = 2;

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -170,7 +170,7 @@ export const shapecast = ( function () {
 			while ( ! node.count ) {
 
 				node = node.left;
-				if ( node.continueGeneration ) {
+				if ( /* skip */ node.continueGeneration ) {
 
 					node.continueGeneration();
 
@@ -193,7 +193,7 @@ export const shapecast = ( function () {
 			while ( ! node.count ) {
 
 				node = node.right;
-				if ( node.continueGeneration ) {
+				if ( /* skip */ node.continueGeneration ) {
 
 					node.continueGeneration();
 

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -134,7 +134,7 @@ export const shapecast = ( function () {
 	const cachedBox1 = new Box3();
 	const cachedBox2 = new Box3();
 
-	function iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc ) {
+	function iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, contained = false ) {
 
 		const index = geometry.index;
 		const pos = geometry.attributes.position;
@@ -143,7 +143,7 @@ export const shapecast = ( function () {
 			setTriangle( triangle, i, index, pos );
 			triangle.needsUpdate = true;
 
-			if ( intersectsTriangleFunc( triangle, i, i + 1, i + 2 ) ) {
+			if ( intersectsTriangleFunc( triangle, i, i + 1, i + 2, contained ) ) {
 
 				return true;
 
@@ -161,9 +161,20 @@ export const shapecast = ( function () {
 		// when converting to the buffer equivalents
 		function getLeftOffset( node ) {
 
+			if ( node.continueGeneration ) {
+
+				node.continueGeneration();
+
+			}
+
 			while ( ! node.count ) {
 
 				node = node.left;
+				if ( node.continueGeneration ) {
+
+					node.continueGeneration();
+
+				}
 
 			}
 
@@ -173,9 +184,20 @@ export const shapecast = ( function () {
 
 		function getRightEndOffset( node ) {
 
+			if ( node.continueGeneration ) {
+
+				node.continueGeneration();
+
+			}
+
 			while ( ! node.count ) {
 
 				node = node.right;
+				if ( node.continueGeneration ) {
+
+					node.continueGeneration();
+
+				}
 
 			}
 
@@ -252,7 +274,7 @@ export const shapecast = ( function () {
 				const end = getRightEndOffset( c1 );
 				const count = end - offset;
 
-				c1StopTraversal = intersectsTriangleFunc( offset, count, geometry, intersectsTriangleFunc );
+				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true );
 
 			} else {
 
@@ -280,7 +302,7 @@ export const shapecast = ( function () {
 				const end = getRightEndOffset( c2 );
 				const count = end - offset;
 
-				c2StopTraversal = intersectsTriangleFunc( offset, count, geometry, intersectsTriangleFunc );
+				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true );
 
 			} else {
 

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -155,31 +155,33 @@ export const shapecast = ( function () {
 
 	}
 
-	function getLeftOffset( node ) {
-
-		while ( ! node.count ) {
-
-			node = node.left;
-
-		}
-
-		return node.offset;
-
-	}
-
-	function getRightEndOffset( node ) {
-
-		while ( ! node.count ) {
-
-			node = node.right;
-
-		}
-
-		return node.offset + node.count;
-
-	}
-
 	return function shapecast( node, mesh, intersectsBoundsFunc, intersectsTriangleFunc = null, nodeScoreFunc = null ) {
+
+		// Define these inside the function so it has access to the local variables needed
+		// when converting to the buffer equivalents
+		function getLeftOffset( node ) {
+
+			while ( ! node.count ) {
+
+				node = node.left;
+
+			}
+
+			return node.offset;
+
+		}
+
+		function getRightEndOffset( node ) {
+
+			while ( ! node.count ) {
+
+				node = node.right;
+
+			}
+
+			return node.offset + node.count;
+
+		}
 
 		if ( node.continueGeneration ) {
 

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -16,7 +16,6 @@ const boundingBox = new Box3();
 const boxIntersection = new Vector3();
 const xyzFields = [ 'x', 'y', 'z' ];
 
-
 export function raycastBuffer( stride4Offset, mesh, raycaster, ray, intersects ) {
 
 	const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
@@ -54,7 +53,6 @@ export function raycastFirstBuffer( stride4Offset, mesh, raycaster, ray ) {
 		return intersectClosestTri( mesh, mesh.geometry, raycaster, ray, /* node offset */ uint32Array[ stride4Offset + 6 ], /* node count */ uint16Array[ stride2Offset + 14 ] );
 
 	} else {
-
 
 		// consider the position of the split plane with respect to the oncoming ray; whichever direction
 		// the ray is coming from, look for an intersection among that side of the tree first
@@ -156,7 +154,7 @@ export const shapecastBuffer = ( function () {
 			while ( ! /* node count */ uint16Array[ stride2Offset + 14 ] ) {
 
 				/* node */ stride4Offset = /* node left */ stride4Offset + 8, stride2Offset = stride4Offset * 2;
-				
+
 			}
 
 			return /* node offset */ uint32Array[ stride4Offset + 6 ];
@@ -170,7 +168,7 @@ export const shapecastBuffer = ( function () {
 			while ( ! /* node count */ uint16Array[ stride2Offset + 14 ] ) {
 
 				/* node */ stride4Offset = /* node right */ uint32Array[ stride4Offset + 6 ], stride2Offset = stride4Offset * 2;
-				
+
 			}
 
 			return /* node offset */ uint32Array[ stride4Offset + 6 ] + /* node count */ uint16Array[ stride2Offset + 14 ];
@@ -408,7 +406,6 @@ export const intersectsGeometryBuffer = ( function () {
 
 			if ( leftIntersection ) return true;
 
-
 			arrayToBoxBuffer( /* right boundingData */ right, float32Array, boundingBox );
 			const rightIntersection =
 				cachedObb.intersectsBox( boundingBox ) &&
@@ -423,7 +420,6 @@ export const intersectsGeometryBuffer = ( function () {
 	};
 
 } )();
-
 
 function intersectRayBuffer( stride4Offset, array, ray, target ) {
 

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -18,9 +18,9 @@ const xyzFields = [ 'x', 'y', 'z' ];
 
 export function raycastBuffer( stride4Offset, mesh, raycaster, ray, intersects ) {
 
-	const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+	let stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
 
-	const isLeaf = /* node count */ uint16Array[ stride2Offset + 15 ] === 0xffff;
+	const isLeaf = ! /* node count */ ( uint16Array[ stride2Offset + 15 ] !== 0xffff );
 	if ( isLeaf ) {
 
 		intersectTris( mesh, mesh.geometry, raycaster, ray, /* node offset */ uint32Array[ stride4Offset + 6 ], /* node count */ uint16Array[ stride2Offset + 14 ], intersects );
@@ -45,9 +45,9 @@ export function raycastBuffer( stride4Offset, mesh, raycaster, ray, intersects )
 
 export function raycastFirstBuffer( stride4Offset, mesh, raycaster, ray ) {
 
-	const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+	let stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
 
-	const isLeaf = /* node count */ uint16Array[ stride2Offset + 15 ] === 0xffff;
+	const isLeaf = ! /* node count */ ( uint16Array[ stride2Offset + 15 ] !== 0xffff );
 	if ( isLeaf ) {
 
 		return intersectClosestTri( mesh, mesh.geometry, raycaster, ray, /* node offset */ uint32Array[ stride4Offset + 6 ], /* node count */ uint16Array[ stride2Offset + 14 ] );
@@ -149,9 +149,9 @@ export const shapecastBuffer = ( function () {
 		// when converting to the buffer equivalents
 		function getLeftOffsetBuffer( stride4Offset ) {
 
-			const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+			let stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
 
-			while ( ! /* node count */ uint16Array[ stride2Offset + 14 ] ) {
+			while ( /* node count */ ( uint16Array[ stride2Offset + 15 ] !== 0xffff ) ) {
 
 				/* node */ stride4Offset = /* node left */ stride4Offset + 8, stride2Offset = stride4Offset * 2;
 
@@ -163,9 +163,9 @@ export const shapecastBuffer = ( function () {
 
 		function getRightEndOffsetBuffer( stride4Offset ) {
 
-			const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+			let stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
 
-			while ( ! /* node count */ uint16Array[ stride2Offset + 14 ] ) {
+			while ( /* node count */ ( uint16Array[ stride2Offset + 15 ] !== 0xffff ) ) {
 
 				/* node */ stride4Offset = /* node right */ uint32Array[ stride4Offset + 6 ], stride2Offset = stride4Offset * 2;
 
@@ -175,9 +175,9 @@ export const shapecastBuffer = ( function () {
 
 		}
 
-		const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+		let stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
 
-		const isLeaf = /* node count */ uint16Array[ stride2Offset + 15 ] === 0xffff;
+		const isLeaf = ! /* node count */ ( uint16Array[ stride2Offset + 15 ] !== 0xffff );
 		if ( isLeaf && intersectsTriangleFunc ) {
 
 			const geometry = mesh.geometry;
@@ -229,7 +229,7 @@ export const shapecastBuffer = ( function () {
 
 			}
 
-			const isC1Leaf = /* c1 count */ uint16Array[ c1 + 15 ] === 0xffff;
+			const isC1Leaf = ! /* c1 count */ ( uint16Array[ c1 + 15 ] !== 0xffff );
 			const c1Intersection = intersectsBoundsFunc( box1, isC1Leaf, score1 );
 
 			let c1StopTraversal;
@@ -257,7 +257,7 @@ export const shapecastBuffer = ( function () {
 			box2 = cachedBox2;
 			arrayToBoxBuffer( /* c2 boundingData */ c2, float32Array, box2 );
 
-			const isC2Leaf = /* c2 count */ uint16Array[ c2 + 15 ] === 0xffff;
+			const isC2Leaf = ! /* c2 count */ ( uint16Array[ c2 + 15 ] !== 0xffff );
 			const c2Intersection = intersectsBoundsFunc( box2, isC2Leaf, score2 );
 
 			let c2StopTraversal;
@@ -298,7 +298,7 @@ export const intersectsGeometryBuffer = ( function () {
 
 	return function intersectsGeometryBuffer( stride4Offset, mesh, geometry, geometryToBvh, cachedObb = null ) {
 
-		const stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
+		let stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
 
 		if ( cachedObb === null ) {
 
@@ -314,7 +314,7 @@ export const intersectsGeometryBuffer = ( function () {
 
 		}
 
-		const isLeaf = /* node count */ uint16Array[ stride2Offset + 15 ] === 0xffff;
+		const isLeaf = ! /* node count */ ( uint16Array[ stride2Offset + 15 ] !== 0xffff );
 		if ( isLeaf ) {
 
 			const thisGeometry = mesh.geometry;

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -147,11 +147,11 @@ export const shapecastBuffer = ( function () {
 
 		// Define these inside the function so it has access to the local variables needed
 		// when converting to the buffer equivalents
-		function getLeftOffset( node ) {
+		function getLeftOffsetBuffer( stride4Offset ) {
 
 			while ( ! /* node count */ uint16Array[ stride2Offset + 14 ] ) {
 
-				node = /* node left */ stride4Offset + 8;
+				/* node */ stride4Offset = /* node left */ stride4Offset + 8;
 
 			}
 
@@ -159,11 +159,11 @@ export const shapecastBuffer = ( function () {
 
 		}
 
-		function getRightEndOffset( node ) {
+		function getRightEndOffsetBuffer( stride4Offset ) {
 
 			while ( ! /* node count */ uint16Array[ stride2Offset + 14 ] ) {
 
-				node = /* node right */ uint32Array[ stride4Offset + 6 ];
+				/* node */ stride4Offset = /* node right */ uint32Array[ stride4Offset + 6 ];
 
 			}
 
@@ -231,8 +231,8 @@ export const shapecastBuffer = ( function () {
 			if ( c1Intersection === CONTAINED ) {
 
 				const geometry = mesh.geometry;
-				const offset = getLeftOffset( c1 );
-				const end = getRightEndOffset( c1 );
+				const offset = getLeftOffsetBuffer( c1 );
+				const end = getRightEndOffsetBuffer( c1 );
 				const count = end - offset;
 
 				c1StopTraversal = intersectsTriangleFunc( offset, count, geometry, intersectsTriangleFunc );
@@ -259,8 +259,8 @@ export const shapecastBuffer = ( function () {
 			if ( c2Intersection === CONTAINED ) {
 
 				const geometry = mesh.geometry;
-				const offset = getLeftOffset( c2 );
-				const end = getRightEndOffset( c2 );
+				const offset = getLeftOffsetBuffer( c2 );
+				const end = getRightEndOffsetBuffer( c2 );
 				const count = end - offset;
 
 				c2StopTraversal = intersectsTriangleFunc( offset, count, geometry, intersectsTriangleFunc );

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { Ray, Matrix4, Mesh } from 'three';
 import MeshBVH from './MeshBVH.js';
 import Visualizer from './MeshBVHVisualizer.js';
-import { CENTER, AVERAGE, SAH } from './Constants.js';
+import { CENTER, AVERAGE, SAH, NOT_INTERSECTED, INTERSECTED, CONTAINED } from './Constants.js';
 import { getBVHExtremes, estimateMemoryInBytes } from './Utils/Debug.js';
 import { MeshBVHDebug } from './MeshBVHDebug.js';
 
@@ -53,6 +53,6 @@ function disposeBoundsTree() {
 export {
 	MeshBVH, Visualizer, Visualizer as MeshBVHVisualizer, MeshBVHDebug,
 	acceleratedRaycast, computeBoundsTree, disposeBoundsTree,
-	CENTER, AVERAGE, SAH,
+	CENTER, AVERAGE, SAH, NOT_INTERSECTED, INTERSECTED, CONTAINED,
 	estimateMemoryInBytes, getBVHExtremes
 };


### PR DESCRIPTION
Fix #104
Fix #84 

Add shapecast optimization if an object is reported to be contained so we can stop traversal early and iterate over all contained triangles.

### TODO
- [x] Add tests.
- [x] Update docs to update `intersectTriangleFunc` return value, constants.
- [x] Update description of `intersectsBoundsFunc`.
- [x] Use contains return value in an example.
- [x] Fix castFunctionsBuffer script so it properly converts the `getLeftOffset` and `getRightEndOffset` functions.
- [x] Lint fix the buffer functions after generating them
- [x] Consider changing the triangle intersects function to one that takes the list of triangles to iterate over rather than the individual triangle itself as an optimization: `( triOffset, triCount ) => {}`. But then the user would have to set their own triangle and would probably mean exposing SATTriangle (Make new issue) #173 

### Next
- Add lasso example