### PR TITLE
Update clippedEdges demo

### DIFF
--- a/example/clippedEdges.js
+++ b/example/clippedEdges.js
@@ -327,7 +327,6 @@ function render() {
 		inverseMatrix.copy( colliderMesh.matrixWorld ).invert();
 		localPlane.copy( clippingPlane ).applyMatrix4( inverseMatrix );
 
-		// TODO: we can probably build a whole clipped geometry here
 		let index = 0;
 		const posAttr = outlineLines.geometry.attributes.position;
 		const startTime = window.performance.now();

--- a/example/clippedEdges.js
+++ b/example/clippedEdges.js
@@ -91,7 +91,9 @@ function init() {
 
 	// create line geometry with enough data to hold 100000 segments
 	const lineGeometry = new THREE.BufferGeometry();
-	lineGeometry.setAttribute( 'position', new THREE.BufferAttribute( new Float32Array( 300000 ), 3, false ) );
+	const linePosAttr = new THREE.BufferAttribute( new Float32Array( 300000 ), 3, false );
+	linePosAttr.setUsage( THREE.DynamicDrawUsage );
+	lineGeometry.setAttribute( 'position', linePosAttr );
 	outlineLines = new THREE.LineSegments( lineGeometry, new THREE.LineBasicMaterial() );
 	outlineLines.material.color.set( 0x00acc1 ).convertSRGBToLinear();
 	outlineLines.frustumCulled = false;
@@ -325,6 +327,7 @@ function render() {
 		inverseMatrix.copy( colliderMesh.matrixWorld ).invert();
 		localPlane.copy( clippingPlane ).applyMatrix4( inverseMatrix );
 
+		// TODO: we can probably build a whole clipped geometry here
 		let index = 0;
 		const posAttr = outlineLines.geometry.attributes.position;
 		const startTime = window.performance.now();


### PR DESCRIPTION
- Add dynamic draw usage for outlines

**TODO**
- [ ] Generate a full clipped geometry instead of using global clip planes
- [ ] Add toggle for toggling clip planes vs generating geometry
  - Use "CONTAIN" to determine whether or not to try plane intersection
  - May require specifying that `intersectsBounds` is guaranteed to be run immediately before `intersectsTriangle` so we know whether the specified range is known to be contained or not.