### PR TITLE
CPU Path Tracing Example

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,7 @@
 {
-	"presets": [ "@babel/preset-env" ]
+	"presets": [ [ "@babel/preset-env", {
+		"targets": {
+			"node": "current"
+		}
+	} ] ]
 }

--- a/example/cpuPathTracing.html
+++ b/example/cpuPathTracing.html
@@ -21,15 +21,14 @@
             position: absolute;
             top: 0;
             width: 100%;
-            color: white;
+            color: #778;
             font-family: monospace;
             text-align: center;
             padding: 5px 0;
-            pointer-events: none;
-        }
+		}
 
         a {
-            color: #eee;
+            color: #778;
         }
 
         #output {
@@ -49,6 +48,9 @@
 </head>
 <body>
     <div id="info">
+		CPU Path Tracer demo based on a smattering of online resources. Engine by <a href="https://sketchfab.com/3d-models/internal-combustion-engine-0be463c1041743d88f0c35b1c2f50f2f">T-FLEX CAD on Sketchfab</a>.
+		<br/><br/>
+		Checkout the <a href="https://raytracing.github.io/">Raytracing in One Weekend</a> series and <a href="http://pbr-book.org/">PBR Book</a> for some great introductions to path tracing!
 	</div>
 	<div id="output">
 	</div>

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -4,7 +4,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
-import { bsdfDirection } from './pathtracing/materialSampling.js';
+import { bsdfSample } from './pathtracing/materialSampling.js';
 
 import { GUI } from 'dat.gui';
 import {
@@ -591,7 +591,7 @@ function* runPathTracing() {
 				invBasis.copy( normalBasis ).invert();
 				localDirection.copy( ray.direction ).applyMatrix4( invBasis ).multiplyScalar( - 1 ).normalize();
 
-				const colorWeight = bsdfDirection( localDirection, hit, material, tempRay.direction );
+				const colorWeight = bsdfSample( localDirection, hit, material, tempRay.direction );
 				tempRay.direction.applyMatrix4( normalBasis ).normalize();
 
 				tempRay.origin.copy( hit.point );

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -511,6 +511,7 @@ function onResize() {
 	camera.aspect = window.innerWidth / window.innerHeight;
 	camera.updateProjectionMatrix();
 
+	// compute the new resolution based on the use parameters
 	const dpr = window.devicePixelRatio;
 	const divisor = Math.pow( 2, parseFloat( params.resolution.resolutionScale ) - 1 );
 	if ( params.resolution.stretchImage ) {
@@ -546,6 +547,7 @@ function onResize() {
 
 function resetImage() {
 
+	// clear the draw buffer and restart the path tracing loop
 	dataTexture.image.data.fill( 0 );
 	dataTexture.needsUpdate = true;
 	samples = 0;

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -736,12 +736,15 @@ function* runPathTracingLoop() {
 					// only add light on one side
 					if ( currentRay.direction.dot( lightForward ) < 0 ) {
 
-						const weight = 1.0;
-						targetColor.r += weight * throughputColor.r * lightMesh.material.color.r;
-						targetColor.g += weight * throughputColor.g * lightMesh.material.color.g;
-						targetColor.b += weight * throughputColor.b * lightMesh.material.color.b;
+						// const weight = 1.0;
+						// targetColor.r += weight * throughputColor.r * lightMesh.material.color.r;
+						// targetColor.g += weight * throughputColor.g * lightMesh.material.color.g;
+						// targetColor.b += weight * throughputColor.b * lightMesh.material.color.b;
 
 					}
+
+					if ( i === 0 )
+						targetColor.set( 0xffffff )
 
 					break;
 
@@ -751,54 +754,53 @@ function* runPathTracingLoop() {
 					const { material } = hit;
 					const nextRay = rayStack[ i ];
 
-					// /* Direct Light Sampling */
-					// // get a random point on the surface of the light
-					// tempVector
-					// 	.set( Math.random() - 0.5, Math.random() - 0.5, 0 )
-					// 	.applyMatrix4( lightMesh.matrixWorld );
+					/* Direct Light Sampling */
+					// get a random point on the surface of the light
+					tempVector
+						.set( Math.random() - 0.5, Math.random() - 0.5, 0 )
+						.applyMatrix4( lightMesh.matrixWorld );
 
-					// // get a ray to the light point
-					// nextRay.origin.copy( hit.point ).addScaledVector( hit.geometryNormal, EPSILON );
-					// nextRay.direction.subVectors( tempVector, nextRay.origin ).normalize();
+					// get a ray to the light point
+					nextRay.origin.copy( hit.point ).addScaledVector( hit.geometryNormal, EPSILON );
+					nextRay.direction.subVectors( tempVector, nextRay.origin ).normalize();
 
-					// // TODO: we should leave this attenuation check up to the PDF of a sample -- what about transmission?
-					// if ( nextRay.direction.dot( lightForward ) < 0 ) {
+					// TODO: we should leave this attenuation check up to the PDF of a sample -- what about transmission?
+					if ( nextRay.direction.dot( lightForward ) < 0 ) {
 
-					// 	// compute the probability of hitting the light on the hemisphere
-					// 	const lightArea = lightWidth * lightHeight;
-					// 	const lightDistSq = nextRay.origin.distanceToSquared( tempVector );
-					// 	const lightPdf = lightDistSq / ( lightArea * - nextRay.direction.dot( lightForward ) );
+						// compute the probability of hitting the light on the hemisphere
+						const lightArea = lightWidth * lightHeight;
+						const lightDistSq = nextRay.origin.distanceToSquared( tempVector );
+						const lightPdf = lightDistSq / ( lightArea * - nextRay.direction.dot( lightForward ) );
 
-					// 	raycaster.ray.copy( nextRay );
-					// 	const shadowHit = raycaster.intersectObjects( objects, true )[ 0 ];
-					// 	if ( shadowHit && shadowHit.object === lightMesh ) {
+						raycaster.ray.copy( nextRay );
+						const shadowHit = raycaster.intersectObjects( objects, true )[ 0 ];
+						if ( shadowHit && shadowHit.object === lightMesh ) {
 
-					// 		// TODO
-					// 		// - get the BSDF PDF for this direction
-					// 		// - get the BSDF color for this direction
-					// 		// - weight the PDF for this sample by the average of the two PDFs for this direction
-					// 		// - add light output
-					// 		// - continue to accumulate throughput based on surface quality to multiply here and
-					// 		// continue to check for direct lighting / skybox to weight in the other direction
-					// 		// (is that the same as MIS?)
+							// TODO
+							// - get the BSDF PDF for this direction
+							// - get the BSDF color for this direction
+							// - weight the PDF for this sample by the average of the two PDFs for this direction
+							// - add light output
+							// - continue to accumulate throughput based on surface quality to multiply here and
+							// continue to check for direct lighting / skybox to weight in the other direction
+							// (is that the same as MIS?)
 
-					// 		getBasisFromNormal( hit.normal, normalBasis );
-					// 		invBasis.copy( normalBasis ).invert();
-					// 		localDirection.copy( currentRay.direction ).applyMatrix4( invBasis ).multiplyScalar( - 1 ).normalize();
+							getBasisFromNormal( hit.normal, normalBasis );
+							invBasis.copy( normalBasis ).invert();
+							localDirection.copy( currentRay.direction ).applyMatrix4( invBasis ).multiplyScalar( - 1 ).normalize();
 
-					// 		tempVector.copy( nextRay.direction ).applyMatrix4( invBasis ).normalize();
-					// 		localDirection.normalize();
-					// 		bsdfColor( localDirection, tempVector, material, hit, tempColor );
+							tempVector.copy( nextRay.direction ).applyMatrix4( invBasis ).normalize();
+							localDirection.normalize();
+							bsdfColor( localDirection, tempVector, material, hit, tempColor );
 
-					// 		const weight = 1.0;
-					// 		throughputColor.set( 0xffffff );
-					// 		targetColor.r += lightMesh.material.color.r * throughputColor.r * tempColor.r * weight / lightPdf;
-					// 		targetColor.g += lightMesh.material.color.g * throughputColor.g * tempColor.g * weight / lightPdf;
-					// 		targetColor.b += lightMesh.material.color.b * throughputColor.b * tempColor.b * weight / lightPdf;
+							const weight = 1.0;
+							targetColor.r += lightMesh.material.color.r * throughputColor.r * tempColor.r * weight / lightPdf;
+							targetColor.g += lightMesh.material.color.g * throughputColor.g * tempColor.g * weight / lightPdf;
+							targetColor.b += lightMesh.material.color.b * throughputColor.b * tempColor.b * weight / lightPdf;
 
-					// 	}
+						}
 
-					// }
+					}
 
 					/* BSDF Sampling */
 					// compute the outgoing vector (towards the camera) to feed into the bsdf to get the

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -30,8 +30,12 @@ let dataTexture, samples, ssPoint, task, delay, scanLinePercent;
 let scanLineElement, containerElement, outputContainer;
 let renderStartTime, computationTime;
 let mesh, materials, lightMesh, floorMesh;
+
+// constants
 const DELAY_TIME = 300;
 const FADE_DELAY = 150;
+
+// reusable fields
 const triangle = new THREE.Triangle();
 const normal0 = new THREE.Vector3();
 const normal1 = new THREE.Vector3();
@@ -457,6 +461,8 @@ function init() {
 
 }
 
+// Merges meshes into a single geometry, returns a series of materials and geometry with a vertex attribute buffer
+// containing information about the material index to use
 function mergeMeshes( meshes, cloneGeometry = true ) {
 
 	const transformedGeometry = [];
@@ -563,11 +569,14 @@ function resetImage() {
 function* runPathTracingLoop() {
 
 	let lastStartTime = performance.now();
+	// extract options
 	const { width, height, data } = dataTexture.image;
 	const bounces = parseInt( params.pathTracing.bounces );
 	const skyIntensity = parseFloat( params.environment.skyIntensity );
 	const skyMode = params.environment.skyMode;
 	const smoothNormals = params.pathTracing.smoothNormals;
+
+	// reusable variables
 	const radianceColor = new THREE.Color();
 	const throughputColor = new THREE.Color();
 	const halfVector = new THREE.Vector3();
@@ -577,14 +586,17 @@ function* runPathTracingLoop() {
 	const lightWidth = lightMesh.scale.x;
 	const lightHeight = lightMesh.scale.y;
 	const raycaster = new THREE.Raycaster();
-	const seedRay = new THREE.Ray();
 	raycaster.firstHitOnly = true;
 
+	const seedRay = new THREE.Ray();
 	const sampleInfo = {
 		pdf: 0,
 		color: new THREE.Color(),
 		direction: new THREE.Vector3(),
 	};
+
+	// initialization of progress variables
+	let lastStartTime = performance.now();
 	renderStartTime = performance.now();
 	computationTime = 0;
 	scanLinePercent = 100;
@@ -597,7 +609,6 @@ function* runPathTracingLoop() {
 		material.side = THREE.DoubleSide;
 
 	} );
-
 
 	while ( true ) {
 
@@ -664,6 +675,7 @@ function* runPathTracingLoop() {
 
 	}
 
+	// extract other necessary information from the hit
 	function expandHitInformation( hit, ray, accumulatedRoughness ) {
 
 		const object = hit.object;
@@ -840,6 +852,8 @@ function* runPathTracingLoop() {
 
 								// get the material color and pdf
 								bsdfColor( localDirection, tempVector, material, hit, tempColor );
+
+								// add light contribution to the final color
 								const materialPdf = bsdfPdf( localDirection, tempVector, material, hit );
 								const misWeight = lightPdf / ( materialPdf + lightPdf );
 								targetColor.r += lightMesh.material.color.r * throughputColor.r * tempColor.r * misWeight / lightPdf;

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -733,11 +733,16 @@ function* runPathTracingLoop() {
 
 				if ( hit.object === lightMesh ) {
 
-					// TODO: is it correct to attenuate on the cosine of the hit direction?
-					const weight = Math.max( - currentRay.direction.dot( lightForward ), 0.0 );
-					targetColor.r += weight * throughputColor.r * lightMesh.material.color.r;
-					targetColor.g += weight * throughputColor.g * lightMesh.material.color.g;
-					targetColor.b += weight * throughputColor.b * lightMesh.material.color.b;
+					// only add light on one side
+					if ( currentRay.direction.dot( lightForward ) < 0 ) {
+
+						const weight = 1.0;
+						targetColor.r += weight * throughputColor.r * lightMesh.material.color.r;
+						targetColor.g += weight * throughputColor.g * lightMesh.material.color.g;
+						targetColor.b += weight * throughputColor.b * lightMesh.material.color.b;
+
+					}
+
 					break;
 
 				} else {
@@ -746,53 +751,54 @@ function* runPathTracingLoop() {
 					const { material } = hit;
 					const nextRay = rayStack[ i ];
 
-					/* Direct Light Sampling */
-					// get a random point on the surface of the light
-					tempVector
-						.set( Math.random() - 0.5, Math.random() - 0.5, 0 )
-						.applyMatrix4( lightMesh.matrixWorld );
+					// /* Direct Light Sampling */
+					// // get a random point on the surface of the light
+					// tempVector
+					// 	.set( Math.random() - 0.5, Math.random() - 0.5, 0 )
+					// 	.applyMatrix4( lightMesh.matrixWorld );
 
-					// get a ray to the light point
-					nextRay.origin.copy( hit.point ).addScaledVector( nextRay.direction, EPSILON );
-					nextRay.direction.subVectors( tempVector, nextRay.origin ).normalize();
+					// // get a ray to the light point
+					// nextRay.origin.copy( hit.point ).addScaledVector( hit.geometryNormal, EPSILON );
+					// nextRay.direction.subVectors( tempVector, nextRay.origin ).normalize();
 
-					// TODO: we should leave this attenuation check up to the PDF of a sample -- what about transmission?
-					if ( nextRay.direction.dot( lightForward ) < 0 ) {
+					// // TODO: we should leave this attenuation check up to the PDF of a sample -- what about transmission?
+					// if ( nextRay.direction.dot( lightForward ) < 0 ) {
 
-						// compute the probability of hitting the light on the hemisphere
-						const lightArea = lightWidth * lightHeight;
-						const lightDistSq = nextRay.origin.distanceToSquared( tempVector );
-						const lightPdf = lightDistSq / ( lightArea * - nextRay.direction.dot( lightForward ) );
+					// 	// compute the probability of hitting the light on the hemisphere
+					// 	const lightArea = lightWidth * lightHeight;
+					// 	const lightDistSq = nextRay.origin.distanceToSquared( tempVector );
+					// 	const lightPdf = lightDistSq / ( lightArea * - nextRay.direction.dot( lightForward ) );
 
-						raycaster.ray.copy( nextRay );
-						const shadowHit = raycaster.intersectObjects( objects, true )[ 0 ];
-						if ( shadowHit && shadowHit.object === lightMesh ) {
+					// 	raycaster.ray.copy( nextRay );
+					// 	const shadowHit = raycaster.intersectObjects( objects, true )[ 0 ];
+					// 	if ( shadowHit && shadowHit.object === lightMesh ) {
 
-							// TODO
-							// - get the BSDF PDF for this direction
-							// - get the BSDF color for this direction
-							// - weight the PDF for this sample by the average of the two PDFs for this direction
-							// - add light output
-							// - continue to accumulate throughput based on surface quality to multiply here and
-							// continue to check for direct lighting / skybox to weight in the other direction
-							// (is that the same as MIS?)
+					// 		// TODO
+					// 		// - get the BSDF PDF for this direction
+					// 		// - get the BSDF color for this direction
+					// 		// - weight the PDF for this sample by the average of the two PDFs for this direction
+					// 		// - add light output
+					// 		// - continue to accumulate throughput based on surface quality to multiply here and
+					// 		// continue to check for direct lighting / skybox to weight in the other direction
+					// 		// (is that the same as MIS?)
 
-							getBasisFromNormal( hit.normal, normalBasis );
-							invBasis.copy( normalBasis ).invert();
-							localDirection.copy( currentRay.direction ).applyMatrix4( invBasis ).multiplyScalar( - 1 ).normalize();
+					// 		getBasisFromNormal( hit.normal, normalBasis );
+					// 		invBasis.copy( normalBasis ).invert();
+					// 		localDirection.copy( currentRay.direction ).applyMatrix4( invBasis ).multiplyScalar( - 1 ).normalize();
 
-							tempVector.copy( nextRay.direction ).applyMatrix4( invBasis ).normalize();
-							localDirection.normalize();
-							bsdfColor( localDirection, tempVector, material, hit, tempColor );
+					// 		tempVector.copy( nextRay.direction ).applyMatrix4( invBasis ).normalize();
+					// 		localDirection.normalize();
+					// 		bsdfColor( localDirection, tempVector, material, hit, tempColor );
 
-							const weight = 1.0;
-							targetColor.r += lightMesh.material.color.r * throughputColor.r * tempColor.r * weight / lightPdf;
-							targetColor.g += lightMesh.material.color.g * throughputColor.g * tempColor.g * weight / lightPdf;
-							targetColor.b += lightMesh.material.color.b * throughputColor.b * tempColor.b * weight / lightPdf;
+					// 		const weight = 1.0;
+					// 		throughputColor.set( 0xffffff );
+					// 		targetColor.r += lightMesh.material.color.r * throughputColor.r * tempColor.r * weight / lightPdf;
+					// 		targetColor.g += lightMesh.material.color.g * throughputColor.g * tempColor.g * weight / lightPdf;
+					// 		targetColor.b += lightMesh.material.color.b * throughputColor.b * tempColor.b * weight / lightPdf;
 
-						}
+					// 	}
 
-					}
+					// }
 
 					/* BSDF Sampling */
 					// compute the outgoing vector (towards the camera) to feed into the bsdf to get the

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -744,8 +744,6 @@ function* runPathTracingLoop() {
 						const lightDistSq = hit.distance * hit.distance;
 						const lightArea = lightWidth * lightHeight;
 						const lightPdf = lightDistSq / ( lightArea * - currentRay.direction.dot( lightForward ) );
-						// TODO: we need the material sample PDF here so we should probably get and look at the hit on
-						// the previous iteration rather than this next one
 
 						const weight = lastPdf / ( lastPdf + lightPdf );
 						targetColor.r += weight * throughputColor.r * lightMesh.material.color.r;
@@ -796,8 +794,7 @@ function* runPathTracingLoop() {
 							// get the material color and pdf
 							bsdfColor( localDirection, tempVector, material, hit, tempColor );
 							const materialPdf = bsdfPdf( localDirection, tempVector, material, hit );
-							// const misWeight = lightPdf / ( materialPdf + lightPdf );
-							const misWeight = 1.0;
+							const misWeight = lightPdf / ( materialPdf + lightPdf );
 							targetColor.r += lightMesh.material.color.r * throughputColor.r * tempColor.r * misWeight / lightPdf;
 							targetColor.g += lightMesh.material.color.g * throughputColor.g * tempColor.g * misWeight / lightPdf;
 							targetColor.b += lightMesh.material.color.b * throughputColor.b * tempColor.b * misWeight / lightPdf;

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -570,7 +570,6 @@ function resetImage() {
 
 function* runPathTracingLoop() {
 
-	let lastStartTime = performance.now();
 	// extract options
 	const { width, height, data } = dataTexture.image;
 	const bounces = parseInt( params.pathTracing.bounces );

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -6,7 +6,7 @@ import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import { bsdfSample } from './pathtracing/materialSampling.js';
 
-import { GUI } from 'three/examples/jsm/libs/dat.gui.module.js';
+import { GUI } from 'dat.gui';
 import {
 	acceleratedRaycast,
 	computeBoundsTree,
@@ -60,11 +60,11 @@ const params = {
 		directLightSampling: true,
 	},
 	material: {
-		color: '#bbbbbb',
+		color: '#0099ff',
 		emissive: '#000000',
 		emissiveIntensity: 1,
-		roughness: 1.0,
-		metalness: 0.0,
+		roughness: 0.1,
+		metalness: 0.1,
 		ior: 1.8,
 		transmission: 0.0,
 	},
@@ -333,19 +333,6 @@ function init() {
 	pathTracingFolder.add( params.pathTracing, 'bounces', 1, 30, 1 ).onChange( resetImage );
 	pathTracingFolder.open();
 
-	const lightFolder = gui.addFolder( 'light' );
-	lightFolder.add( params.light, 'enable' ).onChange( resetImage );
-	lightFolder.addColor( params.light, 'color' ).onChange( resetImage );
-	lightFolder.add( params.light, 'intensity', 0, 20, 0.0001 ).onChange( resetImage );
-	lightFolder.add( params.light, 'width', 0, 5, 0.0001 ).onChange( resetImage );
-	lightFolder.add( params.light, 'height', 0, 5, 0.0001 ).onChange( resetImage );
-	lightFolder.open();
-
-	const envFolder = gui.addFolder( 'environment' );
-	envFolder.add( params.environment, 'skyMode', [ 'sky', 'sun', 'checkerboard' ] ).onChange( resetImage );
-	envFolder.add( params.environment, 'skyIntensity', 0, 2, 0.001 ).onChange( resetImage );
-	envFolder.open();
-
 	const materialFolder = gui.addFolder( 'model' );
 	materialFolder.addColor( params.material, 'color' ).onChange( resetImage );
 	materialFolder.addColor( params.material, 'emissive' ).onChange( resetImage );
@@ -360,7 +347,17 @@ function init() {
 	floorFolder.addColor( params.floor, 'color' ).onChange( resetImage );
 	floorFolder.add( params.floor, 'roughness', 0, 1, 0.001 ).onChange( resetImage );
 	floorFolder.add( params.floor, 'metalness', 0, 1, 0.001 ).onChange( resetImage );
-	floorFolder.open();
+
+	const lightFolder = gui.addFolder( 'light' );
+	lightFolder.add( params.light, 'enable' ).onChange( resetImage );
+	lightFolder.addColor( params.light, 'color' ).onChange( resetImage );
+	lightFolder.add( params.light, 'intensity', 0, 20, 0.0001 ).onChange( resetImage );
+	lightFolder.add( params.light, 'width', 0, 5, 0.0001 ).onChange( resetImage );
+	lightFolder.add( params.light, 'height', 0, 5, 0.0001 ).onChange( resetImage );
+
+	const envFolder = gui.addFolder( 'environment' );
+	envFolder.add( params.environment, 'skyMode', [ 'sky', 'sun', 'checkerboard' ] ).onChange( resetImage );
+	envFolder.add( params.environment, 'skyIntensity', 0, 2, 0.001 ).onChange( resetImage );
 
 	onResize();
 

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -539,8 +539,8 @@ function resetImage() {
 
 	floorMesh.scale.set( params.floor.width, params.floor.height, 1 );
 	floorMesh.material.color.set( params.floor.color );
-	floorMesh.material.roughness = Math.pow( params.floor.roughness, 2.0 );
-	floorMesh.material.metalness = params.floor.metalness, 2.0;
+	floorMesh.material.roughness = Math.pow( params.floor.roughness, 2.0 ); // perceptual roughness
+	floorMesh.material.metalness = params.floor.metalness;
 	floorMesh.visible = params.floor.enable;
 
 }
@@ -977,7 +977,7 @@ function render() {
 
 			case 'Above':
 				lightMesh.rotation.set( Math.PI / 2, 0, 0 );
-				lightMesh.position.set( 0, - model.floorHeight - 1e-3, 0 );
+				lightMesh.position.set( 0, 2 - 1e-3, 0 );
 				break;
 
 			default:

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -32,6 +32,8 @@ let scanLineElement, containerElement, outputContainer;
 let renderStartTime, computationTime;
 let mesh, bvh, materials;
 const MAX_BOUNCES = 30;
+const DELAY_TIME = 300;
+const FADE_DELAY = 150;
 const triangle = new THREE.Triangle();
 const normal0 = new THREE.Vector3();
 const normal1 = new THREE.Vector3();
@@ -42,10 +44,6 @@ const normalBasis = new THREE.Matrix4();
 const invBasis = new THREE.Matrix4();
 const localDirection = new THREE.Vector3();
 const tempColor = new THREE.Color();
-const rayStack = new Array( MAX_BOUNCES ).fill().map( () => new THREE.Ray() );
-const normalStack = new Array( MAX_BOUNCES ).fill().map( () => new THREE.Vector3() );
-const DELAY_TIME = 300;
-const FADE_DELAY = 150;
 
 const models = {};
 const params = {
@@ -453,6 +451,9 @@ function* runPathTracing() {
 	const materialAttr = bvh.geometry.attributes.materialIndex;
 	const radianceColor = new THREE.Color();
 	const throughputColor = new THREE.Color();
+	const normal = new THREE.Vector3();
+	const rayStack = new Array( bounces ).fill().map( () => new THREE.Ray() );
+
 	const sampleInfo = {
 		pdf: 0,
 		color: new THREE.Color(),
@@ -523,9 +524,8 @@ function* runPathTracing() {
 
 	}
 
-	function expandHitInformation( hit, ray, depth ) {
+	function expandHitInformation( hit, ray ) {
 
-		const normal = normalStack[ depth ];
 		const face = hit.face;
 		const geometryNormal = hit.face.normal;
 		if ( smoothNormals ) {
@@ -580,7 +580,7 @@ function* runPathTracing() {
 
 			if ( depth !== bounces ) {
 
-				expandHitInformation( hit, ray, depth );
+				expandHitInformation( hit, ray );
 				const { material } = hit;
 				const tempRay = rayStack[ depth ];
 

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -341,7 +341,7 @@ function init() {
 	materialFolder.add( params.material, 'roughness', 0, 1.0, 0.001 ).onChange( resetImage );
 	materialFolder.add( params.material, 'metalness', 0, 1.0, 0.001 ).onChange( resetImage );
 	materialFolder.add( params.material, 'transmission', 0, 1.0, 0.001 ).onChange( resetImage );
-	materialFolder.add( params.material, 'ior', 0.5, 2.5, 0.001 ).onChange( resetImage );
+	materialFolder.add( params.material, 'ior', 1.0, 2.5, 0.001 ).onChange( resetImage );
 	materialFolder.open();
 
 	const floorFolder = gui.addFolder( 'floor' );

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -42,7 +42,6 @@ const normalBasis = new THREE.Matrix4();
 const invBasis = new THREE.Matrix4();
 const localDirection = new THREE.Vector3();
 const tempColor = new THREE.Color();
-const tempVector = new THREE.Vector3();
 
 const models = {};
 const params = {
@@ -173,6 +172,87 @@ function init() {
 
 		geometry.computeBoundsTree( { strategy: SAH, maxLeafTris: 1 } );
 		models[ 'Sphere' ] = { mesh: merged, materials, floorHeight: - 1 };
+
+	}
+
+	models[ 'Cornell Box' ] = null;
+	{
+
+		const planeGeom = new THREE.PlaneBufferGeometry( 1, 1, 1, 1 );
+		const leftWall = new THREE.Mesh(
+			planeGeom,
+			new THREE.MeshStandardMaterial( {
+				color: 0x00ee00,
+				side: THREE.DoubleSide,
+				// roughness: 0.5,
+			} )
+		);
+		leftWall.rotation.y = Math.PI / 2;
+		leftWall.position.x = - 2;
+		leftWall.scale.setScalar( 4 );
+		leftWall.updateMatrixWorld( true );
+
+		const rightWall = new THREE.Mesh(
+			planeGeom,
+			new THREE.MeshStandardMaterial( {
+				color: 0xee0000,
+			} ),
+		);
+		rightWall.rotation.y = Math.PI / 2;
+		rightWall.position.x = 2;
+		rightWall.scale.setScalar( 4 );
+		rightWall.updateMatrixWorld( true );
+
+		const backWall = new THREE.Mesh(
+			planeGeom,
+			new THREE.MeshStandardMaterial( {
+				color: 0xeeeeee,
+			} ),
+		);
+		backWall.position.z = - 2;
+		backWall.scale.setScalar( 4 );
+		backWall.updateMatrixWorld( true );
+
+		const ceiling = new THREE.Mesh(
+			planeGeom.clone(),
+			new THREE.MeshStandardMaterial( {
+				color: 0xeeeeee,
+			} ),
+		);
+		ceiling.rotation.x = Math.PI / 2;
+		ceiling.position.y = 2;
+		ceiling.scale.setScalar( 4 );
+		ceiling.updateMatrixWorld( true );
+
+		const light = new THREE.Mesh(
+			planeGeom.clone(),
+			new THREE.MeshStandardMaterial( {
+				color: 0x7f7f7f,
+				emissive: 0xffffff,
+				emissiveIntensity: 15.0,
+			} ),
+		);
+		light.rotation.x = Math.PI / 2;
+		light.position.y = 1.999;
+		light.scale.setScalar( 1 );
+		light.updateMatrixWorld( true );
+
+		const box = new THREE.Mesh(
+			new THREE.BoxBufferGeometry( 1, 2, 1 ),
+			new THREE.MeshStandardMaterial( {
+				side: THREE.DoubleSide,
+			} ),
+		);
+		box.position.y = - 1.0;
+		box.position.x = - 0.5;
+		box.rotation.y = Math.PI / 4;
+
+		const { geometry, materials } = mergeMeshes( [ box, leftWall, rightWall, backWall, ceiling, light ], true );
+		const merged = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
+		scene.add( merged );
+
+		geometry.computeBoundsTree( { strategy: SAH, maxLeafTris: 1 } );
+		models[ 'Cornell Box' ] = { mesh: merged, materials, floorHeight: - 2 };
 
 	}
 
@@ -498,6 +578,8 @@ function* runPathTracingLoop() {
 		material.side = THREE.DoubleSide;
 
 	} );
+
+	mesh.material.side = THREE.DoubleSide;
 
 	while ( true ) {
 

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -598,9 +598,19 @@ function* runPathTracing() {
 					invBasis.copy( normalBasis ).invert();
 					localDirection.copy( ray.direction ).applyMatrix4( invBasis ).multiplyScalar( - 1 ).normalize();
 
-					const colorWeight = bsdfDirection( localDirection, hit, material, tempRay );
+					const colorWeight = bsdfDirection( localDirection, hit, material, tempRay.direction );
 					tempRay.direction.applyMatrix4( normalBasis ).normalize();
-					tempRay.origin.applyMatrix4( normalBasis ).add( hit.point );
+
+					tempRay.origin.copy( hit.point );
+					if ( tempRay.direction.dot( hit.geometryNormal ) < 0 ) {
+
+						tempRay.origin.addScaledVector( hit.geometryNormal, - EPSILON );
+
+					} else {
+
+						tempRay.origin.addScaledVector( hit.geometryNormal, EPSILON );
+
+					}
 
 					getColorSample( tempRay, tempColor, depth + 1 );
 					tempColor.r = THREE.MathUtils.lerp( tempColor.r, tempColor.r * color.r, colorWeight );

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -853,8 +853,8 @@ function* runPathTracingLoop() {
 					/* BSDF Sampling */
 					// compute the outgoing vector (towards the camera) to feed into the bsdf to get the
 					// incident light vector.
-					raycaster.ray.copy( currentRay );
-					localDirection.copy( currentRay.direction ).applyMatrix4( invBasis ).multiplyScalar( - 1 ).normalize();
+					localDirection.copy( currentRay.direction ).applyMatrix4( invBasis )
+						.multiplyScalar( - 1 ).normalize();
 
 					// sample the surface to get the pdf, reflected color, and direction
 					bsdfSample( localDirection, hit, material, sampleInfo );
@@ -866,16 +866,10 @@ function* runPathTracingLoop() {
 
 					// transform ray back to world frame and offset from surface
 					nextRay.direction.copy( sampleInfo.direction ).applyMatrix4( normalBasis ).normalize();
-					nextRay.origin.copy( hit.point );
-					if ( nextRay.direction.dot( hit.geometryNormal ) < 0 ) {
 
-						nextRay.origin.addScaledVector( hit.geometryNormal, - EPSILON );
-
-					} else {
-
-						nextRay.origin.addScaledVector( hit.geometryNormal, EPSILON );
-
-					}
+					const isBelowSurface = nextRay.direction.dot( hit.geometryNormal ) < 0;
+					nextRay.origin.copy( hit.point )
+						.addScaledVector( hit.geometryNormal, isBelowSurface ? - EPSILON : EPSILON );
 
 					const { emissive, emissiveIntensity } = material;
 					targetColor.r += ( emissiveIntensity * emissive.r * throughputColor.r );

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -26,11 +26,10 @@ THREE.BufferGeometry.prototype.disposeBoundsTree = disposeBoundsTree;
 
 let scene, camera, renderer, light, clock;
 let fsQuad, controls;
-let raycaster, dataTexture, samples, ssPoint, task, delay, scanLinePercent;
+let dataTexture, samples, ssPoint, task, delay, scanLinePercent;
 let scanLineElement, containerElement, outputContainer;
 let renderStartTime, computationTime;
 let mesh, materials, lightMesh;
-const MAX_BOUNCES = 30;
 const DELAY_TIME = 300;
 const FADE_DELAY = 150;
 const triangle = new THREE.Triangle();
@@ -319,8 +318,6 @@ function init() {
 	ssPoint = new THREE.Vector3();
 	samples = 0;
 	clock = new THREE.Clock();
-	raycaster = new THREE.Raycaster();
-	raycaster.firstHitOnly = true;
 
 	const gui = new GUI();
 	gui.add( params, 'model', Object.keys( models ) ).onChange( resetImage );
@@ -341,7 +338,7 @@ function init() {
 	pathTracingFolder.add( params.pathTracing, 'antialiasing' ).onChange( resetImage );
 	pathTracingFolder.add( params.pathTracing, 'directLightSampling' ).onChange( resetImage );
 	pathTracingFolder.add( params.pathTracing, 'smoothNormals' ).onChange( resetImage );
-	pathTracingFolder.add( params.pathTracing, 'bounces', 1, MAX_BOUNCES, 1 ).onChange( resetImage );
+	pathTracingFolder.add( params.pathTracing, 'bounces', 1, 30, 1 ).onChange( resetImage );
 	pathTracingFolder.open();
 
 	const lightFolder = gui.addFolder( 'light' );
@@ -483,6 +480,8 @@ function* runPathTracing() {
 	const normal = new THREE.Vector3();
 	const rayStack = new Array( bounces ).fill().map( () => new THREE.Ray() );
 	const lightForward = new THREE.Vector3( 0, 0, 1 ).transformDirection( lightMesh.matrixWorld );
+	const raycaster = new THREE.Raycaster();
+	raycaster.firstHitOnly = true;
 
 	const sampleInfo = {
 		pdf: 0,

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -616,9 +616,15 @@ function* runPathTracing() {
 				targetColor.g += ( emissiveIntensity * emissive.g * throughput.g );
 				targetColor.b += ( emissiveIntensity * emissive.b * throughput.b );
 
-				throughput.multiply( sampleInfo.color );
+				// If our PDF indicates there's a less than 0 probability of sampling this direction then
+				// don't include it in our sampling and terminate the ray modeling that the ray has been absorbed.
+				if ( sampleInfo.pdf > 0 ) {
 
-				getColorSample( tempRay, throughput, targetColor, depth + 1 );
+					sampleInfo.color.multiplyScalar( 1 / sampleInfo.pdf );
+					throughput.multiply( sampleInfo.color );
+					getColorSample( tempRay, throughput, targetColor, depth + 1 );
+
+				}
 
 			}
 

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -600,6 +600,7 @@ function* runPathTracing() {
 
 					const colorWeight = bsdfDirection( localDirection, hit, material, tempRay );
 					tempRay.direction.applyMatrix4( normalBasis ).normalize();
+					tempRay.origin.applyMatrix4( normalBasis ).add( hit.point );
 
 					getColorSample( tempRay, tempColor, depth + 1 );
 					tempColor.r = THREE.MathUtils.lerp( tempColor.r, tempColor.r * color.r, colorWeight );

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -108,6 +108,7 @@ function init() {
 	containerElement.style.position = 'absolute';
 	containerElement.style.inset = '0';
 	containerElement.style.margin = 'auto';
+	containerElement.style.zIndex = '-1';
 	document.body.appendChild( containerElement );
 	containerElement.appendChild( renderer.domElement );
 
@@ -774,7 +775,6 @@ function* runPathTracingLoop() {
 					nextRay.origin.copy( hit.point ).addScaledVector( hit.geometryNormal, EPSILON );
 					nextRay.direction.subVectors( tempVector, nextRay.origin ).normalize();
 
-					// TODO: we should leave this attenuation check up to the PDF of a sample -- what about transmission?
 					if ( nextRay.direction.dot( lightForward ) < 0 ) {
 
 						// compute the probability of hitting the light on the hemisphere

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -144,7 +144,7 @@ function init() {
 
 		const planeMesh = new THREE.Mesh(
 			new THREE.PlaneBufferGeometry(),
-			new THREE.MeshStandardMaterial( { color: 0x7f7f7f } ),
+			new THREE.MeshStandardMaterial( { color: 0x7f7f7f, roughness: 0.5, metalness: 0.0 } ),
 		);
 
 		planeMesh.rotation.x = - Math.PI / 2;
@@ -483,10 +483,6 @@ function* runPathTracing() {
 				radianceColor.set( 0 );
 				getColorSample( raycaster.ray, throughputColor, radianceColor );
 
-				radianceColor.r = Math.min( radianceColor.r, 1.0 );
-				radianceColor.g = Math.min( radianceColor.g, 1.0 );
-				radianceColor.b = Math.min( radianceColor.b, 1.0 );
-
 				const index = ( y * width + x ) * 4;
 				if ( samples === 0 ) {
 
@@ -656,10 +652,9 @@ function* runPathTracing() {
 
 					let value2 = ( value - 0.95 ) / 0.05;
 					value2 *= value2;
-					tempColor.r = THREE.MathUtils.lerp( 0.5, 20.0, value2 );
-					tempColor.g = THREE.MathUtils.lerp( 0.7, 20.0, value2 );
-					tempColor.b = THREE.MathUtils.lerp( 1.0, 20.0, value2 );
-
+					tempColor.r = THREE.MathUtils.lerp( 0.5, 10.0, value2 );
+					tempColor.g = THREE.MathUtils.lerp( 0.7, 10.0, value2 );
+					tempColor.b = THREE.MathUtils.lerp( 1.0, 10.0, value2 );
 
 				}
 

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -1059,8 +1059,7 @@ function render() {
 
 	}
 
-	fsQuad.material.map = dataTexture;
-	fsQuad.material.opacity = fade;
+	// update the scan line
 	scanLineElement.style.bottom = `${ scanLinePercent }%`;
 	if ( params.resolution.stretchImage ) {
 
@@ -1072,8 +1071,13 @@ function render() {
 
 	}
 
+	// render the scene
 	renderer.render( scene, camera );
 	renderer.autoClear = false;
+
+	// overlay the path traced image
+	fsQuad.material.map = dataTexture;
+	fsQuad.material.opacity = fade;
 	fsQuad.render( renderer );
 	renderer.autoClear = true;
 

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -79,7 +79,7 @@ const params = {
 	},
 	light: {
 		enable: true,
-		position: 'Default',
+		position: 'Diagonal',
 		intensity: 5.0,
 		color: '#ffffff',
 		width: 1,
@@ -433,7 +433,7 @@ function init() {
 	lightFolder.add( params.light, 'intensity', 0, 30, 0.001 ).onChange( resetImage );
 	lightFolder.add( params.light, 'width', 0, 5, 0.001 ).onChange( resetImage );
 	lightFolder.add( params.light, 'height', 0, 5, 0.001 ).onChange( resetImage );
-	lightFolder.add( params.light, 'position', [ 'Default', 'Below', 'Above' ] ).onChange( resetImage );
+	lightFolder.add( params.light, 'position', [ 'Diagonal', 'Above', 'Below' ] ).onChange( resetImage );
 
 	const envFolder = gui.addFolder( 'environment' );
 	envFolder.add( params.environment, 'skyMode', [ 'sky', 'sun', 'checkerboard' ] ).onChange( resetImage );

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -734,17 +734,19 @@ function* runPathTracingLoop() {
 				if ( hit.object === lightMesh ) {
 
 					// only add light on one side
-					if ( currentRay.direction.dot( lightForward ) < 0 ) {
+					if ( i === 0 ) {
 
+						targetColor.copy( lightMesh.material.color );
+
+					} else if ( currentRay.direction.dot( lightForward ) < 0 ) {
+
+						// only add light on one side
 						// const weight = 1.0;
 						// targetColor.r += weight * throughputColor.r * lightMesh.material.color.r;
 						// targetColor.g += weight * throughputColor.g * lightMesh.material.color.g;
 						// targetColor.b += weight * throughputColor.b * lightMesh.material.color.b;
 
 					}
-
-					if ( i === 0 )
-						targetColor.set( 0xffffff )
 
 					break;
 

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -236,10 +236,22 @@ function init() {
 			} ),
 		);
 		box.position.y = - 1.0;
-		box.position.x = - 0.5;
+		box.position.x = - 0.6;
+		box.position.z = - 0.25;
 		box.rotation.y = Math.PI / 4;
 
-		const { geometry, materials } = mergeMeshes( [ box, leftWall, rightWall, backWall, ceiling ], true );
+		const box2 = new THREE.Mesh(
+			new THREE.BoxBufferGeometry( 1, 1, 1 ),
+			new THREE.MeshStandardMaterial( {
+				side: THREE.DoubleSide,
+			} ),
+		);
+		box2.position.y = - 1.5;
+		box2.position.x = 0.75;
+		box2.position.z = 0.5;
+		box2.rotation.y = - Math.PI / 8;
+
+		const { geometry, materials } = mergeMeshes( [ box, box2, leftWall, rightWall, backWall, ceiling ], true );
 		const merged = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 		scene.add( merged );
 
@@ -1011,6 +1023,7 @@ function render() {
 		// https://google.github.io/filament/Filament.html#materialsystem/standardmodelsummary
 		material.roughness = Math.pow( parseFloat( params.material.roughness ), 2.0 );
 
+		// adjust the position of the area light before rendering
 		switch ( params.light.position ) {
 
 			case 'Below':
@@ -1038,6 +1051,7 @@ function render() {
 
 	}
 
+	// Fade the path traced image in after the user stops moving the camera
 	let fade = 0;
 	if ( delay > FADE_DELAY ) {
 

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -814,6 +814,8 @@ function* runPathTracingLoop() {
 							.applyMatrix4( lightMesh.matrixWorld );
 
 						// get a ray to the light point
+						// note that the ray always starts on the front side of the face implying that transmissive
+						// contributions are not included here.
 						nextRay.origin.copy( hit.point ).addScaledVector( hit.geometryNormal, EPSILON );
 						nextRay.direction.subVectors( tempVector, nextRay.origin ).normalize();
 
@@ -871,12 +873,13 @@ function* runPathTracingLoop() {
 					nextRay.origin.copy( hit.point )
 						.addScaledVector( hit.geometryNormal, isBelowSurface ? - EPSILON : EPSILON );
 
+					// emission contribution
 					const { emissive, emissiveIntensity } = material;
 					targetColor.r += ( emissiveIntensity * emissive.r * throughputColor.r );
 					targetColor.g += ( emissiveIntensity * emissive.g * throughputColor.g );
 					targetColor.b += ( emissiveIntensity * emissive.b * throughputColor.b );
 
-					// If our PDF indicates there's a less than 0 probability of sampling this direction then
+					// If our PDF indicates there's a less than 0 probability of sampling this new direction then
 					// don't include it in our sampling and terminate the ray modeling that the ray has been absorbed.
 					if (
 						sampleInfo.pdf <= 0

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -573,13 +573,13 @@ function* runPathTracingLoop() {
 	scanLineElement.style.visibility = params.pathTracing.displayScanLine ? 'visible' : 'hidden';
 
 	// ensure the materials are all set to double side for transmissive rendering
+	mesh.material.side = THREE.DoubleSide;
 	materials.forEach( material => {
 
 		material.side = THREE.DoubleSide;
 
 	} );
 
-	mesh.material.side = THREE.DoubleSide;
 
 	while ( true ) {
 

--- a/example/pathtracing/ggxSampling.js
+++ b/example/pathtracing/ggxSampling.js
@@ -1,5 +1,4 @@
 import { Vector3 } from 'three';
-import { getHalfVector } from './utils.js';
 
 const _V = new Vector3();
 const _T1 = new Vector3();
@@ -78,22 +77,6 @@ export function ggxShadowMaskG2( wi, wo, roughness ) {
 
 }
 
-// See equation (33) in https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf
-// export function ggxDistribution( theta, roughness ) {
-
-// 	const cosTheta = Math.cos( theta );
-// 	const cosTheta2 = cosTheta * cosTheta;
-// 	const cosTheta4 = cosTheta2 * cosTheta2;
-// 	const tanTheta = Math.tan( theta );
-// 	const tanTheta2 = tanTheta * tanTheta;
-// 	const alpha2 = roughness * roughness;
-
-// 	const denom = M_PI * cosTheta4 * Math.pow( alpha2 + tanTheta2, 2 );
-// 	return alpha2 / denom;
-
-// }
-
-
 // See equation (1)
 export function ggxDistribution( halfVector, roughness ) {
 
@@ -110,8 +93,6 @@ export function ggxDistribution( halfVector, roughness ) {
 export function ggxvndfPDF( wi, halfVector, roughness ) {
 
 	const incidentTheta = Math.acos( wi.z );
-	const halfTheta = Math.acos( wi.z );
-
 	const D = ggxDistribution( halfVector, roughness );
 	const G1 = ggxShadowMaskG1( incidentTheta, roughness );
 

--- a/example/pathtracing/ggxSampling.js
+++ b/example/pathtracing/ggxSampling.js
@@ -80,6 +80,7 @@ export function ggxShadowMaskG2( wi, wo, roughness ) {
 // See equation (1)
 export function ggxDistribution( halfVector, roughness ) {
 
+	// TODO: replace with equation (33) from https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf
 	const { x, y, z } = halfVector;
 	const a2 = roughness * roughness;
 	const mult = x * x / a2 + y * y / a2 + z * z;

--- a/example/pathtracing/ggxSampling.js
+++ b/example/pathtracing/ggxSampling.js
@@ -94,7 +94,7 @@ export function ggxDistribution( theta, roughness ) {
 }
 
 // See equation (3)
-function ggxvndfPDF( wi, halfVector, roughness ) {
+export function ggxvndfPDF( wi, halfVector, roughness ) {
 
 	const incidentTheta = Math.acos( wi.z );
 	const halfTheta = Math.acos( wi.z );
@@ -103,13 +103,5 @@ function ggxvndfPDF( wi, halfVector, roughness ) {
 	const G1 = ggxShadowMaskG1( incidentTheta, roughness );
 
 	return D * G1 * Math.max( 0.0, wi.dot( halfVector ) ) / wi.z;
-
-}
-
-// See equation (17)
-export function sampledGGXPDF( wi, wo, roughness ) {
-
-	const halfVector = getHalfVector( wi, wo, _HALF_VECTOR );
-	return ggxvndfPDF( wi, halfVector, roughness ) / ( 4 * wi.dot( wo ) );
 
 }

--- a/example/pathtracing/ggxSampling.js
+++ b/example/pathtracing/ggxSampling.js
@@ -78,7 +78,8 @@ export function ggxShadowMaskG2( wi, wo, roughness ) {
 
 }
 
-function ggxDistribution( theta, roughness ) {
+// TODO: where is this from?
+export function ggxDistribution( theta, roughness ) {
 
 	const cosTheta = Math.cos( theta );
 	const cosTheta2 = cosTheta * cosTheta;

--- a/example/pathtracing/ggxSampling.js
+++ b/example/pathtracing/ggxSampling.js
@@ -14,8 +14,7 @@ const M_PI = Math.PI;
 // [2] http://jcgt.org/published/0007/04/01/
 // [4] http://jcgt.org/published/0003/02/03/
 
-// TODO: rename function to ggx (not vndf)
-export function ggxvndfDirection( incidentDir, roughnessX, roughnessY, random1, random2, target ) {
+export function ggxDirection( incidentDir, roughnessX, roughnessY, random1, random2, target ) {
 
 	// TODO: try GGXVNDF implementation from reference [2], here. Needs to update ggxDistribution
 	// function below, as well
@@ -109,7 +108,7 @@ export function ggxDistribution( halfVector, roughness ) {
 }
 
 // See equation (3) from reference [2]
-export function ggxvndfPDF( wi, halfVector, roughness ) {
+export function ggxPDF( wi, halfVector, roughness ) {
 
 	const incidentTheta = Math.acos( wi.z );
 	const D = ggxDistribution( halfVector, roughness );

--- a/example/pathtracing/ggxSampling.js
+++ b/example/pathtracing/ggxSampling.js
@@ -6,11 +6,11 @@ const _T1 = new Vector3();
 const _T2 = new Vector3();
 const _N = new Vector3();
 const _Z_VECTOR = new Vector3( 0, 0, 1 );
-const _HALF_VECTOR = new Vector3();
 const M_PI = Math.PI;
 
 // The GGX functions provide sampling and distribution information for normals as output so
 // in order to get probability of scatter direction the half vector must be computed and provided.
+// https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf
 // https://hal.archives-ouvertes.fr/hal-01509746/document
 // http://jcgt.org/published/0007/04/01/
 export function ggxvndfDirection( incidentDir, roughnessX, roughnessY, random1, random2, target ) {
@@ -78,18 +78,31 @@ export function ggxShadowMaskG2( wi, wo, roughness ) {
 
 }
 
-// TODO: where is this from?
-export function ggxDistribution( theta, roughness ) {
+// See equation (33) in https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf
+// export function ggxDistribution( theta, roughness ) {
 
-	const cosTheta = Math.cos( theta );
-	const cosTheta2 = cosTheta * cosTheta;
-	const cosTheta4 = cosTheta2 * cosTheta2;
-	const tanTheta = Math.tan( theta );
-	const tanTheta2 = tanTheta * tanTheta;
-	const alpha2 = roughness * roughness;
+// 	const cosTheta = Math.cos( theta );
+// 	const cosTheta2 = cosTheta * cosTheta;
+// 	const cosTheta4 = cosTheta2 * cosTheta2;
+// 	const tanTheta = Math.tan( theta );
+// 	const tanTheta2 = tanTheta * tanTheta;
+// 	const alpha2 = roughness * roughness;
 
-	const denom = M_PI * cosTheta4 * Math.pow( alpha2 + tanTheta2, 2 );
-	return alpha2 / denom;
+// 	const denom = M_PI * cosTheta4 * Math.pow( alpha2 + tanTheta2, 2 );
+// 	return alpha2 / denom;
+
+// }
+
+
+// See equation (1)
+export function ggxDistribution( halfVector, roughness ) {
+
+	const { x, y, z } = halfVector;
+	const a2 = roughness * roughness;
+	const mult = x * x / a2 + y * y / a2 + z * z;
+	const mult2 = mult * mult;
+
+	return 1.0 / Math.PI * a2 * mult2;
 
 }
 
@@ -99,7 +112,7 @@ export function ggxvndfPDF( wi, halfVector, roughness ) {
 	const incidentTheta = Math.acos( wi.z );
 	const halfTheta = Math.acos( wi.z );
 
-	const D = ggxDistribution( halfTheta, roughness );
+	const D = ggxDistribution( halfVector, roughness );
 	const G1 = ggxShadowMaskG1( incidentTheta, roughness );
 
 	return D * G1 * Math.max( 0.0, wi.dot( halfVector ) ) / wi.z;

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -16,7 +16,9 @@ function diffuseWeight( reflectance, metalness, transmission ) {
 
 function diffusePDF( direction, normal, roughness ) {
 
-	return 1; // TODO
+	// https://raytracing.github.io/books/RayTracingTheRestOfYourLife.html#lightscattering/thescatteringpdf
+	const cosValue = direction.dot( normal );
+	return cosValue / Math.PI;
 
 }
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -1,5 +1,5 @@
-import { schlickFresnelReflectance, refract, getRandomUnitDirection, getHalfVector, schlickFresnel } from './utils.js';
-import { ggxvndfDirection, ggxvndfPDF, ggxShadowMaskG2, ggxDistribution } from './ggxSampling.js';
+import { schlickFresnelReflectance, refract, getRandomUnitDirection, getHalfVector } from './utils.js';
+import { ggxDirection, ggxPDF, ggxShadowMaskG2, ggxDistribution } from './ggxSampling.js';
 import { MathUtils, Vector3, Color } from 'three';
 
 // Technically this value should be based on the index of refraction of the given dielectric.
@@ -28,6 +28,7 @@ function diffuseDirection( wo, hit, material, lightDirection ) {
 
 function diffuseColor( wo, wi, material, hit, colorTarget ) {
 
+	// TODO: scale by 1 - F here
 	// note on division by PI
 	// https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
 	const { metalness, transmission } = material;
@@ -44,7 +45,7 @@ function specularPDF( wo, wi, material, hit ) {
 	// See equation (17) in http://jcgt.org/published/0003/02/03/
 	const minRoughness = Math.max( material.roughness, MIN_ROUGHNESS );
 	getHalfVector( wi, wo, halfVector );
-	return ggxvndfPDF( wi, halfVector, minRoughness ) / ( 4 * wi.dot( halfVector ) );
+	return ggxPDF( wi, halfVector, minRoughness ) / ( 4 * wi.dot( halfVector ) );
 
 }
 
@@ -52,7 +53,7 @@ function specularDirection( wo, hit, material, lightDirection ) {
 
 	// sample ggx vndf distribution which gives a new normal
 	const minRoughness = Math.max( material.roughness, MIN_ROUGHNESS );
-	ggxvndfDirection(
+	ggxDirection(
 		wo,
 		minRoughness,
 		minRoughness,
@@ -249,7 +250,6 @@ export function bsdfColor( wo, wi, material, hit, targetColor ) {
 export function bsdfSample( wo, hit, material, sampleInfo ) {
 
 	const lightDirection = sampleInfo.direction;
-	const color = sampleInfo.color;
 	const { ior, metalness, transmission } = material;
 	const { frontFace } = hit;
 
@@ -264,29 +264,26 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 
 	}
 
-	let pdf = 0;
 	if ( Math.random() < transmission ) {
 
 		const specularProb = MathUtils.lerp( reflectance, 1.0, metalness );
 		if ( Math.random() < specularProb ) {
 
 			specularDirection( wo, hit, material, lightDirection );
-			pdf = specularPDF( wo, lightDirection, material, hit );
-			specularColor( wo, lightDirection, material, hit, color );
-
-			pdf *= specularProb;
+			// pdf = specularPDF( wo, lightDirection, material, hit );
+			// specularColor( wo, lightDirection, material, hit, color );
+			// pdf *= specularProb;
 
 		} else {
 
 			transmissionDirection( wo, hit, material, lightDirection );
-			pdf = transmissionPDF( wo, lightDirection, material, hit );
-			transmissionColor( wo, lightDirection, material, hit, color );
-
-			pdf *= ( 1.0 - specularProb );
+			// pdf = transmissionPDF( wo, lightDirection, material, hit );
+			// transmissionColor( wo, lightDirection, material, hit, color );
+			// pdf *= ( 1.0 - specularProb );
 
 		}
 
-		pdf *= transmission;
+		// pdf *= transmission;
 
 	} else {
 
@@ -294,22 +291,20 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 		if ( Math.random() < specularProb ) {
 
 			specularDirection( wo, hit, material, lightDirection );
-			pdf = specularPDF( wo, lightDirection, material, hit );
-			specularColor( wo, lightDirection, material, hit, color );
-
-			pdf *= specularProb;
+			// pdf = specularPDF( wo, lightDirection, material, hit );
+			// specularColor( wo, lightDirection, material, hit, color );
+			// pdf *= specularProb;
 
 		} else {
 
 			diffuseDirection( wo, hit, material, lightDirection );
-			pdf = diffusePDF( wo, lightDirection, material, hit );
-			diffuseColor( wo, lightDirection, material, hit, color );
-
-			pdf *= ( 1.0 - specularProb );
+			// pdf = diffusePDF( wo, lightDirection, material, hit );
+			// diffuseColor( wo, lightDirection, material, hit, color );
+			// pdf *= ( 1.0 - specularProb );
 
 		}
 
-		pdf *= ( 1.0 - transmission );
+		// pdf *= ( 1.0 - transmission );
 
 	}
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -23,12 +23,11 @@ function diffusePDF( direction, normal, roughness ) {
 function diffuseDirection( wo, hit, material, rayTarget ) {
 
 	const { origin, direction } = rayTarget;
-	const { geometryNormal } = hit;
 
 	getRandomUnitDirection( direction );
 	direction.z += 1;
 	direction.normalize();
-	origin.copy( hit.point ).addScaledVector( geometryNormal, EPSILON );
+	origin.set( 0, 0, EPSILON );
 
 }
 
@@ -49,7 +48,6 @@ function specularDirection( wo, hit, material, rayTarget ) {
 
 	const { roughness } = material;
 	const { origin, direction } = rayTarget;
-	const { geometryNormal } = hit;
 
 	// sample ggx vndf distribution which gives a new normal
 	ggxvndfDirection(
@@ -63,7 +61,7 @@ function specularDirection( wo, hit, material, rayTarget ) {
 
 	// apply to new ray by reflecting off the new normal
 	direction.copy( wo ).reflect( tempVector ).multiplyScalar( - 1 );
-	origin.copy( hit.point ).addScaledVector( geometryNormal, EPSILON );
+	origin.set( 0, 0, EPSILON );
 
 	// // basic implementation
 	// const { roughness } = material;
@@ -93,7 +91,7 @@ function transmissionDirection( wo, hit, material, rayTarget ) {
 
 	const { roughness, ior } = material;
 	const { origin, direction } = rayTarget;
-	const { geometryNormal, frontFace } = hit;
+	const { frontFace } = hit;
 	const ratio = frontFace ? 1 / ior : ior;
 
 	// sample ggx vndf distribution which gives a new normal
@@ -109,7 +107,7 @@ function transmissionDirection( wo, hit, material, rayTarget ) {
 	// apply to new ray by reflecting off the new normal
 	tempDir.copy( wo ).multiplyScalar( - 1 );
 	refract( tempDir, tempVector, ratio, direction );
-	origin.copy( hit.point ).addScaledVector( geometryNormal, - EPSILON );
+	origin.set( 0, 0, - EPSILON );
 
 }
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -113,7 +113,7 @@ function transmissionPDF( wo, wi, material, hit ) {
 	halfVector.set( 0, 0, 0 ).addScaledVector( wi, ratio ).addScaledVector( wo, 1.0 ).normalize().multiplyScalar( - 1 );
 
 	const denom = Math.pow( ratio * halfVector.dot( wi ) + 1.0 * halfVector.dot( wo ), 2.0 );
-	return ggxvndfPDF( wo, halfVector, minRoughness ) / denom;
+	return ggxPDF( wo, halfVector, minRoughness ) / denom;
 
 }
 
@@ -125,7 +125,7 @@ function transmissionDirection( wo, hit, material, lightDirection ) {
 	const minRoughness = Math.max( roughness, MIN_ROUGHNESS );
 
 	// sample ggx vndf distribution which gives a new normal
-	ggxvndfDirection(
+	ggxDirection(
 		wo,
 		minRoughness,
 		minRoughness,
@@ -140,10 +140,13 @@ function transmissionDirection( wo, hit, material, lightDirection ) {
 
 }
 
-function transmissionColor( wo, wi, material, colorTarget ) {
+function transmissionColor( wo, wi, material, hit, colorTarget ) {
 
-	const { metalness } = material;
-	colorTarget.copy( material.color ).multiplyScalar( ( 1.0 - metalness ) * wo.z / Math.PI );
+	const { metalness, transmission } = material;
+	colorTarget
+		.copy( material.color )
+		.multiplyScalar( ( 1.0 - metalness ) * wo.z )
+		.multiplyScalar( transmission );
 
 }
 */

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -32,20 +32,20 @@ function diffuseDirection( wo, hit, material, lightDirection ) {
 function specularPDF( wo, wi, material ) {
 
 	// See equation (17) in http://jcgt.org/published/0003/02/03/
+	const minRoughness = Math.max( material.roughness, MIN_ROUGHNESS );
 	getHalfVector( wi, wo, halfVector );
-	return ggxvndfPDF( wi, halfVector, Math.max( material.roughness, MIN_ROUGHNESS ) ) / ( 4 * wi.dot( wo ) );
+	return ggxvndfPDF( wi, halfVector, minRoughness ) / ( 4 * wi.dot( halfVector ) );
 
 }
 
 function specularDirection( wo, hit, material, lightDirection ) {
 
-	const { roughness } = material;
-
 	// sample ggx vndf distribution which gives a new normal
+	const minRoughness = Math.max( material.roughness, MIN_ROUGHNESS );
 	ggxvndfDirection(
 		wo,
-		roughness,
-		roughness,
+		minRoughness,
+		minRoughness,
 		Math.random(),
 		Math.random(),
 		tempVector,
@@ -139,7 +139,7 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 		if ( Math.random() < 0.5 ) {
 
 			specularDirection( wo, hit, material, lightDirection );
-			pdf = Math.abs( specularPDF( wo, lightDirection, material ) );
+			pdf = specularPDF( wo, lightDirection, material );
 
 			// if roughness is set to 0 then D === NaN which results in black pixels
 			const minRoughness = Math.max( roughness, MIN_ROUGHNESS );
@@ -156,7 +156,6 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 				.multiplyScalar( G * D / ( 4 * Math.abs( lightDirection.z * wo.z ) ) )
 				.multiplyScalar( MathUtils.lerp( F, 1.0, metalness ) );
 
-			color.setRGB( D, D, D )
 
 		} else {
 
@@ -168,8 +167,6 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 			color.copy( material.color )
 				// .lerp( whiteColor, F )
 				.multiplyScalar( ( 1.0 - metalness ) * pdf * 1.0 );
-
-			color.set( 0 );
 
 		}
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -134,7 +134,7 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 
 	const lightDirection = sampleInfo.direction;
 	const color = sampleInfo.color;
-	const { ior, metalness, transmission, roughness } = material;
+	const { ior, metalness, transmission } = material;
 	const { frontFace } = hit;
 
 	// TODO: this schlick fresnel is just for dialectrics because it uses ior interally
@@ -176,7 +176,6 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 		}
 
 		pdf *= transmission;
-		color.multiplyScalar( 1 / pdf );
 
 	} else {
 
@@ -202,9 +201,10 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 		}
 
 		pdf *= ( 1.0 - transmission );
-		color.multiplyScalar( 1.0 / pdf );
 
 	}
+
+	sampleInfo.pdf = pdf;
 
 }
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -36,7 +36,7 @@ function diffuseColor( wo, wi, material, colorTarget ) {
 	const { metalness } = material;
 	colorTarget
 		.copy( material.color )
-		.multiplyScalar( ( 1.0 - metalness ) * wi.z / Math.PI );
+		.multiplyScalar( ( 1.0 - metalness ) * wi.z / Math.PI / Math.PI );
 
 }
 
@@ -154,8 +154,6 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 	const { ior, metalness, transmission, roughness } = material;
 	const { frontFace } = hit;
 
-	// TODO: this schlick fresnel is just for dialectrics because it uses ior interally
-	// Change this to use a common fresnel function
 	const ratio = frontFace ? 1 / ior : ior;
 	const cosTheta = Math.min( wo.z, 1.0 );
 	const sinTheta = Math.sqrt( 1.0 - cosTheta * cosTheta );
@@ -170,9 +168,7 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 	let pdf = 0;
 	if ( Math.random() < transmission ) {
 
-		// TODO: 1.0 metalness and 1.0 transmission needs to be fixed
-		const specularProb = 0.5;//MathUtils.lerp( reflectance, 1.0, metalness );
-
+		const specularProb = MathUtils.lerp( reflectance, 1.0, metalness );
 		if ( Math.random() < specularProb ) {
 
 			specularDirection( wo, hit, material, lightDirection );
@@ -215,8 +211,7 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 
 	} else {
 
-		// TODO: is there a better way to determine probability here?
-		const specProb = 0.5;// + 0.5 * metalness;
+		const specProb = 0.5 + 0.5 * metalness;
 		if ( Math.random() < specProb ) {
 
 			specularDirection( wo, hit, material, lightDirection );
@@ -224,7 +219,7 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 
 			specularColor( wo, lightDirection, material, hit, color );
 
-			pdf *= 0.5;
+			pdf *= specProb;
 
 		} else {
 
@@ -233,7 +228,7 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 
 			diffuseColor( wo, lightDirection, material, color );
 
-			pdf *= 0.5;
+			pdf *= ( 1.0 - specProb );
 
 		}
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -33,7 +33,8 @@ function diffuseColor( wo, wi, material, hit, colorTarget ) {
 	const { metalness, transmission } = material;
 	colorTarget
 		.copy( material.color )
-		.multiplyScalar( ( 1.0 - metalness ) * wi.z / Math.PI / Math.PI );
+		.multiplyScalar( ( 1.0 - metalness ) * wi.z / Math.PI / Math.PI )
+		.multiplyScalar( 1.0 - transmission );
 
 }
 
@@ -170,11 +171,12 @@ function transmissionDirection( wo, hit, material, lightDirection ) {
 
 function transmissionColor( wo, wi, material, hit, colorTarget ) {
 
-	const { metalness } = material;
+	const { metalness, transmission } = material;
 	colorTarget
 		.copy( material.color )
 		.multiplyScalar( 1.0 - metalness )
-		.multiplyScalar( Math.abs( wi.z ) );
+		.multiplyScalar( Math.abs( wi.z ) )
+		.multiplyScalar( transmission );
 
 	// Color is clamped to [0, 1] to make up for incorrect PDF and over sampling
 	colorTarget.r = Math.min( colorTarget.r, 1.0 );
@@ -218,9 +220,9 @@ export function bsdfPdf( wo, wi, material, hit ) {
 	const diffSpecularProb = 0.5 + 0.5 * metalness;
 	const pdf =
 		spdf * transmission * transSpecularProb
-		+ tpdf * transmission * ( 1.0 - transSpecularProb ) * tpdf
+		+ tpdf * transmission * ( 1.0 - transSpecularProb )
 		+ spdf * ( 1.0 - transmission ) * diffSpecularProb
-		+ dpdf * ( 1.0 - transmission ) * ( 1.0 - diffSpecularProb ) * dpdf;
+		+ dpdf * ( 1.0 - transmission ) * ( 1.0 - diffSpecularProb );
 
 	return pdf;
 
@@ -312,6 +314,10 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 	}
 
 	sampleInfo.pdf = pdf;
+
+	// TODO: how is this supposed to work?
+	// sampleInfo.pdf = bsdfPdf( wo, lightDirection, material, hit );
+	// bsdfColor( wo, lightDirection, material, hit, color );
 
 }
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -100,6 +100,7 @@ function specularColor( wo, wi, material, hit, colorTarget ) {
 
 }
 
+/*
 // transmission
 function transmissionPDF( wo, wi, material, hit ) {
 
@@ -127,8 +128,8 @@ function transmissionDirection( wo, hit, material, lightDirection ) {
 	// sample ggx vndf distribution which gives a new normal
 	ggxvndfDirection(
 		wo,
-		roughness,
-		roughness,
+		minRoughness,
+		minRoughness,
 		Math.random(),
 		Math.random(),
 		halfVector,
@@ -146,6 +147,7 @@ function transmissionColor( wo, wi, material, colorTarget ) {
 	colorTarget.copy( material.color ).multiplyScalar( ( 1.0 - metalness ) * wo.z / Math.PI );
 
 }
+*/
 
 export function bsdfSample( wo, hit, material, sampleInfo ) {
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -31,8 +31,12 @@ function diffuseDirection( wo, hit, material, lightDirection ) {
 
 function diffuseColor( wo, wi, material, colorTarget ) {
 
+	// note on division by PI
+	// https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
 	const { metalness } = material;
-	colorTarget.copy( material.color ).multiplyScalar( ( 1.0 - metalness ) * wi.z / Math.PI / Math.PI );
+	colorTarget
+		.copy( material.color )
+		.multiplyScalar( ( 1.0 - metalness ) * wi.z / Math.PI );
 
 }
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -313,11 +313,8 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 
 	}
 
-	sampleInfo.pdf = pdf;
-
-	// TODO: how is this supposed to work?
-	// sampleInfo.pdf = bsdfPdf( wo, lightDirection, material, hit );
-	// bsdfColor( wo, lightDirection, material, hit, color );
+	sampleInfo.pdf = bsdfPdf( wo, lightDirection, material, hit );
+	bsdfColor( wo, lightDirection, material, hit, sampleInfo.color );
 
 }
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -1,4 +1,4 @@
-import { schlickFresnelReflectance, refract, getRandomUnitDirection, getHalfVector } from './utils.js';
+import { schlickFresnelFromIor, refract, getHalfVector } from './utils.js';
 import { ggxDirection, ggxPDF, ggxShadowMaskG2, ggxDistribution } from './ggxSampling.js';
 import { MathUtils, Vector3, Color } from 'three';
 
@@ -19,7 +19,7 @@ function diffusePDF( wo, wi, material, hit ) {
 
 function diffuseDirection( wo, hit, material, lightDirection ) {
 
-	getRandomUnitDirection( lightDirection );
+	lightDirection.randomDirection();
 	lightDirection.z += 1;
 	lightDirection.normalize();
 
@@ -78,7 +78,7 @@ function specularColor( wo, wi, material, hit, colorTarget ) {
 	const G = ggxShadowMaskG2( wi, wo, filteredRoughness );
 	const D = ggxDistribution( halfVector, filteredRoughness );
 
-	let F = schlickFresnelReflectance( wi.dot( halfVector ), iorRatio );
+	let F = schlickFresnelFromIor( wi.dot( halfVector ), iorRatio );
 	const cosTheta = Math.min( wo.z, 1.0 );
 	const sinTheta = Math.sqrt( 1.0 - cosTheta * cosTheta );
 	const cannotRefract = iorRatio * sinTheta > 1.0;
@@ -164,8 +164,7 @@ function transmissionDirection( wo, hit, material, lightDirection ) {
 
 	tempDir.copy( wo ).multiplyScalar( - 1 );
 	refract( tempDir, new Vector3( 0, 0, 1 ), ratio, lightDirection );
-	getRandomUnitDirection( tempDir );
-	tempDir.multiplyScalar( roughness );
+	tempDir.randomDirection().multiplyScalar( roughness );
 	lightDirection.add( tempDir );
 
 }
@@ -194,7 +193,7 @@ export function bsdfPdf( wo, wi, material, hit ) {
 	const ratio = frontFace ? 1 / ior : ior;
 	const cosTheta = Math.min( wo.z, 1.0 );
 	const sinTheta = Math.sqrt( 1.0 - cosTheta * cosTheta );
-	let reflectance = schlickFresnelReflectance( cosTheta, ratio );
+	let reflectance = schlickFresnelFromIor( cosTheta, ratio );
 	const cannotRefract = ratio * sinTheta > 1.0;
 	if ( cannotRefract ) {
 
@@ -256,7 +255,7 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 	const ratio = frontFace ? 1 / ior : ior;
 	const cosTheta = Math.min( wo.z, 1.0 );
 	const sinTheta = Math.sqrt( 1.0 - cosTheta * cosTheta );
-	let reflectance = schlickFresnelReflectance( cosTheta, ratio );
+	let reflectance = schlickFresnelFromIor( cosTheta, ratio );
 	const cannotRefract = ratio * sinTheta > 1.0;
 	if ( cannotRefract ) {
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -191,6 +191,7 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 			pdf = 1.0;
 			color
 				.copy( material.color )
+				.multiplyScalar( 1.0 - metalness )
 				.multiplyScalar( Math.abs( lightDirection.z ) );
 
 			// Color is clamped to [0, 1] to make up for incorrect PDF and over sampling
@@ -218,7 +219,6 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 			pdf = specularPDF( wo, lightDirection, material, hit );
 
 			specularColor( wo, lightDirection, material, hit, color );
-			color.multiplyScalar( lightDirection.z );
 
 			pdf *= 0.5;
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -8,7 +8,7 @@ const halfVector = new Vector3();
 const tempSpecularColor = new Color();
 const tempMetallicColor = new Color();
 const tempDiffuseColor = new Color();
-
+const whiteColor = new Color( 0xffffff );
 
 // diffuse
 function diffusePDF( wo, wi, material ) {
@@ -96,8 +96,10 @@ function transmissionDirection( wo, hit, material, lightDirection ) {
 
 }
 
-export function bsdfSample( wo, hit, material, lightDirection ) {
+export function bsdfSample( wo, hit, material, sampleInfo ) {
 
+	const lightDirection = sampleInfo.direction;
+	const color = sampleInfo.color;
 	const { ior, metalness, transmission } = material;
 	const { frontFace } = hit;
 
@@ -120,12 +122,12 @@ export function bsdfSample( wo, hit, material, lightDirection ) {
 		if ( Math.random() < specularProb ) {
 
 			specularDirection( wo, hit, material, lightDirection );
-			return metalness;
+			color.lerpColors( whiteColor, material.color, metalness );
 
 		} else {
 
 			transmissionDirection( wo, hit, material, lightDirection );
-			return 1.0;
+			color.copy( material.color );
 
 		}
 
@@ -134,12 +136,12 @@ export function bsdfSample( wo, hit, material, lightDirection ) {
 		if ( Math.random() < specularProb ) {
 
 			specularDirection( wo, hit, material, lightDirection );
-			return metalness;
+			color.lerpColors( whiteColor, material.color, metalness );
 
 		} else {
 
 			diffuseDirection( wo, hit, material, lightDirection );
-			return 1;
+			color.copy( material.color );
 
 		}
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -273,20 +273,12 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 		if ( Math.random() < specularProb ) {
 
 			specularDirection( wo, hit, material, lightDirection );
-			// pdf = specularPDF( wo, lightDirection, material, hit );
-			// specularColor( wo, lightDirection, material, hit, color );
-			// pdf *= specularProb;
 
 		} else {
 
 			transmissionDirection( wo, hit, material, lightDirection );
-			// pdf = transmissionPDF( wo, lightDirection, material, hit );
-			// transmissionColor( wo, lightDirection, material, hit, color );
-			// pdf *= ( 1.0 - specularProb );
 
 		}
-
-		// pdf *= transmission;
 
 	} else {
 
@@ -294,20 +286,12 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 		if ( Math.random() < specularProb ) {
 
 			specularDirection( wo, hit, material, lightDirection );
-			// pdf = specularPDF( wo, lightDirection, material, hit );
-			// specularColor( wo, lightDirection, material, hit, color );
-			// pdf *= specularProb;
 
 		} else {
 
 			diffuseDirection( wo, hit, material, lightDirection );
-			// pdf = diffusePDF( wo, lightDirection, material, hit );
-			// diffuseColor( wo, lightDirection, material, hit, color );
-			// pdf *= ( 1.0 - specularProb );
 
 		}
-
-		// pdf *= ( 1.0 - transmission );
 
 	}
 

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -96,7 +96,7 @@ function transmissionDirection( wo, hit, material, lightDirection ) {
 
 }
 
-export function bsdfDirection( wo, hit, material, lightDirection ) {
+export function bsdfSample( wo, hit, material, lightDirection ) {
 
 	const { ior, metalness, transmission } = material;
 	const { frontFace } = hit;

--- a/example/pathtracing/materialSampling.js
+++ b/example/pathtracing/materialSampling.js
@@ -166,6 +166,7 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 	let pdf = 0;
 	if ( Math.random() < transmission ) {
 
+		// TODO: 1.0 metalness and 1.0 transmission needs to be fixed
 		const specularProb = 0.5;//MathUtils.lerp( reflectance, 1.0, metalness );
 
 		if ( Math.random() < specularProb ) {
@@ -191,6 +192,11 @@ export function bsdfSample( wo, hit, material, sampleInfo ) {
 			color
 				.copy( material.color )
 				.multiplyScalar( Math.abs( lightDirection.z ) );
+
+			// Color is clamped to [0, 1] to make up for incorrect PDF and over sampling
+			color.r = Math.min( color.r, 1.0 );
+			color.g = Math.min( color.g, 1.0 );
+			color.b = Math.min( color.b, 1.0 );
 
 			// transmissionDirection( wo, hit, material, lightDirection );
 			// pdf = transmissionPDF( wo, lightDirection, material, hit );

--- a/example/pathtracing/utils.js
+++ b/example/pathtracing/utils.js
@@ -41,9 +41,10 @@ export function refract( dir, norm, iorRatio, target ) {
 
 }
 
+// forms a basis with the normal vector as Z
 export function getBasisFromNormal( normal, targetMatrix ) {
 
-	if ( normal.x > 0.5 ) {
+	if ( Math.abs( normal.x ) > 0.5 ) {
 
 		tempVector.set( 0, 1, 0 );
 
@@ -53,8 +54,8 @@ export function getBasisFromNormal( normal, targetMatrix ) {
 
 	}
 
-	tempVector1.crossVectors( normal, tempVector );
-	tempVector2.crossVectors( normal, tempVector1 );
+	tempVector1.crossVectors( normal, tempVector ).normalize();
+	tempVector2.crossVectors( normal, tempVector1 ).normalize();
 	targetMatrix.makeBasis( tempVector2, tempVector1, normal );
 
 }

--- a/example/pathtracing/utils.js
+++ b/example/pathtracing/utils.js
@@ -26,6 +26,8 @@ export function schlickFresnelReflectance( cosine, iorRatio ) {
 
 	// Schlick approximation
 	const r0 = Math.pow( ( 1 - iorRatio ) / ( 1 + iorRatio ), 2 );
+
+	// https://google.github.io/filament/Filament.md.html#materialsystem/diffusebrdf
 	return r0 + ( 1 - r0 ) * Math.pow( 1.0 - cosine, 5 );
 
 }

--- a/example/pathtracing/utils.js
+++ b/example/pathtracing/utils.js
@@ -15,6 +15,13 @@ export const ANTIALIAS_OFFSETS = [
 	[ - 8, 0 ], [ 7, - 4 ], [ 6, 7 ], [ - 7, - 8 ],
 ];
 
+export function schlickFresnel( cosine, f0 ) {
+
+	// https://google.github.io/filament/Filament.md.html#materialsystem/diffusebrdf
+	return f0 + ( 1.0 - f0 ) * Math.pow( 1.0 - cosine, 5.0 );
+
+}
+
 export function schlickFresnelReflectance( cosine, iorRatio ) {
 
 	// Schlick approximation

--- a/example/pathtracing/utils.js
+++ b/example/pathtracing/utils.js
@@ -75,6 +75,7 @@ export function getHalfVector( a, b, target ) {
 
 }
 
+// from three.js
 export function getRandomUnitDirection( target ) {
 
 	const u = ( Math.random() - 0.5 ) * 2;
@@ -86,5 +87,17 @@ export function getRandomUnitDirection( target ) {
 	target.z = u;
 
 	return target;
+
+}
+
+// The discrepancy between interpolated surface normal and geometry normal can cause issues when a ray
+// is cast that is on the top side of the geometry normal plane but below the surface normal plane. If
+// we find a ray like that we ignore it to avoid artifacts.
+// This function returns if the direction is on the same side of both planes.
+export function isDirectionValid( direction, surfaceNormal, geometryNormal ) {
+
+	const aboveSurfaceNormal = direction.dot( surfaceNormal ) > 0;
+	const aboveGeometryNormal = direction.dot( geometryNormal ) > 0;
+	return aboveSurfaceNormal === aboveGeometryNormal;
 
 }

--- a/example/pathtracing/utils.js
+++ b/example/pathtracing/utils.js
@@ -15,20 +15,19 @@ export const ANTIALIAS_OFFSETS = [
 	[ - 8, 0 ], [ 7, - 4 ], [ 6, 7 ], [ - 7, - 8 ],
 ];
 
+// https://google.github.io/filament/Filament.md.html#materialsystem/diffusebrdf
 export function schlickFresnel( cosine, f0 ) {
 
-	// https://google.github.io/filament/Filament.md.html#materialsystem/diffusebrdf
 	return f0 + ( 1.0 - f0 ) * Math.pow( 1.0 - cosine, 5.0 );
 
 }
 
-export function schlickFresnelReflectance( cosine, iorRatio ) {
+// https://raytracing.github.io/books/RayTracingInOneWeekend.html#dielectrics/schlickapproximation
+export function schlickFresnelFromIor( cosine, iorRatio ) {
 
 	// Schlick approximation
 	const r0 = Math.pow( ( 1 - iorRatio ) / ( 1 + iorRatio ), 2 );
-
-	// https://google.github.io/filament/Filament.md.html#materialsystem/diffusebrdf
-	return r0 + ( 1 - r0 ) * Math.pow( 1.0 - cosine, 5 );
+	return schlickFresnel( cosine, r0 );
 
 }
 
@@ -72,21 +71,6 @@ export function getBasisFromNormal( normal, targetMatrix ) {
 export function getHalfVector( a, b, target ) {
 
 	return target.addVectors( a, b ).normalize();
-
-}
-
-// from three.js
-export function getRandomUnitDirection( target ) {
-
-	const u = ( Math.random() - 0.5 ) * 2;
-	const t = Math.random() * Math.PI * 2;
-	const f = Math.sqrt( 1 - u ** 2 );
-
-	target.x = f * Math.cos( t );
-	target.y = f * Math.sin( t );
-	target.z = u;
-
-	return target;
 
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14267,9 +14267,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.132.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.132.2.tgz",
-      "integrity": "sha512-0wcR7LxxkXMn6Gi58gEs3QvY8WpTVXA31L2VOvpjm4ZPYFRHCZC13UqynheFoS5OXDYgtBneN0dhbaNBE8iLhQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.133.0.tgz",
+      "integrity": "sha512-1p8xTXnJD4hMM2Ktm7+FqOOBoImBoftKnKtAZT/b9AQeL3LhRkVu/HnIJhWA69qIMvUYpjfnunNsO4WdObw1ZQ==",
       "dev": true
     },
     "throat": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "simplex-noise": "^2.4.0",
     "static-server": "^2.2.1",
     "stats.js": "^0.17.0",
-    "three": "^0.132.0"
+    "three": "^0.133.0"
   },
   "dependencies": {}
 }

--- a/src/workers/GenerateMeshBVHWorker.js
+++ b/src/workers/GenerateMeshBVHWorker.js
@@ -1,4 +1,4 @@
-import { Box3 } from 'three';
+import { Box3, BufferAttribute } from 'three';
 import { MeshBVH } from '../core/MeshBVH.js';
 
 export class GenerateMeshBVHWorker {
@@ -48,6 +48,11 @@ export class GenerateMeshBVHWorker {
 					if ( geometry.index ) {
 
 						geometry.index.array = serialized.index;
+
+					} else {
+
+						const newIndex = new BufferAttribute( serialized.index, 1, false );
+						geometry.setIndex( newIndex );
 
 					}
 


### PR DESCRIPTION
Related to #291 

**TODO**
- [ ] ~Apply cosine attenuation to specular as well as diffuse? (do it outside of sampling functions)~
- [ ] ~fix scenario where we could have a normal of (0, 0, 0)~ (handled with the case of the PDF being 0)
- [ ] ~Include rover model?~
- [x] Cleanup / comments
- [x] Fix SDS rays / hot spots
  - hits diffuse surface at high reflectance spot, then specular surface which hits light directly
  - accumulate a roughness to use -- use max roughness found during traversal? Or some scaling factor of it
  - See discussion on Blender's solution [here](https://github.com/hoverinc/ray-tracing-renderer/issues/12#issuecomment-531613711)
  - Determine if a ray is "rough" based on its dot from the perfect specular ray b/c even if a surface is smooth there are still diffuse rays that get used
- [x] Fix normals issue for translucent model + direct light sampling
- [x] Pick models to use
- [x] * ~Don't have a separate branch for hitting a light? Need to take direct light sampling branch and direct hit branch when looking at next hit?~
- [x] multiple importance sampling
- [x] * Account for light leaking with shading normals that are inconsistent with geometry normals (see [here](https://www.pbr-book.org/3ed-2018/Materials/BSDFs)) (fixed by checking if hits go below tangent / pdf <= 0)
- [x] * Fix the direct light sampling-only case with Cornell Box because there seem to be a lot of incorrect gray / white pixels
- [x] Implement area light sampling
- [x] * Blend both diffuse and specular in a single pass
- [x] Add cornell box scene
- [x] Add ability to change floor material (and add floor to engine scene)
- [x] * Convert path tracing iteration to use a for loop
- [x] * Improved importance sampling for ray selection
- [x] * Unpack material properties in the "hit" object so we can avoid redundant calculations
- [x] * Add comment and link for 1 / PI term
- [x] * understand 1/PI term for lambert
- [x] ~Lower fresnel value to 0.1~
- [x] ~Add transmission specular function~
- [x] * Fix black pixels (NaNs, below the surface, in weird gap between surface and geom normal, ignore negative / 0 pdfs)
- [x] * fix fresnel term to use ggx sampled normal rather than vertex normal (validate function implementations, see [link](https://boksajak.github.io/blog/BRDF))
    - Switch to use just diffuse / specular for debugging
    - Switch to use the approach to divide out the PDF initially then handle both diffuse and specular together
    - https://learnopengl.com/PBR/Theory
    - https://graphics.stanford.edu/courses/cs348b-01/course29.hanrahan.pdf
- [x] * rearchitect material color sampling
- [x] * convert all functions to operate under the assumption that incoming and outgoing vectors are specified in a local normal basis frame
- [x] reconsider scaling the number of samples by roughness directly because diffuse is still included in the samples.
- [x] Implement GGX microfacet model ([paper](https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf), [link1](https://schuttejoe.github.io/post/ggximportancesamplingpart1/), [link 2](https://schuttejoe.github.io/post/ggximportancesamplingpart2/), [link 3](https://computergraphics.stackexchange.com/questions/7656/importance-sampling-microfacet-ggx/7662), [sample implementation](https://hal.archives-ouvertes.fr/hal-01509746/document))
- [x] *Scale the number of subsequent rays cast per pixel base on needs (highly / sharply reflective surfaces need fewer)
- [x] Fix random direction sampling
- [x] Comments
- [x] Included fresnel effect (see [here](https://www.pbr-book.org/3ed-2018/Reflection_Models/Specular_Reflection_and_Transmission), [here](https://www.pbr-book.org/3ed-2018/Reflection_Models/Fresnel_Incidence_Effects))
- [x] Implement translucent material w/ internal reflection
- [x] Sample materials properties in the raytrace
- [x] Add EPSILON back (and add back face checks, as well. If the material is not translucent then return black)
- [x] add sphere example (for translucency)
- [x] AA is blurry?
- [x] Strange edge / rim / silhouette highlight on the edges of models (seems to be related to smooth normals)
- [x] high emissive value invalidates the antialiasing strategy -- maybe clamp the result before writing to the buffer 
- [x] Allow for selecting another model
- [x] Stratified AA
- [x] ability to pause sampling
- [x] add render duration, finished samples stats
- [x] Allow for dimming the sky box
- [x] Implement multiple bounces

**ISSUES**

- [x] Fix occasional fireflies
- [x] Fix case where ior === 1.0 and there are black dots
- [x] Black pixels on edges with highly reflective surface? (0 metalness, 0 roughness)
- [x] "SmoothNormals" makes translucency look odd
- [x] Black samples around the edge of the sphere (seems to be from retrieving back faces?)

**TO READ**
- http://graphics.stanford.edu/papers/veach_thesis/
- http://jcgt.org/published/0007/04/01/slides.pdf
- https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.pdf
- https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.html
- https://www.scratchapixel.com/lessons/3d-basic-rendering/global-illumination-path-tracing/global-illumination-path-tracing-practical-implementation
- https://www.racoon-artworks.de/cgbasics/fresnel.php
- PBR book chapters ~5~, ~8~, 9, 13, 14, 15, 16


**Next**
- #333
- Fix GGX translucency
- global fog (with distance limit for sampling sky?)
- Model internal absorption for transmissive materials

**Future**
- Multiple stratified samples per hit
- Denoising (https://alain.xyz/blog/ray-tracing-denoising)
- Minimize computation where possible (specifically precompute some randomness per frame)
- Add "russian roulette" termination ([link](https://computergraphics.stackexchange.com/questions/2316/is-russian-roulette-really-the-answer/5808))
- Better sampling approaches ([video 1](https://www.youtube.com/watch?v=TbWQ4lMnLNw), [video 2](https://www.youtube.com/watch?v=oHLR287rDRA), bidirectional tracing, multiple importance sampling)
- Better normal distribution function ([link 1](https://dqlin.xyz/tech/2016/12/03/03_render/), [link 2](https://raytracing.github.io/books/RayTracingTheRestOfYourLife.html#generatingrandomdirections), [link 3](https://google.github.io/filament/Filament.html#materialsystem/standardmodelsummary))
- Implement depth of field
- Textures
- Spectrum class, dispersion
- refract through surfaces to the light to get caustics more quickly?
- Allow for moving the area light
- Better microfacet modeling? (see [here](https://www.pbr-book.org/3ed-2018/Reflection_Models/Microfacet_Models))
- Use stratified samples for ray bounces (how?)
- Next Event Estimation (https://cs.dartmouth.edu/~wjarosz/publications/koerner16subdivision-slides.pdf) (same as direct light sampling?)
- Improve viability / performance of generating an SAH BVH for the engine model (right now it takes a very long time) (see #286)

<details>
<summary>Notes</summary>

- Weight of light contribution to point diminishes with angle
- Use a cosine weighted hemisphere sampling to better align with light accumulation at point

</details>

**Other Papers**
- http://www.graphics.cornell.edu/pubs/2005/Wal05.pdf
- http://jcgt.org/published/0007/04/01/paper.pdf
- https://www.gdcvault.com/play/1024478/PBR-Diffuse-Lighting-for-GGX
- https://computergraphics.stackexchange.com/questions/7650/is-the-microfacet-ggx-bsdf-normally-implemented-as-separate-brdf-and-btdfs
- https://rgl.s3.eu-central-1.amazonaws.com/media/papers/Zeltner2020Specular.pdf