### PR TITLE
Unsupported Face3 dependency was replaced

### DIFF
--- a/example/characterMovement.js
+++ b/example/characterMovement.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { RoundedBoxBufferGeometry } from 'three/examples/jsm/geometries/RoundedBoxBufferGeometry.js';
+import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
@@ -90,7 +90,7 @@ function init() {
 
 	// character
 	player = new THREE.Mesh(
-		new RoundedBoxBufferGeometry( 1.0, 2.0, 1.0, 10, 0.5 ),
+		new RoundedBoxGeometry( 1.0, 2.0, 1.0, 10, 0.5 ),
 		new THREE.MeshStandardMaterial()
 	);
 	player.geometry.translate( 0, - 0.5, 0 );

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "simplex-noise": "^2.4.0",
     "static-server": "^2.2.1",
     "stats.js": "^0.17.0",
-    "three": "^0.123.0"
+    "three": "^0.125.0"
   },
   "dependencies": {}
 }

--- a/src/Utils/ThreeIntersectionUtilities.js
+++ b/src/Utils/ThreeIntersectionUtilities.js
@@ -1,4 +1,4 @@
-import { Vector3, Vector2, Triangle, DoubleSide, BackSide, Face3 } from 'three';
+import { Vector3, Vector2, Triangle, DoubleSide, BackSide } from 'three';
 
 // Ripped and modified From THREE.js Mesh raycast
 // https://github.com/mrdoob/three.js/blob/0aa87c999fe61e216c1133fba7a95772b503eddf/src/objects/Mesh.js#L115

--- a/src/Utils/ThreeIntersectionUtilities.js
+++ b/src/Utils/ThreeIntersectionUtilities.js
@@ -63,8 +63,17 @@ function checkBufferGeometryIntersection( object, raycaster, ray, position, uv, 
 
 		}
 
-		var normal = new Vector3();
-		intersection.face = new Face3( a, b, c, Triangle.getNormal( vA, vB, vC, normal ) );
+		const face = {
+			a: a,
+			b: a,
+			c: c,
+			normal: new Vector3( ),
+			materialIndex: 0
+		};
+		
+		Triangle.getNormal( vA, vB, vC, face.normal );
+		
+		intersection.face = face;
 		intersection.faceIndex = a;
 
 	}


### PR DESCRIPTION
Related to #189 

Related to the last changes in threejs r0.125.x [(Migration Guide r125 -> r126)](https://github.com/mrdoob/three.js/wiki/Migration-Guide#r125--r126)

Replaces Face3 class with an object, because it is now unsupported in r0.125.x. 
