### PR TITLE
World space raycast first fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,22 @@ depth : Number
 
 The depth to traverse and visualize the tree to.
 
+### .color
+
+```js
+color : THREE.Color
+```
+
+The color to render the bounding volume with.
+
+### .opacity
+
+```js
+opacity : Number
+```
+
+The opacity to render the bounding volume with.
+
 ### .constructor
 
 ```js
@@ -481,6 +497,14 @@ update() : void
 ```
 
 Updates the display of the bounds tree in the case that the bounds tree has changed or the depth parameter has changed.
+
+### .dispose
+
+```js
+dispose() : void
+```
+
+Disposes of the material used.
 
 ## Extensions
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -315,7 +315,7 @@ export default class MeshBVH {
 	raycast( mesh, raycaster, ray, intersects ) {
 
 		const geometry = this.geometry;
-		const localIntersects = [];
+		const localIntersects = intersects ? [] : null;
 		for ( const root of this._roots ) {
 
 			setBuffer( root );
@@ -330,7 +330,11 @@ export default class MeshBVH {
 
 		}
 
-		intersects.push( ...localIntersects );
+		if ( intersects ) {
+
+			intersects.push( ...localIntersects );
+
+		}
 
 	}
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -315,13 +315,22 @@ export default class MeshBVH {
 	raycast( mesh, raycaster, ray, intersects ) {
 
 		const geometry = this.geometry;
+		const localIntersects = [];
 		for ( const root of this._roots ) {
 
 			setBuffer( root );
-			raycast( 0, mesh, geometry, raycaster, ray, intersects );
+			raycast( 0, mesh, geometry, raycaster, ray, localIntersects );
 			clearBuffer();
 
 		}
+
+		for ( let i = 0, l = localIntersects.length; i < l; i ++ ) {
+
+			delete localIntersects[ i ].localPoint;
+
+		}
+
+		intersects.push( ...localIntersects );
 
 	}
 
@@ -340,6 +349,12 @@ export default class MeshBVH {
 				closestResult = result;
 
 			}
+
+		}
+
+		if ( closestResult ) {
+
+			delete closestResult.localPoint;
 
 		}
 

--- a/src/MeshBVH.js
+++ b/src/MeshBVH.js
@@ -324,13 +324,13 @@ export default class MeshBVH {
 
 		}
 
-		for ( let i = 0, l = localIntersects.length; i < l; i ++ ) {
-
-			delete localIntersects[ i ].localPoint;
-
-		}
-
 		if ( intersects ) {
+
+			for ( let i = 0, l = localIntersects.length; i < l; i ++ ) {
+
+				delete localIntersects[ i ].localPoint;
+
+			}
 
 			intersects.push( ...localIntersects );
 

--- a/src/MeshBVHVisualizer.js
+++ b/src/MeshBVHVisualizer.js
@@ -155,6 +155,12 @@ class MeshBVHVisualizer extends Group {
 
 	}
 
+	dispose() {
+
+		this._material.dispose();
+
+	}
+
 }
 
 

--- a/src/MeshBVHVisualizer.js
+++ b/src/MeshBVHVisualizer.js
@@ -1,19 +1,19 @@
 import { LineBasicMaterial, Box3Helper, Box3, Group, LineSegments } from 'three';
 import { arrayToBox } from './Utils/ArrayBoxUtilities.js';
 
-const wiremat = new LineBasicMaterial( { color: 0x00FF88, transparent: true, opacity: 0.3 } );
 const boxGeom = new Box3Helper().geometry;
 let boundingBox = new Box3();
 
 class MeshBVHRootVisualizer extends Group {
 
-	constructor( mesh, depth = 10, group = 0 ) {
+	constructor( mesh, material, depth = 10, group = 0 ) {
 
 		super( 'MeshBVHRootVisualizer' );
 
 		this.depth = depth;
 		this.mesh = mesh;
 		this._group = group;
+		this._material = material;
 
 		this.update();
 
@@ -41,7 +41,7 @@ class MeshBVHRootVisualizer extends Group {
 					let m = requiredChildren < this.children.length ? this.children[ requiredChildren ] : null;
 					if ( ! m ) {
 
-						m = new LineSegments( boxGeom, wiremat );
+						m = new LineSegments( boxGeom, this._material );
 						m.raycast = () => [];
 						this.add( m );
 
@@ -70,6 +70,24 @@ class MeshBVHRootVisualizer extends Group {
 
 class MeshBVHVisualizer extends Group {
 
+	get color() {
+
+		return this._material.color;
+
+	}
+
+	get opacity() {
+
+		return this._material.opacity;
+
+	}
+
+	set opacity( v ) {
+
+		this._material.opacity = v;
+
+	}
+
 	constructor( mesh, depth = 10 ) {
 
 		super( 'MeshBVHVisualizer' );
@@ -77,6 +95,7 @@ class MeshBVHVisualizer extends Group {
 		this.depth = depth;
 		this.mesh = mesh;
 		this._roots = [];
+		this._material = new LineBasicMaterial( { color: 0x00FF88, transparent: true, opacity: 0.3 } );
 
 		this.update();
 
@@ -96,7 +115,7 @@ class MeshBVHVisualizer extends Group {
 
 			if ( i >= this._roots.length ) {
 
-				const root = new MeshBVHRootVisualizer( this.mesh, this.depth, i );
+				const root = new MeshBVHRootVisualizer( this.mesh, this._material, this.depth, i );
 				this.add( root );
 				this._roots.push( root );
 

--- a/src/Utils/ThreeIntersectionUtilities.js
+++ b/src/Utils/ThreeIntersectionUtilities.js
@@ -36,6 +36,10 @@ function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point 
 	if ( distance < raycaster.near || distance > raycaster.far ) return null;
 
 	return {
+
+		// EDITED
+		// Including the local-space point so it can be used to accelerate raycasting
+		localPoint: point,
 		distance: distance,
 		point: intersectionPointWorld.clone(),
 		object: object

--- a/src/castFunctions.template.js
+++ b/src/castFunctions.template.js
@@ -129,7 +129,7 @@ export function raycastFirst( nodeIndex32, mesh, geometry, raycaster, ray ) {
 		if ( c1Result ) {
 
 			// check if the point is within the second bounds
-			const point = c1Result.point[ xyzAxis ];
+			const point = c1Result.localPoint[ xyzAxis ];
 			const isOutside = leftToRight ?
 				point <= float32Array[ c2 + splitAxis ] : // min bounding data
 				point >= float32Array[ c2 + splitAxis + 3 ]; // max bounding data


### PR DESCRIPTION
Fix #269 

- Fix first hit raycast not returning the correct result when the model transform has been adjusted.
- Add `opacity`, `color` fields to MeshBVHVisualizer.

**TODO**
- [x] Add docs for Visualizer