### PR TITLE
Shapecast: add use of box pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,8 @@ shapecast(
 			triangleCount : Number
 			contained : Boolean,
 			depth : Number,
-			nodeIndex : Number
+			nodeIndex : Number,
+			box: Box3
 		) => Boolean = null,
 
 		intersectsTriangle : (

--- a/src/core/castFunctions.js
+++ b/src/core/castFunctions.js
@@ -365,7 +365,7 @@ export const shapecast = ( function () {
 
 		}
 
-	};
+	}
 
 } )();
 

--- a/test/ShapeCasts.test.js
+++ b/test/ShapeCasts.test.js
@@ -210,6 +210,72 @@ function runSuiteWithOptions( defaultOptions ) {
 
 		} );
 
+		it( 'should not use the same box twice when being recursively called.', () => {
+
+			const geometry = new SphereBufferGeometry();
+			const bvh = new MeshBVH( geometry );
+
+			let boundsChecks = 0;
+			let rangeChecks = 0;
+			bvh.shapecast( {
+
+				intersectsBounds: box1 => {
+
+					bvh.shapecast( {
+
+						intersectsBounds: box2 => {
+
+							expect( box1 ).not.toBe( box2 );
+							boundsChecks ++;
+							return true;
+
+						},
+
+						intersectsRange: ( offset, count, contained, depth, nodeIndex, box2 ) => {
+
+							expect( box1 ).not.toBe( box2 );
+							boundsChecks ++;
+							return true;
+
+						}
+
+					} );
+					return true;
+
+				},
+				intersectsRange: ( offset, count, contained, depth, nodeIndex, box1 ) => {
+
+					bvh.shapecast( {
+
+						intersectsBounds: box2 => {
+
+							expect( box1 ).not.toBe( box2 );
+							rangeChecks ++;
+							return true;
+
+						},
+
+						intersectsRange: ( offset, count, contained, depth, nodeIndex, box2 ) => {
+
+							expect( box1 ).not.toBe( box2 );
+							rangeChecks ++;
+							return true;
+
+						}
+
+					} );
+
+					return true;
+
+				}
+
+			} );
+
+			expect( rangeChecks ).not.toEqual( 0 );
+			expect( boundsChecks ).not.toEqual( 0 );
+
+		} );
+
 	} );
 
 	describe( 'IntersectsGeometry with BVH', () => {


### PR DESCRIPTION
Fix #313 

- Add use of box pool so recursive shapecast use will not cause collisions
- Add box to intersectsRange function