### PR TITLE
Recursively check bounds for geometry intersection

### DIFF
--- a/scripts/generate-cast-functions.js
+++ b/scripts/generate-cast-functions.js
@@ -127,9 +127,9 @@ function replaceFunctionNames( str ) {
 
 	str = str.replace(
 		new RegExp( `(${ orNames })\\(([\\s\\r\\n]+)?node`, 'gm' ),
-		( match, funcName ) => {
+		( match, funcNameWithSpace, funcName, whitespace ) => {
 
-			return `${ funcName }Buffer( stride4Offset`;
+			return `${ funcNameWithSpace }Buffer(${ whitespace }stride4Offset`;
 
 		}
 	);

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -462,6 +462,8 @@ export const intersectsGeometry = ( function () {
 		//      they've already been iterated over
 		//    - just filter the existing set of triangles
 		//    - TODO: setting a triangle may be a bit slow
+		//    - TODO: need to handle multiple roots in the other geometry
+		//    - TODO: need to handle packed vs not packed BVH
 
 		const result =
 			shapecast(

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -370,7 +370,6 @@ export const intersectsGeometry = ( function () {
 	const _triangle2 = new SeparatingAxisTriangle();
 	const _cachedBox1 = new OrientedBox();
 	const _cachedBox2 = new OrientedBox();
-	const _cachedBox3 = new OrientedBox();
 
 	return function intersectsGeometry( node, mesh, geometry, geometryToBvh ) {
 
@@ -394,7 +393,6 @@ export const intersectsGeometry = ( function () {
 		geometryObb.set( geometry.boundingBox.min, geometry.boundingBox.max, geometryToBvh );
 		geometryObb.update();
 
-		let total = 0;
 		const result =
 			shapecast(
 				node,
@@ -441,7 +439,7 @@ export const intersectsGeometry = ( function () {
 					}
 
 				},
-				undefined, //box => geometryObb.distanceToBox( box ),
+				box => geometryObb.distanceToBox( box ),
 				0,
 				_triangle,
 				_cachedBox1,

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -475,10 +475,9 @@ export const intersectsGeometry = ( function () {
 					tri.c.applyMatrix4( bvhToGeometry );
 					tri.update();
 
-					if ( mesh.geometry.boundsTree ) {
+					if ( geometry.boundsTree ) {
 
-						return cachedMesh
-							.geometry
+						return geometry
 							.boundsTree
 							.shapecast(
 								cachedMesh,

--- a/src/castFunctions.js
+++ b/src/castFunctions.js
@@ -371,7 +371,66 @@ export const intersectsGeometry = ( function () {
 	const _cachedBox1 = new OrientedBox();
 	const _cachedBox2 = new OrientedBox();
 
+	const _box1 = new Box3();
+	const _box2 = new Box3();
+
+	const _perBoundsInfo = [];
+
 	return function intersectsGeometry( node, mesh, geometry, geometryToBvh ) {
+
+		// Takes the other geometrys node and an obb from this bvh in the geometry frame
+		function findLowestIntersectingBox( node, obb, info, indexAttr, posAttr ) {
+
+			const isLeaf = ! ! node.count;
+			if ( isLeaf ) {
+
+				const count = node.count;
+				const offset = node.offset;
+				const tris = info.triangles;
+				tris.length = 0;
+				info.node = node;
+
+				for ( let i = offset, l = offset + count; i < l; i ++ ) {
+
+					setTriangle( _triangle, i, indexAttr, posAttr );
+					if ( obb.intersectsTriangle( _triangle ) ) {
+
+						tris.push( i );
+
+					}
+
+				}
+
+			} else {
+
+				const c1 = node.left;
+				const c2 = node.right;
+
+				arrayToBox( c1.boundingData, _box1 );
+				arrayToBox( c2.boundingData, _box2 );
+
+				const intersectsC1 = obb.intersectsBox( _box1 );
+				const intersectsC2 = obb.intersectsBox( _box2 );
+
+				info.triangles.length = 0;
+
+				if ( intersectsC1 && ! intersectsC2 ) {
+
+					findLowestIntersectingBox( c1, obb, info, indexAttr, posAttr );
+
+				} else if ( ! intersectsC1 && intersectsC2 ) {
+
+					findLowestIntersectingBox( c2, obb, info, indexAttr, posAttr );
+
+				} else if ( intersectsC1 && intersectsC2 ) {
+
+					info.node = node;
+
+				}
+
+			}
+
+		}
 
 		if ( node.continueGeneration ) {
 
@@ -392,6 +451,17 @@ export const intersectsGeometry = ( function () {
 		bvhToGeometry.copy( geometryToBvh ).invert();
 		geometryObb.set( geometry.boundingBox.min, geometry.boundingBox.max, geometryToBvh );
 		geometryObb.update();
+
+		// TODO
+		// - shapecast this bvh
+		// - on checking box
+		//    - convert box to obb in geometry frame
+		//    - traverse geometry bounds until both children are interesected
+		//    - if a leaf is found check all the triangles against the bounds and keep them
+		//    - start at the parents bounds if it's available. Propagate triangles forward if
+		//      they've already been iterated over
+		//    - just filter the existing set of triangles
+		//    - TODO: setting a triangle may be a bit slow
 
 		const result =
 			shapecast(

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -151,7 +151,8 @@ export const shapecastBuffer = ( function () {
 
 	}
 
-	return function shapecastBuffer( stride4Offset,
+	return function shapecastBuffer(
+		stride4Offset,
 		mesh,
 		intersectsBoundsFunc,
 		intersectsTriangleFunc = null,
@@ -425,7 +426,8 @@ export const intersectsGeometryBuffer = ( function () {
 		//    - TODO: setting a triangle may be a bit slow
 
 		const result =
-			shapecastBuffer( stride4Offset,
+			shapecastBuffer(
+				stride4Offset,
 				mesh,
 				box => geometryObb.intersectsBox( box ),
 				tri => {

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -435,10 +435,9 @@ export const intersectsGeometryBuffer = ( function () {
 					tri.c.applyMatrix4( bvhToGeometry );
 					tri.update();
 
-					if ( mesh.geometry.boundsTree ) {
+					if ( geometry.boundsTree ) {
 
-						return cachedMesh
-							.geometry
+						return geometry
 							.boundsTree
 							.shapecast(
 								cachedMesh,

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -335,7 +335,6 @@ export const intersectsGeometryBuffer = ( function () {
 	const _triangle2 = new SeparatingAxisTriangle();
 	const _cachedBox1 = new OrientedBox();
 	const _cachedBox2 = new OrientedBox();
-	const _cachedBox3 = new OrientedBox();
 
 	return function intersectsGeometryBuffer( stride4Offset, mesh, geometry, geometryToBvh ) {
 
@@ -355,7 +354,6 @@ export const intersectsGeometryBuffer = ( function () {
 		geometryObb.set( geometry.boundingBox.min, geometry.boundingBox.max, geometryToBvh );
 		geometryObb.update();
 
-		let total = 0;
 		const result =
 			shapecastBuffer( stride4Offset,
 				mesh,
@@ -401,7 +399,7 @@ export const intersectsGeometryBuffer = ( function () {
 					}
 
 				},
-				undefined, //box => geometryObb.distanceToBox( box ),
+				box => geometryObb.distanceToBox( box ),
 				0,
 				_triangle,
 				_cachedBox1,

--- a/src/castFunctionsBuffer.js
+++ b/src/castFunctionsBuffer.js
@@ -327,134 +327,89 @@ export const shapecastBuffer = ( function () {
 
 export const intersectsGeometryBuffer = ( function () {
 
-	const triangle = new SeparatingAxisTriangle();
-	const triangle2 = new SeparatingAxisTriangle();
 	const cachedMesh = new Mesh();
-	const invertedMat = new Matrix4();
+	const bvhToGeometry = new Matrix4();
+	const geometryObb = new OrientedBox();
 
-	const obb = new OrientedBox();
-	const obb2 = new OrientedBox();
+	const _triangle = new SeparatingAxisTriangle();
+	const _triangle2 = new SeparatingAxisTriangle();
+	const _cachedBox1 = new OrientedBox();
+	const _cachedBox2 = new OrientedBox();
+	const _cachedBox3 = new OrientedBox();
 
-	return function intersectsGeometryBuffer( stride4Offset, mesh, geometry, geometryToBvh, cachedObb = null ) {
+	return function intersectsGeometryBuffer( stride4Offset, mesh, geometry, geometryToBvh ) {
 
 		let stride2Offset = stride4Offset * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
 
-		if ( cachedObb === null ) {
+		if ( ! geometry.boundingBox ) {
 
-			if ( ! geometry.boundingBox ) {
-
-				geometry.computeBoundingBox();
-
-			}
-
-			obb.set( geometry.boundingBox.min, geometry.boundingBox.max, geometryToBvh );
-			obb.update();
-			cachedObb = obb;
+			geometry.computeBoundingBox();
 
 		}
 
-		const isLeaf = ! /* node count */ ( uint16Array[ stride2Offset + 15 ] !== 0xffff );
-		if ( isLeaf ) {
+		const index = geometry.index;
+		const pos = geometry.attributes.position;
 
-			const thisGeometry = mesh.geometry;
-			const thisIndex = thisGeometry.index;
-			const thisPos = thisGeometry.attributes.position;
+		cachedMesh.geometry = geometry;
+		bvhToGeometry.copy( geometryToBvh ).invert();
+		geometryObb.set( geometry.boundingBox.min, geometry.boundingBox.max, geometryToBvh );
+		geometryObb.update();
 
-			const index = geometry.index;
-			const pos = geometry.attributes.position;
+		let total = 0;
+		const result =
+			shapecastBuffer( stride4Offset,
+				mesh,
+				box => geometryObb.intersectsBox( box ),
+				tri => {
 
-			const offset = /* node offset */ uint32Array[ stride4Offset + 6 ];
-			const count = /* node count */ uint16Array[ stride2Offset + 14 ];
-
-			// get the inverse of the geometry matrix so we can transform our triangles into the
-			// geometry space we're trying to test. We assume there are fewer triangles being checked
-			// here.
-			invertedMat.copy( geometryToBvh ).invert();
-
-			if ( geometry.boundsTree ) {
-
-				arrayToBoxBuffer( /* node boundingData */ stride4Offset, float32Array, obb2 );
-				obb2.matrix.copy( invertedMat );
-				obb2.update();
-
-				cachedMesh.geometry = geometry;
-				const res = geometry.boundsTree.shapecast( cachedMesh, box => obb2.intersectsBox( box ), function ( tri ) {
-
-					tri.a.applyMatrix4( geometryToBvh );
-					tri.b.applyMatrix4( geometryToBvh );
-					tri.c.applyMatrix4( geometryToBvh );
+					tri.a.applyMatrix4( bvhToGeometry );
+					tri.b.applyMatrix4( bvhToGeometry );
+					tri.c.applyMatrix4( bvhToGeometry );
 					tri.update();
 
-					for ( let i = offset * 3, l = ( count + offset ) * 3; i < l; i += 3 ) {
+					if ( mesh.geometry.boundsTree ) {
 
-						// this triangle needs to be transformed into the current BVH coordinate frame
-						setTriangle( triangle2, i, thisIndex, thisPos );
-						triangle2.update();
-						if ( tri.intersectsTriangle( triangle2 ) ) {
+						return cachedMesh
+							.geometry
+							.boundsTree
+							.shapecast(
+								cachedMesh,
+								box => box.intersectsTriangle( tri ),
+								tri2 => tri2.intersectsTriangle( tri ),
+								box => Math.min(
+									box.distanceToPoint( tri.a ),
+									box.distanceToPoint( tri.b ),
+									box.distanceToPoint( tri.c )
+								)
+							);
 
-							return true;
+					} else {
 
-						}
+						for ( let i = 0, l = index.count; i < l; i += 3 ) {
 
-					}
+							setTriangle( _triangle2, i, index, pos );
+							_triangle2.update();
 
-					return false;
+							if ( tri.intersectsTriangle( _triangle2 ) ) {
 
-				} );
-				cachedMesh.geometry = null;
+								return true;
 
-				return res;
-
-			} else {
-
-				for ( let i = offset * 3, l = ( count + offset * 3 ); i < l; i += 3 ) {
-
-					// this triangle needs to be transformed into the current BVH coordinate frame
-					setTriangle( triangle, i, thisIndex, thisPos );
-					triangle.a.applyMatrix4( invertedMat );
-					triangle.b.applyMatrix4( invertedMat );
-					triangle.c.applyMatrix4( invertedMat );
-					triangle.update();
-
-					for ( let i2 = 0, l2 = index.count; i2 < l2; i2 += 3 ) {
-
-						setTriangle( triangle2, i2, index, pos );
-						triangle2.update();
-
-						if ( triangle.intersectsTriangle( triangle2 ) ) {
-
-							return true;
+							}
 
 						}
 
 					}
 
-				}
+				},
+				undefined, //box => geometryObb.distanceToBox( box ),
+				0,
+				_triangle,
+				_cachedBox1,
+				_cachedBox2
+			);
 
-			}
-
-		} else {
-
-			const left = /* node left */ stride4Offset + 8;
-			const right = /* node right */ uint32Array[ stride4Offset + 6 ];
-
-			arrayToBoxBuffer( /* left boundingData */ left, float32Array, boundingBox );
-			const leftIntersection =
-				cachedObb.intersectsBox( boundingBox ) &&
-				intersectsGeometryBuffer( left, mesh, geometry, geometryToBvh, cachedObb );
-
-			if ( leftIntersection ) return true;
-
-			arrayToBoxBuffer( /* right boundingData */ right, float32Array, boundingBox );
-			const rightIntersection =
-				cachedObb.intersectsBox( boundingBox ) &&
-				intersectsGeometryBuffer( right, mesh, geometry, geometryToBvh, cachedObb );
-
-			if ( rightIntersection ) return true;
-
-			return false;
-
-		}
+		cachedMesh.geometry = null;
+		return result;
 
 	};
 


### PR DESCRIPTION
Follow up to #181 
Related to #99 

- [ ] Use it to improve closest point geometry to geometry performance
- [ ] Use it to improve closest distance geometry to geometry performance
- [x] Use shapecast for geometry intersection check

Bounds traversal needs to happen for roots and for packed and unpacked BVH data.

