### PR TITLE
Add `esm` ( module ) build output.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,18 +1,38 @@
-export default {
-	input: './src/index.js',
-	treeshake: false,
-	external: p => /^three/.test( p ),
-
-	output: {
-
-		name: 'MeshBVHLib',
-		extend: true,
-		format: 'umd',
-		file: './umd/index.js',
-		sourcemap: true,
-
-		globals: p => /^three/.test( p ) ? 'THREE' : null,
-
+export default [
+	{
+		input: './src/index.js',
+		treeshake: false,
+		external: p => /^three/.test( p ),
+	
+		output: {
+	
+			name: 'MeshBVHLib',
+			extend: true,
+			format: 'umd',
+			file: './umd/index.js',
+			sourcemap: true,
+	
+			globals: p => /^three/.test( p ) ? 'THREE' : null,
+	
+		},
+	
 	},
-
-};
+	{
+		input: './src/index.js',
+		treeshake: false,
+		external: p => /^three/.test( p ),
+	
+		output: {
+	
+			name: 'MeshBVHLib',
+			extend: true,
+			format: 'esm',
+			file: './esm/index.js',
+			sourcemap: true,
+	
+			globals: p => /^three/.test( p ) ? 'THREE' : null,
+	
+		},
+	
+	}
+];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,13 +24,9 @@ export default [
 	
 		output: {
 	
-			name: 'MeshBVHLib',
-			extend: true,
 			format: 'esm',
 			file: './esm/index.js',
 			sourcemap: true,
-	
-			globals: p => /^three/.test( p ) ? 'THREE' : null,
 	
 		},
 	


### PR DESCRIPTION
Related discussion: https://discourse.threejs.org/t/three-mesh-bvh-a-plugin-for-fast-geometry-raycasting-and-spatial-queries/26394/2

This will add a `esm` ( module ) bundle file to `./esm/index.js` after run `npm run build`.

In my current project's specific case, I need change 
`import ... from 'three';` to
`import ... from './three/build/three.module.js';` after build.
But I think I can't hard-code the url of three.js.
Is it acceptable to leave `import ... from 'three';` as is and let user to change the url afterwards?