### PR TITLE
Make MeshBVH.closestPointToPoint, closestPointToGeometry return more info

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,27 +336,25 @@ Performance improves considerably if the provided geometry _also_ has a `boundsT
 ```js
 closestPointToPoint(
 	point : Vector3,
-	target : Vector3,
+	target : Object = { },
 	minThreshold : Number = 0,
 	maxThreshold : Number = Infinity
 ) : Number
 ```
 
-Returns the closest distance from the point to the mesh and puts the closest point on the mesh in `target`.
+Computes the closest distance from the point to the mesh and gives additional information in `target`. The target can be left undefined to default to a new object.
 
 If a point is found that is closer than `minThreshold` then the function will return that result early. Any triangles or points outside of `maxThreshold` are ignored.
 
-### .distanceToPoint
-
 ```js
-distanceToPoint(
+target : {
 	point : Vector3,
-	minThreshold : Number = 0,
-	maxThreshold : Number = Infinity
-) : Number
+	distance : Number,
+	faceIndex: Number
+}
 ```
 
-Convenience function for just getting the distance returned by calling [closestPointToPoint](#closestPointToPoint).
+The returned faceIndex can be used with the standalone function [getTriangleHitPointInfo](#getTriangleHitPointInfo) to obtain more information like UV coordinates, triangle normal and materialIndex.
 
 ### .closestPointToGeometry
 
@@ -371,26 +369,17 @@ closestPointToGeometry(
 ) : Number
 ```
 
-Returns the closest distance from the geometry to the mesh and puts the closest point on the mesh in `target1` and the closest point on the other geometry in `target2` in the frame of the BVH.
+Computes the closest distance from the geometry to the mesh and puts the closest point on the mesh in `target1` (in the frame of the BVH) and the closest point on the other geometry in `target2` (in the geometry frame).
 
 The `geometryToBvh` parameter is the transform of the geometry in the mesh's frame.
 
 If a point is found that is closer than `minThreshold` then the function will return that result early. Any triangles or points outside of `maxThreshold` are ignored.
 
+`target1` and `target2` are optional objects equal to the `target` parameter in [closestPointPoint](#closestPointToPoint)
+
+The returned in `target1` and `target2` can be used with the standalone function [getTriangleHitPointInfo](#getTriangleHitPointInfo) to obtain more information like UV coordinates, triangle normal and materialIndex.
+
 _Note that this function can be very slow if `geometry` does not have a `geometry.boundsTree` computed._
-
-### .distanceToGeometry
-
-```js
-distanceToGeometry(
-	geometry : BufferGeometry,
-	geometryToBvh : Matrix4,
-	minThreshold : Number = 0,
-	maxThreshold : Number = Infinity
-) : Number
-```
-
-Convenience function for just getting the distance returned by calling [closestPointToGeometry](#closestPointToGeometry).
 
 ### .shapecast
 
@@ -498,6 +487,41 @@ getBoundingBox( target : Box3 ) : Box3
 ```
 
 Get the bounding box of the geometry computed from the root node bounds of the BVH. Significantly faster than `BufferGeometry.computeBoundingBox`.
+
+### getTriangleHitPointInfo
+
+```js
+getTriangleHitPointInfo(
+	point: Vector3,
+	geometry : BufferGeometry,
+	triangleIndex: Number
+	target: Object
+): Object
+```
+
+This function returns information of a point related to a geometry. It returns the `target` object or a new one if passed `undefined`:
+
+```js
+target : {
+	point: Vector3,
+	face: {
+		a: Number,
+		b: Number,
+		c: Number,
+		materialIndex: Number,
+		normal: Vector3
+	},
+	uv: Vector2
+}
+```
+
+- `point`: The same point
+- `a`, `b`, `c`: Triangle indices
+- `materialIndex`: Face material index or 0 if not available.
+- `normal`: Face normal
+- `uv`: UV coordinates.
+
+This function would normally be used after a call to [closestPointPoint](#closestPointToPoint) or [closestPointToGeometry](#closestPointToGeometry).
 
 ## SerializedBVH
 

--- a/benchmark/run-benchmark.js
+++ b/benchmark/run-benchmark.js
@@ -18,8 +18,8 @@ box.min.set( 1, 1, 1 );
 const intersectGeometry = new THREE.TorusBufferGeometry( 5, 5, 100, 50 );
 const geomMat = new THREE.Matrix4().compose( new THREE.Vector3(), new THREE.Quaternion(), new THREE.Vector3( 0.1, 0.1, 0.1 ) );
 
-const target1 = new THREE.Vector3();
-const target2 = new THREE.Vector3();
+const target1 = undefined;
+const target2 = undefined;
 
 const geometry = new THREE.TorusBufferGeometry( 5, 5, 700, 300 );
 const mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial() );

--- a/benchmark/run-benchmark.js
+++ b/benchmark/run-benchmark.js
@@ -18,8 +18,8 @@ box.min.set( 1, 1, 1 );
 const intersectGeometry = new THREE.TorusBufferGeometry( 5, 5, 100, 50 );
 const geomMat = new THREE.Matrix4().compose( new THREE.Vector3(), new THREE.Quaternion(), new THREE.Vector3( 0.1, 0.1, 0.1 ) );
 
-const target1 = undefined;
-const target2 = undefined;
+const target1 = {};
+const target2 = {};
 
 const geometry = new THREE.TorusBufferGeometry( 5, 5, 700, 300 );
 const mesh = new THREE.Mesh( geometry, new THREE.MeshBasicMaterial() );

--- a/benchmark/run-benchmark.js
+++ b/benchmark/run-benchmark.js
@@ -255,7 +255,7 @@ function runSuite( strategy ) {
 
 		'DistanceToGeometry w/ BVH',
 		null,
-		() => mesh.geometry.boundsTree.closestPointToGeometry( intersectGeometry, geomMat, target1, target2 ),
+		() => mesh.geometry.boundsTree.closestPointToGeometry( intersectGeometry, geomMat, target1, target2 ).distance,
 		3000
 
 	);
@@ -265,7 +265,7 @@ function runSuite( strategy ) {
 
 		'DistanceToPoint',
 		null,
-		() => mesh.geometry.boundsTree.closestPointToPoint( vec, target1 ),
+		() => mesh.geometry.boundsTree.closestPointToPoint( vec, target1 ).distance,
 		3000
 
 	);

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -884,7 +884,7 @@ export class MeshBVH {
 			if ( ! target2.point ) target2.point = tempTargetDest2.clone();
 			else target2.point.copy( tempTargetDest2 );
 			target2.point.applyMatrix4( tempMatrix );
-			tempTargetDest1.applyMatrix4( tempMatrix )
+			tempTargetDest1.applyMatrix4( tempMatrix );
 			target2.distance = tempTargetDest1.sub( target2.point ).length();
 			target2.faceIndex = closestDistanceOtherTriIndex;
 

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -1128,7 +1128,7 @@ export class MeshBVH {
 			target.face.b = b;
 			target.face.c = c;
 			target.face.materialIndex = 0;
-			if ( ! target.face.normal ) target.face.normal  = new Vector3();
+			if ( ! target.face.normal ) target.face.normal = new Vector3();
 			Triangle.getNormal( tempV1, tempV2, tempV3, target.face.normal );
 			if ( ! target.uv ) target.uv = new Vector2();
 			target.uv.copy( uv );

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -970,8 +970,7 @@ export class MeshBVH {
 			if ( target2 ) target2.copy( tempTargetDest2 );
 			return closestDistance;
 
-		}
-		else {
+		} else {
 
 			if ( target1 ) {
 
@@ -1120,8 +1119,7 @@ export class MeshBVH {
 
 			return target;
 
-		}
-		else {
+		} else {
 
 			return {
 

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -1,4 +1,4 @@
-import { Vector2, Vector3, BufferAttribute, Box3, FrontSide, Matrix4, Triangle } from 'three';
+import { Vector3, BufferAttribute, Box3, FrontSide, Matrix4 } from 'three';
 import { CENTER } from './Constants.js';
 import { BYTES_PER_NODE, IS_LEAFNODE_FLAG, buildPackedTree } from './buildFunctions.js';
 import {

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -916,7 +916,9 @@ export class MeshBVH {
 			tempV2.fromBufferAttribute( positions1, b1 );
 			tempV3.fromBufferAttribute( positions1, c1 );
 
-			normal1 = Triangle.getNormal( tempV1, tempV2, tempV3, new Vector3() );
+			if ( target1.face && target1.face.normal ) normal1 = target1.face.normal;
+			else normal1 = new Vector3();
+			Triangle.getNormal( tempV1, tempV2, tempV3, normal1 );
 
 			if ( uvs1 ) {
 
@@ -924,7 +926,9 @@ export class MeshBVH {
 				tempUV2.fromBufferAttribute( uvs1, b1 );
 				tempUV3.fromBufferAttribute( uvs1, c1 );
 
-				uv1 = Triangle.getUV( tempTargetDest1, tempV1, tempV2, tempV3, tempUV1, tempUV2, tempUV3, new Vector2() );
+				if ( target1.uv ) uv1 = target1.uv;
+				else uv1 = new Vector2();
+				Triangle.getUV( tempTargetDest1, tempV1, tempV2, tempV3, tempUV1, tempUV2, tempUV3, uv1 );
 
 			}
 
@@ -950,7 +954,9 @@ export class MeshBVH {
 			tempV2.fromBufferAttribute( positions2, b2 );
 			tempV3.fromBufferAttribute( positions2, c2 );
 
-			normal2 = Triangle.getNormal( tempV1, tempV2, tempV3, new Vector3() );
+			if ( target2.face && target2.face.normal ) normal2 = target2.face.normal;
+			else normal2 = new Vector3();
+			Triangle.getNormal( tempV1, tempV2, tempV3, normal2 );
 
 			if ( uvs2 ) {
 
@@ -958,7 +964,9 @@ export class MeshBVH {
 				tempUV2.fromBufferAttribute( uvs2, b2 );
 				tempUV3.fromBufferAttribute( uvs2, c2 );
 
-				uv2 = Triangle.getUV( tempTargetDest2, tempV1, tempV2, tempV3, tempUV1, tempUV2, tempUV3, new Vector2() );
+				if ( target2.uv ) uv2 = target2.uv;
+				else uv2 = new Vector2();
+				Triangle.getUV( tempTargetDest2, tempV1, tempV2, tempV3, tempUV1, tempUV2, tempUV3, uv2 );
 
 			}
 
@@ -974,28 +982,30 @@ export class MeshBVH {
 
 			if ( target1 ) {
 
-				target1.point = tempTargetDest1.clone();
+				if ( ! target1.point ) target1.point = new Vector3();
+				target1.point.copy( tempTargetDest1 );
 				target1.distance = closestDistance;
 				if ( ! target1.face ) target1.face = { };
 				target1.face.a = a1;
 				target1.face.b = b1;
 				target1.face.c = c1;
-				target1.materialIndex = 0;
-				target1.normal = normal1;
+				target1.face.materialIndex = 0;
+				target1.face.normal = normal1;
 				target1.uv = uv1;
 
 			}
 
 			if ( target2 ) {
 
-				target2.point = tempTargetDest2.clone();
+				if ( ! target2.point ) target2.point = new Vector3();
+				target2.point.copy( tempTargetDest2 );
 				target2.distance = closestDistance;
 				if ( ! target2.face ) target2.face = { };
 				target2.face.a = a2;
 				target2.face.b = b2;
 				target2.face.c = c2;
-				target2.materialIndex = 0;
-				target2.normal = normal2;
+				target2.face.materialIndex = 0;
+				target2.face.normal = normal2;
 				target2.uv = uv2;
 
 			}
@@ -1095,7 +1105,9 @@ export class MeshBVH {
 			tempUV2.fromBufferAttribute( uvs, b );
 			tempUV3.fromBufferAttribute( uvs, c );
 
-			uv = Triangle.getUV( temp1, tempV1, tempV2, tempV3, tempUV1, tempUV2, tempUV3, new Vector2() );
+			if ( target && target.uv ) uv = target.uv;
+			else uv = new Vector2();
+			Triangle.getUV( temp1, tempV1, tempV2, tempV3, tempUV1, tempUV2, tempUV3, uv );
 
 		}
 
@@ -1108,14 +1120,18 @@ export class MeshBVH {
 
 			}
 
-			target.point = temp1.clone();
+			if ( ! target.point ) target.point = new Vector3();
+			target.point.copy( temp1 );
 			target.distance = closestDistance;
 			if ( ! target.face ) target.face = { };
 			target.face.a = a;
 			target.face.b = b;
 			target.face.c = c;
-			target.materialIndex = 0;
-			target.normal = Triangle.getNormal( tempV1, tempV2, tempV3, new Vector3() );
+			target.face.materialIndex = 0;
+			if ( ! target.face.normal ) target.face.normal  = new Vector3();
+			Triangle.getNormal( tempV1, tempV2, tempV3, target.face.normal );
+			if ( ! target.uv ) target.uv = new Vector2();
+			target.uv.copy( uv );
 
 			return target;
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,4 @@ export { MeshBVHVisualizer } from './objects/MeshBVHVisualizer.js';
 export { CENTER, AVERAGE, SAH, NOT_INTERSECTED, INTERSECTED, CONTAINED } from './core/Constants.js';
 export { getBVHExtremes, estimateMemoryInBytes, getJSONStructure, validateBounds } from './debug/Debug.js';
 export { acceleratedRaycast, computeBoundsTree, disposeBoundsTree } from './utils/ExtensionUtilities.js';
+export { getTriangleHitPointInfo } from './utils/TriangleUtilities.js';

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -115,11 +115,11 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 		target.uv.copy( uv );
 
 		return target;
-	}
-	else {
 
+	}
+	else {
 		return {
-			point: point.clone(),
+		point: point.clone(),
 			distance: 0,
 			face: {
 				a: a,

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -1,5 +1,5 @@
 
-import { Vector2, Vector3 } from 'three';
+import { Vector2, Vector3, Triangle } from 'three';
 
 // sets the vertices of triangle `tri` with the 3 vertices after i
 export function setTriangle( tri, i, index, pos ) {

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -100,7 +100,7 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 	if ( target ) {
 
 		if ( ! target.point ) target.point = new Vector3();
-		target.point.copy( temp1 );
+		target.point.copy( point );
 
 		if ( ! target.face ) target.face = { };
 		target.face.a = a;
@@ -116,8 +116,8 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 
 		return target;
 
-	}
-	else {
+	} else {
+
 		return {
 			point: point.clone(),
 			distance: 0,

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -119,7 +119,7 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 	}
 	else {
 		return {
-		point: point.clone(),
+			point: point.clone(),
 			distance: 0,
 			face: {
 				a: a,

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -120,7 +120,6 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 
 		return {
 			point: point.clone(),
-			distance: 0,
 			face: {
 				a: a,
 				b: b,

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -1,3 +1,6 @@
+
+import { Vector2, Vector3 } from 'three';
+
 // sets the vertices of triangle `tri` with the 3 vertices after i
 export function setTriangle( tri, i, index, pos ) {
 
@@ -56,5 +59,78 @@ export function iterateOverTriangles(
 	}
 
 	return false;
+
+}
+
+const tempV1 = /* @__PURE__ */ new Vector3();
+const tempV2 = /* @__PURE__ */ new Vector3();
+const tempV3 = /* @__PURE__ */ new Vector3();
+const tempUV1 = /* @__PURE__ */ new Vector2();
+const tempUV2 = /* @__PURE__ */ new Vector2();
+const tempUV3 = /* @__PURE__ */ new Vector2();
+
+export function getTriangleHitPointInfo( point, geometry, triangleIndex, target ) {
+
+	const indices = geometry.getIndex().array;
+	const positions = geometry.getAttribute( 'position' );
+	const uvs = geometry.getAttribute( 'uv' );
+
+	const a = indices[ triangleIndex * 3 ];
+	const b = indices[ triangleIndex * 3 + 1 ];
+	const c = indices[ triangleIndex * 3 + 2 ];
+
+	tempV1.fromBufferAttribute( positions, a );
+	tempV2.fromBufferAttribute( positions, b );
+	tempV3.fromBufferAttribute( positions, c );
+
+	let uv = null;
+	if ( uvs ) {
+
+		tempUV1.fromBufferAttribute( uvs, a );
+		tempUV2.fromBufferAttribute( uvs, b );
+		tempUV3.fromBufferAttribute( uvs, c );
+
+		if ( target && target.uv ) uv = target.uv;
+		else uv = new Vector2();
+
+		Triangle.getUV( point, tempV1, tempV2, tempV3, tempUV1, tempUV2, tempUV3, uv );
+
+	}
+
+	if ( target ) {
+
+		if ( ! target.point ) target.point = new Vector3();
+		target.point.copy( temp1 );
+
+		if ( ! target.face ) target.face = { };
+		target.face.a = a;
+		target.face.b = b;
+		target.face.c = c;
+		target.face.materialIndex = 0;
+		if ( ! target.face.normal ) target.face.normal = new Vector3();
+		Triangle.getNormal( tempV1, tempV2, tempV3, target.face.normal );
+
+		target.distance = 0;
+		if ( ! target.uv ) target.uv = new Vector2();
+		target.uv.copy( uv );
+
+		return target;
+	}
+	else {
+
+		return {
+			point: point.clone(),
+			distance: 0,
+			face: {
+				a: a,
+				b: b,
+				c: c,
+				materialIndex: 0,
+				normal: Triangle.getNormal( tempV1, tempV2, tempV3, new Vector3() )
+			},
+			uv: uv
+		};
+
+	}
 
 }

--- a/test/ShapeCasts.test.js
+++ b/test/ShapeCasts.test.js
@@ -549,7 +549,7 @@ function runSuiteWithOptions( defaultOptions ) {
 
 		it( 'should return the radius if at the center of the geometry', () => {
 
-			const dist = bvh.closestPointToPoint( new Vector3(), target ).distance;
+			const dist = bvh.closestPointToPoint( new Vector3(), target );
 			expect( dist ).toBeLessThanOrEqual( 1 );
 			expect( dist ).toBeGreaterThanOrEqual( 1 - EPSILON );
 
@@ -557,7 +557,7 @@ function runSuiteWithOptions( defaultOptions ) {
 
 		it( 'should return 0 if on the surface of the geometry', () => {
 
-			const dist = bvh.closestPointToPoint( new Vector3( 0, 1, 0 ), target ).distance;
+			const dist = bvh.closestPointToPoint( new Vector3( 0, 1, 0 ), target );
 			expect( dist ).toBe( 0 );
 
 		} );
@@ -575,7 +575,7 @@ function runSuiteWithOptions( defaultOptions ) {
 				vec.normalize().multiplyScalar( length );
 
 				const expectedDist = Math.abs( 1 - length );
-				const dist = bvh.closestPointToPoint( vec, target ).distance;
+				const dist = bvh.closestPointToPoint( vec, target );
 				expect( dist ).toBeLessThanOrEqual( expectedDist + EPSILON );
 				expect( dist ).toBeGreaterThanOrEqual( expectedDist - EPSILON );
 
@@ -615,7 +615,7 @@ function runSuiteWithOptions( defaultOptions ) {
 					new Quaternion(),
 					new Vector3( 0.001, 0.001, 0.001 )
 				);
-			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 ).distance;
+			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
 			expect( dist ).toBeLessThanOrEqual( 1 );
 			expect( dist ).toBeGreaterThanOrEqual( 1 - EPSILON );
 
@@ -629,7 +629,7 @@ function runSuiteWithOptions( defaultOptions ) {
 					new Quaternion(),
 					new Vector3( 0.1, 0.1, 0.1 )
 				);
-			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 ).distance;
+			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
 			expect( dist ).toBe( 0 );
 
 		} );
@@ -659,7 +659,7 @@ function runSuiteWithOptions( defaultOptions ) {
 
 				const distToCenter = Math.abs( 1 - length );
 				const expectedDist = distToCenter < radius ? 0 : distToCenter - radius;
-				const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 ).distance;
+				const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
 				expect( dist ).toBeLessThanOrEqual( expectedDist + EPSILON );
 				expect( dist ).toBeGreaterThanOrEqual( expectedDist - EPSILON );
 

--- a/test/ShapeCasts.test.js
+++ b/test/ShapeCasts.test.js
@@ -549,7 +549,7 @@ function runSuiteWithOptions( defaultOptions ) {
 
 		it( 'should return the radius if at the center of the geometry', () => {
 
-			const dist = bvh.closestPointToPoint( new Vector3(), target );
+			const dist = bvh.closestPointToPoint( new Vector3(), target ).distance;
 			expect( dist ).toBeLessThanOrEqual( 1 );
 			expect( dist ).toBeGreaterThanOrEqual( 1 - EPSILON );
 
@@ -557,7 +557,7 @@ function runSuiteWithOptions( defaultOptions ) {
 
 		it( 'should return 0 if on the surface of the geometry', () => {
 
-			const dist = bvh.closestPointToPoint( new Vector3( 0, 1, 0 ), target );
+			const dist = bvh.closestPointToPoint( new Vector3( 0, 1, 0 ), target ).distance;
 			expect( dist ).toBe( 0 );
 
 		} );
@@ -575,7 +575,7 @@ function runSuiteWithOptions( defaultOptions ) {
 				vec.normalize().multiplyScalar( length );
 
 				const expectedDist = Math.abs( 1 - length );
-				const dist = bvh.closestPointToPoint( vec, target );
+				const dist = bvh.closestPointToPoint( vec, target ).distance;
 				expect( dist ).toBeLessThanOrEqual( expectedDist + EPSILON );
 				expect( dist ).toBeGreaterThanOrEqual( expectedDist - EPSILON );
 
@@ -615,7 +615,7 @@ function runSuiteWithOptions( defaultOptions ) {
 					new Quaternion(),
 					new Vector3( 0.001, 0.001, 0.001 )
 				);
-			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
+			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 ).distance;
 			expect( dist ).toBeLessThanOrEqual( 1 );
 			expect( dist ).toBeGreaterThanOrEqual( 1 - EPSILON );
 
@@ -629,7 +629,7 @@ function runSuiteWithOptions( defaultOptions ) {
 					new Quaternion(),
 					new Vector3( 0.1, 0.1, 0.1 )
 				);
-			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
+			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 ).distance;
 			expect( dist ).toBe( 0 );
 
 		} );
@@ -659,7 +659,7 @@ function runSuiteWithOptions( defaultOptions ) {
 
 				const distToCenter = Math.abs( 1 - length );
 				const expectedDist = distToCenter < radius ? 0 : distToCenter - radius;
-				const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
+				const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 ).distance;
 				expect( dist ).toBeLessThanOrEqual( expectedDist + EPSILON );
 				expect( dist ).toBeGreaterThanOrEqual( expectedDist - EPSILON );
 

--- a/test/ShapeCasts.test.js
+++ b/test/ShapeCasts.test.js
@@ -537,7 +537,7 @@ function runSuiteWithOptions( defaultOptions ) {
 		// not being perfectly round
 		const EPSILON = 0.001;
 		let bvh = null;
-		let target = null;
+		let target = undefined;
 
 		beforeAll( () => {
 
@@ -591,15 +591,14 @@ function runSuiteWithOptions( defaultOptions ) {
 
 		let geometry = null;
 		let bvh = null;
-		let target1 = null;
-		let target2 = null;
+		let target1 = undefined;
+		let target2 = undefined;
 
 		beforeEach( () => {
 
 			const geom = new SphereBufferGeometry( 1, 20, 20 );
 			bvh = new MeshBVH( geom, { verbose: false } );
 
-			target1 = null;
 			target2 = { };
 
 			geometry = new SphereBufferGeometry( 1, 5, 5 );

--- a/test/ShapeCasts.test.js
+++ b/test/ShapeCasts.test.js
@@ -543,13 +543,13 @@ function runSuiteWithOptions( defaultOptions ) {
 
 			const geom = new SphereBufferGeometry( 1, 200, 200 );
 			bvh = new MeshBVH( geom, { verbose: false } );
-			target = new Vector3();
 
 		} );
 
 		it( 'should return the radius if at the center of the geometry', () => {
 
-			const dist = bvh.closestPointToPoint( new Vector3(), target );
+			target = bvh.closestPointToPoint( new Vector3(), target );
+			const dist = target.distance;
 			expect( dist ).toBeLessThanOrEqual( 1 );
 			expect( dist ).toBeGreaterThanOrEqual( 1 - EPSILON );
 
@@ -557,7 +557,8 @@ function runSuiteWithOptions( defaultOptions ) {
 
 		it( 'should return 0 if on the surface of the geometry', () => {
 
-			const dist = bvh.closestPointToPoint( new Vector3( 0, 1, 0 ), target );
+			target = bvh.closestPointToPoint( new Vector3( 0, 1, 0 ), target );
+			const dist = target.distance;
 			expect( dist ).toBe( 0 );
 
 		} );
@@ -575,7 +576,8 @@ function runSuiteWithOptions( defaultOptions ) {
 				vec.normalize().multiplyScalar( length );
 
 				const expectedDist = Math.abs( 1 - length );
-				const dist = bvh.closestPointToPoint( vec, target );
+				target = bvh.closestPointToPoint( vec, target );
+				const dist = target.distance;
 				expect( dist ).toBeLessThanOrEqual( expectedDist + EPSILON );
 				expect( dist ).toBeGreaterThanOrEqual( expectedDist - EPSILON );
 
@@ -597,8 +599,8 @@ function runSuiteWithOptions( defaultOptions ) {
 			const geom = new SphereBufferGeometry( 1, 20, 20 );
 			bvh = new MeshBVH( geom, { verbose: false } );
 
-			target1 = new Vector3();
-			target2 = new Vector3();
+			target1 = null;
+			target2 = { };
 
 			geometry = new SphereBufferGeometry( 1, 5, 5 );
 
@@ -615,7 +617,8 @@ function runSuiteWithOptions( defaultOptions ) {
 					new Quaternion(),
 					new Vector3( 0.001, 0.001, 0.001 )
 				);
-			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
+			target1 = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
+			const dist = target1.distance;
 			expect( dist ).toBeLessThanOrEqual( 1 );
 			expect( dist ).toBeGreaterThanOrEqual( 1 - EPSILON );
 
@@ -629,7 +632,8 @@ function runSuiteWithOptions( defaultOptions ) {
 					new Quaternion(),
 					new Vector3( 0.1, 0.1, 0.1 )
 				);
-			const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
+			target1 = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
+			const dist = target1.distance;
 			expect( dist ).toBe( 0 );
 
 		} );
@@ -659,7 +663,8 @@ function runSuiteWithOptions( defaultOptions ) {
 
 				const distToCenter = Math.abs( 1 - length );
 				const expectedDist = distToCenter < radius ? 0 : distToCenter - radius;
-				const dist = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
+				target1 = bvh.closestPointToGeometry( geometry, matrix, target1, target2 );
+				const dist = target1.distance;
 				expect( dist ).toBeLessThanOrEqual( expectedDist + EPSILON );
 				expect( dist ).toBeGreaterThanOrEqual( expectedDist - EPSILON );
 


### PR DESCRIPTION
fixes #318, #321 

I've made the changes described in the mentioned issues: Target parameters can be Vector3 (as before), or objects (either ```{ }``` or the object from a previous execution). The objects (if not null) are filled with face indices, normal, uv, etc.

For ```closestPointToGeometry``` I've made it return always the info for target1 (```this.geometry```), but target2 (related to otherGeometry) is updated if it is an object. Mixing Vector3 and info object for target1 and target2 is not suported.

Also I've removed the ```distanceToPoint``` and ```distanceToGeometry``` functions of ```MeshBVH```.

The code has become large, let me know if there is something you would remove/modify.

Edit: Forgot to mention I've run the tests and they work fine. But the benchmark seems not to work, it complains about ```performance.now()``` not being defined.