### PR TITLE
Add depth parameter to shapecast callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,8 @@ shapecast(
 	intersectsBoundsFunc : (
 		box : Box3,
 		isLeaf : Boolean,
-		score : Number | undefined
+		score : Number | undefined,
+		depth : Number
 	) => NOT_INTERSECTED | INTERSECTED | CONTAINED,
 
 	intersectsTriangleFunc : (
@@ -336,7 +337,8 @@ shapecast(
 		index1 : Number,
 		index2 : Number,
 		index3 : Number,
-		contained : Boolean
+		contained : Boolean,
+		depth : Number
 	) => Boolean = null,
 
 	orderNodesFunc : (
@@ -346,7 +348,7 @@ shapecast(
 ) : Boolean
 ```
 
-A generalized cast function that can be used to implement intersection logic for custom shapes. This is used internally for [intersectsBox](#intersectsBox) and [intersectsSphere](#intersectsSphere). The function returns as soon as a triangle has been reported as intersected and returns `true` if a triangle has been intersected.
+A generalized cast function that can be used to implement intersection logic for custom shapes. This is used internally for [intersectsBox](#intersectsBox) and [intersectsSphere](#intersectsSphere). The function returns as soon as a triangle has been reported as intersected and returns `true` if a triangle has been intersected. The bounds are traversed in depth first order calling `orderNodesFunc`, `intersectsBoundsFunc` and `intersectsTrianglesFunc` for each node and using the results to determine traversal depth. The `depth` value passed to `intersectsBoundsFunc` and `intersectsTriangleFunc` indicates the depth of the bounds the provided box or bounds belongs to unless the triangles are indicated to be `CONTAINED`, in which case depth is the depth of the parent bounds that were contained. It can be used to precompute, cache, and then read information about a parent bound to improve performance while traversing.
 
 `mesh` is the is the object this BVH is representing.
 

--- a/scripts/generate-cast-functions.js
+++ b/scripts/generate-cast-functions.js
@@ -126,7 +126,7 @@ function replaceFunctionNames( str ) {
 	const orNames = '\\s(raycast|raycastFirst|shapecast|intersectsGeometry|getLeftOffset|getRightEndOffset)';
 
 	str = str.replace(
-		new RegExp( `(${ orNames })\\((\\s|[\\r|\\n])?node`, 'gm' ),
+		new RegExp( `(${ orNames })\\(([\\s\\r\\n]+)?node`, 'gm' ),
 		( match, funcName ) => {
 
 			return `${ funcName }Buffer( stride4Offset`;

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -264,7 +264,7 @@ export const shapecast = ( function () {
 			}
 
 			const isC1Leaf = ! ! c1.count;
-			const c1Intersection = intersectsBoundsFunc( box1, isC1Leaf, score1, depth );
+			const c1Intersection = intersectsBoundsFunc( box1, isC1Leaf, score1, depth + 1 );
 
 			let c1StopTraversal;
 			if ( c1Intersection === CONTAINED ) {
@@ -274,13 +274,13 @@ export const shapecast = ( function () {
 				const end = getRightEndOffset( c1 );
 				const count = end - offset;
 
-				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth );
+				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1 );
 
 			} else {
 
 				c1StopTraversal =
 					c1Intersection &&
-					shapecast( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth );
+					shapecast( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
 
 			}
 
@@ -292,7 +292,7 @@ export const shapecast = ( function () {
 			arrayToBox( c2.boundingData, box2 );
 
 			const isC2Leaf = ! ! c2.count;
-			const c2Intersection = intersectsBoundsFunc( box2, isC2Leaf, score2, depth );
+			const c2Intersection = intersectsBoundsFunc( box2, isC2Leaf, score2, depth + 1 );
 
 			let c2StopTraversal;
 			if ( c2Intersection === CONTAINED ) {
@@ -302,13 +302,13 @@ export const shapecast = ( function () {
 				const end = getRightEndOffset( c2 );
 				const count = end - offset;
 
-				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth );
+				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1 );
 
 			} else {
 
 				c2StopTraversal =
 					c2Intersection &&
-					shapecast( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth );
+					shapecast( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
 
 			}
 

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -130,11 +130,19 @@ export function raycastFirst( node, mesh, raycaster, ray ) {
 
 export const shapecast = ( function () {
 
-	const triangle = new SeparatingAxisTriangle();
-	const cachedBox1 = new Box3();
-	const cachedBox2 = new Box3();
+	const _triangle = new SeparatingAxisTriangle();
+	const _cachedBox1 = new Box3();
+	const _cachedBox2 = new Box3();
 
-	function iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, contained = false, depth ) {
+	function iterateOverTriangles(
+		offset,
+		count,
+		geometry,
+		intersectsTriangleFunc,
+		contained,
+		depth,
+		triangle
+	) {
 
 		const index = geometry.index;
 		const pos = geometry.attributes.position;
@@ -155,7 +163,17 @@ export const shapecast = ( function () {
 
 	}
 
-	return function shapecast( node, mesh, intersectsBoundsFunc, intersectsTriangleFunc = null, nodeScoreFunc = null, depth = 0 ) {
+	return function shapecast(
+		node,
+		mesh,
+		intersectsBoundsFunc,
+		intersectsTriangleFunc = null,
+		nodeScoreFunc = null,
+		depth = 0,
+		triangle = _triangle,
+		cachedBox1 = _cachedBox1,
+		cachedBox2 = _cachedBox2
+	) {
 
 		// Define these inside the function so it has access to the local variables needed
 		// when converting to the buffer equivalents
@@ -217,7 +235,7 @@ export const shapecast = ( function () {
 			const geometry = mesh.geometry;
 			const offset = node.offset;
 			const count = node.count;
-			return iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, false, depth );
+			return iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, false, depth, triangle );
 
 		} else {
 
@@ -274,13 +292,23 @@ export const shapecast = ( function () {
 				const end = getRightEndOffset( c1 );
 				const count = end - offset;
 
-				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1 );
+				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1, triangle );
 
 			} else {
 
 				c1StopTraversal =
 					c1Intersection &&
-					shapecast( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
+					shapecast(
+						c1,
+						mesh,
+						intersectsBoundsFunc,
+						intersectsTriangleFunc,
+						nodeScoreFunc,
+						depth + 1,
+						triangle,
+						cachedBox1,
+						cachedBox2
+					);
 
 			}
 
@@ -302,13 +330,23 @@ export const shapecast = ( function () {
 				const end = getRightEndOffset( c2 );
 				const count = end - offset;
 
-				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1 );
+				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1, triangle );
 
 			} else {
 
 				c2StopTraversal =
 					c2Intersection &&
-					shapecast( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
+					shapecast(
+						c2,
+						mesh,
+						intersectsBoundsFunc,
+						intersectsTriangleFunc,
+						nodeScoreFunc,
+						depth + 1,
+						triangle,
+						cachedBox1,
+						cachedBox2
+					);
 
 			}
 

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -134,7 +134,7 @@ export const shapecast = ( function () {
 	const cachedBox1 = new Box3();
 	const cachedBox2 = new Box3();
 
-	function iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, contained = false ) {
+	function iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, contained = false, depth ) {
 
 		const index = geometry.index;
 		const pos = geometry.attributes.position;
@@ -143,7 +143,7 @@ export const shapecast = ( function () {
 			setTriangle( triangle, i, index, pos );
 			triangle.needsUpdate = true;
 
-			if ( intersectsTriangleFunc( triangle, i, i + 1, i + 2, contained ) ) {
+			if ( intersectsTriangleFunc( triangle, i, i + 1, i + 2, contained, depth ) ) {
 
 				return true;
 
@@ -155,7 +155,7 @@ export const shapecast = ( function () {
 
 	}
 
-	return function shapecast( node, mesh, intersectsBoundsFunc, intersectsTriangleFunc = null, nodeScoreFunc = null ) {
+	return function shapecast( node, mesh, intersectsBoundsFunc, intersectsTriangleFunc = null, nodeScoreFunc = null, depth = 0 ) {
 
 		// Define these inside the function so it has access to the local variables needed
 		// when converting to the buffer equivalents
@@ -217,7 +217,7 @@ export const shapecast = ( function () {
 			const geometry = mesh.geometry;
 			const offset = node.offset;
 			const count = node.count;
-			return iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc );
+			return iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, false, depth );
 
 		} else {
 
@@ -264,7 +264,7 @@ export const shapecast = ( function () {
 			}
 
 			const isC1Leaf = ! ! c1.count;
-			const c1Intersection = intersectsBoundsFunc( box1, isC1Leaf, score1 );
+			const c1Intersection = intersectsBoundsFunc( box1, isC1Leaf, score1, depth );
 
 			let c1StopTraversal;
 			if ( c1Intersection === CONTAINED ) {
@@ -274,13 +274,13 @@ export const shapecast = ( function () {
 				const end = getRightEndOffset( c1 );
 				const count = end - offset;
 
-				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true );
+				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth );
 
 			} else {
 
 				c1StopTraversal =
 					c1Intersection &&
-					shapecast( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc );
+					shapecast( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
 
 			}
 
@@ -292,7 +292,7 @@ export const shapecast = ( function () {
 			arrayToBox( c2.boundingData, box2 );
 
 			const isC2Leaf = ! ! c2.count;
-			const c2Intersection = intersectsBoundsFunc( box2, isC2Leaf, score2 );
+			const c2Intersection = intersectsBoundsFunc( box2, isC2Leaf, score2, depth );
 
 			let c2StopTraversal;
 			if ( c2Intersection === CONTAINED ) {
@@ -302,13 +302,13 @@ export const shapecast = ( function () {
 				const end = getRightEndOffset( c2 );
 				const count = end - offset;
 
-				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true );
+				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth );
 
 			} else {
 
 				c2StopTraversal =
 					c2Intersection &&
-					shapecast( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc );
+					shapecast( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
 
 			}
 

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -280,7 +280,7 @@ export const shapecast = ( function () {
 
 				c1StopTraversal =
 					c1Intersection &&
-					shapecast( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
+					shapecast( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth );
 
 			}
 
@@ -308,7 +308,7 @@ export const shapecast = ( function () {
 
 				c2StopTraversal =
 					c2Intersection &&
-					shapecast( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
+					shapecast( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth );
 
 			}
 

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -230,7 +230,7 @@ export const shapecastBuffer = ( function () {
 			}
 
 			const isC1Leaf = ! /* c1 count */ ( uint16Array[ c1 + 15 ] !== 0xffff );
-			const c1Intersection = intersectsBoundsFunc( box1, isC1Leaf, score1, depth );
+			const c1Intersection = intersectsBoundsFunc( box1, isC1Leaf, score1, depth + 1 );
 
 			let c1StopTraversal;
 			if ( c1Intersection === CONTAINED ) {
@@ -240,13 +240,13 @@ export const shapecastBuffer = ( function () {
 				const end = getRightEndOffsetBuffer( c1 );
 				const count = end - offset;
 
-				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth );
+				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1 );
 
 			} else {
 
 				c1StopTraversal =
 					c1Intersection &&
-					shapecastBuffer( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth );
+					shapecastBuffer( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
 
 			}
 
@@ -258,7 +258,7 @@ export const shapecastBuffer = ( function () {
 			arrayToBoxBuffer( /* c2 boundingData */ c2, float32Array, box2 );
 
 			const isC2Leaf = ! /* c2 count */ ( uint16Array[ c2 + 15 ] !== 0xffff );
-			const c2Intersection = intersectsBoundsFunc( box2, isC2Leaf, score2, depth );
+			const c2Intersection = intersectsBoundsFunc( box2, isC2Leaf, score2, depth + 1 );
 
 			let c2StopTraversal;
 			if ( c2Intersection === CONTAINED ) {
@@ -268,13 +268,13 @@ export const shapecastBuffer = ( function () {
 				const end = getRightEndOffsetBuffer( c2 );
 				const count = end - offset;
 
-				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth );
+				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1 );
 
 			} else {
 
 				c2StopTraversal =
 					c2Intersection &&
-					shapecastBuffer( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth );
+					shapecastBuffer( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
 
 			}
 

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -118,11 +118,19 @@ export function raycastFirstBuffer( stride4Offset, mesh, raycaster, ray ) {
 
 export const shapecastBuffer = ( function () {
 
-	const triangle = new SeparatingAxisTriangle();
-	const cachedBox1 = new Box3();
-	const cachedBox2 = new Box3();
+	const _triangle = new SeparatingAxisTriangle();
+	const _cachedBox1 = new Box3();
+	const _cachedBox2 = new Box3();
 
-	function iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, contained = false, depth ) {
+	function iterateOverTriangles(
+		offset,
+		count,
+		geometry,
+		intersectsTriangleFunc,
+		contained,
+		depth,
+		triangle
+	) {
 
 		const index = geometry.index;
 		const pos = geometry.attributes.position;
@@ -143,7 +151,16 @@ export const shapecastBuffer = ( function () {
 
 	}
 
-	return function shapecastBuffer( stride4Offset, mesh, intersectsBoundsFunc, intersectsTriangleFunc = null, nodeScoreFunc = null, depth = 0 ) {
+	return function shapecastBuffer( stride4Offset,
+		mesh,
+		intersectsBoundsFunc,
+		intersectsTriangleFunc = null,
+		nodeScoreFunc = null,
+		depth = 0,
+		triangle = _triangle,
+		cachedBox1 = _cachedBox1,
+		cachedBox2 = _cachedBox2
+	) {
 
 		// Define these inside the function so it has access to the local variables needed
 		// when converting to the buffer equivalents
@@ -183,7 +200,7 @@ export const shapecastBuffer = ( function () {
 			const geometry = mesh.geometry;
 			const offset = /* node offset */ uint32Array[ stride4Offset + 6 ];
 			const count = /* node count */ uint16Array[ stride2Offset + 14 ];
-			return iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, false, depth );
+			return iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, false, depth, triangle );
 
 		} else {
 
@@ -240,13 +257,23 @@ export const shapecastBuffer = ( function () {
 				const end = getRightEndOffsetBuffer( c1 );
 				const count = end - offset;
 
-				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1 );
+				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1, triangle );
 
 			} else {
 
 				c1StopTraversal =
 					c1Intersection &&
-					shapecastBuffer( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
+					shapecastBuffer(
+						c1,
+						mesh,
+						intersectsBoundsFunc,
+						intersectsTriangleFunc,
+						nodeScoreFunc,
+						depth + 1,
+						triangle,
+						cachedBox1,
+						cachedBox2
+					);
 
 			}
 
@@ -268,13 +295,23 @@ export const shapecastBuffer = ( function () {
 				const end = getRightEndOffsetBuffer( c2 );
 				const count = end - offset;
 
-				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1 );
+				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth + 1, triangle );
 
 			} else {
 
 				c2StopTraversal =
 					c2Intersection &&
-					shapecastBuffer( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth + 1 );
+					shapecastBuffer(
+						c2,
+						mesh,
+						intersectsBoundsFunc,
+						intersectsTriangleFunc,
+						nodeScoreFunc,
+						depth + 1,
+						triangle,
+						cachedBox1,
+						cachedBox2
+					);
 
 			}
 

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -7,7 +7,6 @@
 
 import { Box3, Vector3, Mesh, Matrix4 } from 'three';
 import { intersectTris, intersectClosestTri } from './Utils/RayIntersectTriUtlities.js';
-
 import { OrientedBox } from './Utils/OrientedBox.js';
 import { setTriangle } from './Utils/TriangleUtils.js';
 import { SeparatingAxisTriangle } from './Utils/SeparatingAxisTriangle.js';
@@ -123,7 +122,7 @@ export const shapecastBuffer = ( function () {
 	const cachedBox1 = new Box3();
 	const cachedBox2 = new Box3();
 
-	function iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, contained = false ) {
+	function iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, contained = false, depth ) {
 
 		const index = geometry.index;
 		const pos = geometry.attributes.position;
@@ -132,7 +131,7 @@ export const shapecastBuffer = ( function () {
 			setTriangle( triangle, i, index, pos );
 			triangle.needsUpdate = true;
 
-			if ( intersectsTriangleFunc( triangle, i, i + 1, i + 2, contained ) ) {
+			if ( intersectsTriangleFunc( triangle, i, i + 1, i + 2, contained, depth ) ) {
 
 				return true;
 
@@ -144,7 +143,7 @@ export const shapecastBuffer = ( function () {
 
 	}
 
-	return function shapecastBuffer( stride4Offset, mesh, intersectsBoundsFunc, intersectsTriangleFunc = null, nodeScoreFunc = null ) {
+	return function shapecastBuffer( stride4Offset, mesh, intersectsBoundsFunc, intersectsTriangleFunc = null, nodeScoreFunc = null, depth = 0 ) {
 
 		// Define these inside the function so it has access to the local variables needed
 		// when converting to the buffer equivalents
@@ -184,7 +183,7 @@ export const shapecastBuffer = ( function () {
 			const geometry = mesh.geometry;
 			const offset = /* node offset */ uint32Array[ stride4Offset + 6 ];
 			const count = /* node count */ uint16Array[ stride2Offset + 14 ];
-			return iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc );
+			return iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, false, depth );
 
 		} else {
 
@@ -231,7 +230,7 @@ export const shapecastBuffer = ( function () {
 			}
 
 			const isC1Leaf = ! /* c1 count */ ( uint16Array[ c1 + 15 ] !== 0xffff );
-			const c1Intersection = intersectsBoundsFunc( box1, isC1Leaf, score1 );
+			const c1Intersection = intersectsBoundsFunc( box1, isC1Leaf, score1, depth );
 
 			let c1StopTraversal;
 			if ( c1Intersection === CONTAINED ) {
@@ -241,13 +240,13 @@ export const shapecastBuffer = ( function () {
 				const end = getRightEndOffsetBuffer( c1 );
 				const count = end - offset;
 
-				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true );
+				c1StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth );
 
 			} else {
 
 				c1StopTraversal =
 					c1Intersection &&
-					shapecastBuffer( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc );
+					shapecastBuffer( c1, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth );
 
 			}
 
@@ -259,7 +258,7 @@ export const shapecastBuffer = ( function () {
 			arrayToBoxBuffer( /* c2 boundingData */ c2, float32Array, box2 );
 
 			const isC2Leaf = ! /* c2 count */ ( uint16Array[ c2 + 15 ] !== 0xffff );
-			const c2Intersection = intersectsBoundsFunc( box2, isC2Leaf, score2 );
+			const c2Intersection = intersectsBoundsFunc( box2, isC2Leaf, score2, depth );
 
 			let c2StopTraversal;
 			if ( c2Intersection === CONTAINED ) {
@@ -269,13 +268,13 @@ export const shapecastBuffer = ( function () {
 				const end = getRightEndOffsetBuffer( c2 );
 				const count = end - offset;
 
-				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true );
+				c2StopTraversal = iterateOverTriangles( offset, count, geometry, intersectsTriangleFunc, true, depth );
 
 			} else {
 
 				c2StopTraversal =
 					c2Intersection &&
-					shapecastBuffer( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc );
+					shapecastBuffer( c2, mesh, intersectsBoundsFunc, intersectsTriangleFunc, nodeScoreFunc, depth );
 
 			}
 


### PR DESCRIPTION
Related to #99

- Add depth argument
- Use the depth argument in the lasso example to improve performance

### TODO

- [ ] Use it to improve closest point geometry to geometry performance
- [ ] Use it to improve closest distance geometry to geometry performance
- [ ] Use shapecast for geometry intersection check
    - Shapecast cannot be called in a nested way (enable passing a cached bounds and triangle in)
- [x] Update README
