### PR TITLE
add /* @__PURE__ */ identifiers

### DIFF
--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -18,16 +18,16 @@ import { convertRaycastIntersect } from '../utils/GeometryRayIntersectUtilities.
 
 const SKIP_GENERATION = Symbol( 'skip tree generation' );
 
-const aabb = new Box3();
-const aabb2 = new Box3();
-const tempMatrix = new Matrix4();
-const obb = new OrientedBox();
-const obb2 = new OrientedBox();
-const temp = new Vector3();
-const temp1 = new Vector3();
-const temp2 = new Vector3();
-const tempBox = new Box3();
-const trianglePool = new PrimitivePool( () => new SeparatingAxisTriangle() );
+const aabb = /* @__PURE__ */ new Box3();
+const aabb2 = /* @__PURE__ */ new Box3();
+const tempMatrix = /* @__PURE__ */ new Matrix4();
+const obb = /* @__PURE__ */ new OrientedBox();
+const obb2 = /* @__PURE__ */ new OrientedBox();
+const temp = /* @__PURE__ */ new Vector3();
+const temp1 = /* @__PURE__ */ new Vector3();
+const temp2 = /* @__PURE__ */ new Vector3();
+const tempBox = /* @__PURE__ */ new Box3();
+const trianglePool = /* @__PURE__ */ new PrimitivePool( () => new SeparatingAxisTriangle() );
 
 export class MeshBVH {
 

--- a/src/core/bvhcast.js
+++ b/src/core/bvhcast.js
@@ -16,7 +16,7 @@ import { MeshBVH } from './MeshBVH.js';
 import { setTriangle } from '../utils/TriangleUtilities.js';
 import { SeparatingAxisTriangle } from '../math/SeparatingAxisTriangle.js';
 
-const trianglePool = new PrimitivePool( () => new SeparatingAxisTriangle() );
+const trianglePool = /* @__PURE__ */ new PrimitivePool( () => new SeparatingAxisTriangle() );
 
 MeshBVH.prototype.bvhcast = function ( otherBvh, matrixToLocal, callbacks ) {
 

--- a/src/debug/Debug.js
+++ b/src/debug/Debug.js
@@ -2,6 +2,10 @@ import { Box3, Vector3 } from 'three';
 import { TRAVERSAL_COST, TRIANGLE_INTERSECT_COST } from '../core/Constants.js';
 import { arrayToBox } from '../utils/ArrayBoxUtilities.js';
 
+const _box1 = /* @__PURE__ */ new Box3();
+const _box2 = /* @__PURE__ */ new Box3();
+const _vec = /* @__PURE__ */ new Vector3();
+
 // https://stackoverflow.com/questions/1248302/how-to-get-the-size-of-a-javascript-object
 function getPrimitiveSize( el ) {
 
@@ -158,10 +162,6 @@ function estimateMemoryInBytes( obj ) {
 
 }
 
-const box1 = new Box3();
-const box2 = new Box3();
-const vec = new Vector3();
-
 function validateBounds( bvh ) {
 
 	const geometry = bvh.geometry;
@@ -181,7 +181,7 @@ function validateBounds( bvh ) {
 		};
 		depthStack[ depth ] = info;
 
-		arrayToBox( 0, boundingData, box1 );
+		arrayToBox( 0, boundingData, _box1 );
 		const parent = depthStack[ depth - 1 ];
 
 		if ( isLeaf ) {
@@ -195,14 +195,14 @@ function validateBounds( bvh ) {
 
 				let isContained;
 
-				vec.fromBufferAttribute( position, i0 );
-				isContained = box1.containsPoint( vec );
+				_vec.fromBufferAttribute( position, i0 );
+				isContained = _box1.containsPoint( _vec );
 
-				vec.fromBufferAttribute( position, i1 );
-				isContained = isContained && box1.containsPoint( vec );
+				_vec.fromBufferAttribute( position, i1 );
+				isContained = isContained && _box1.containsPoint( _vec );
 
-				vec.fromBufferAttribute( position, i2 );
-				isContained = isContained && box1.containsPoint( vec );
+				_vec.fromBufferAttribute( position, i2 );
+				isContained = isContained && _box1.containsPoint( _vec );
 
 				console.assert( isContained, 'Leaf bounds does not fully contain triangle.' );
 				passes = passes && isContained;
@@ -214,9 +214,9 @@ function validateBounds( bvh ) {
 		if ( parent ) {
 
 			// check if my bounds fit in my parents
-			arrayToBox( 0, boundingData, box2 );
+			arrayToBox( 0, boundingData, _box2 );
 
-			const isContained = box2.containsBox( box1 );
+			const isContained = _box2.containsBox( _box1 );
 			console.assert( isContained, 'Parent bounds does not fully contain child.' );
 			passes = passes && isContained;
 

--- a/src/objects/MeshBVHVisualizer.js
+++ b/src/objects/MeshBVHVisualizer.js
@@ -1,7 +1,7 @@
 import { LineBasicMaterial, BufferAttribute, Box3, Group, MeshBasicMaterial, Object3D, BufferGeometry } from 'three';
 import { arrayToBox } from '../utils/ArrayBoxUtilities.js';
 
-const boundingBox = new Box3();
+const boundingBox = /* @__PURE__ */ new Box3();
 class MeshBVHRootVisualizer extends Object3D {
 
 	get isMesh() {

--- a/src/utils/ExtensionUtilities.js
+++ b/src/utils/ExtensionUtilities.js
@@ -2,8 +2,8 @@ import { Ray, Matrix4, Mesh } from 'three';
 import { convertRaycastIntersect } from './GeometryRayIntersectUtilities.js';
 import { MeshBVH } from '../core/MeshBVH.js';
 
-const ray = new Ray();
-const tmpInverseMatrix = new Matrix4();
+const ray = /* @__PURE__ */ new Ray();
+const tmpInverseMatrix = /* @__PURE__ */ new Matrix4();
 const origMeshRaycastFunc = Mesh.prototype.raycast;
 
 export function acceleratedRaycast( raycaster, intersects ) {

--- a/src/utils/ThreeRayIntersectUtilities.js
+++ b/src/utils/ThreeRayIntersectUtilities.js
@@ -2,15 +2,15 @@ import { Vector3, Vector2, Triangle, DoubleSide, BackSide } from 'three';
 
 // Ripped and modified From THREE.js Mesh raycast
 // https://github.com/mrdoob/three.js/blob/0aa87c999fe61e216c1133fba7a95772b503eddf/src/objects/Mesh.js#L115
-const vA = new Vector3();
-const vB = new Vector3();
-const vC = new Vector3();
+const vA = /* @__PURE__ */ new Vector3();
+const vB = /* @__PURE__ */ new Vector3();
+const vC = /* @__PURE__ */ new Vector3();
 
-const uvA = new Vector2();
-const uvB = new Vector2();
-const uvC = new Vector2();
+const uvA = /* @__PURE__ */ new Vector2();
+const uvB = /* @__PURE__ */ new Vector2();
+const uvC = /* @__PURE__ */ new Vector2();
 
-const intersectionPoint = new Vector3();
+const intersectionPoint = /* @__PURE__ */ new Vector3();
 function checkIntersection( ray, pA, pB, pC, point, side ) {
 
 	let intersect;


### PR DESCRIPTION
To help enable tree shaking, though in practice the MeshBVH class is probably  too monolithic at the moment to enable it effectively. 