### PR TITLE
getTriangleHitPointInfo: Extract material index correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,6 @@ This function returns information of a point related to a geometry. It returns t
 
 ```js
 target : {
-	point: Vector3,
 	face: {
 		a: Number,
 		b: Number,
@@ -515,13 +514,12 @@ target : {
 }
 ```
 
-- `point`: The same point
 - `a`, `b`, `c`: Triangle indices
 - `materialIndex`: Face material index or 0 if not available.
 - `normal`: Face normal
 - `uv`: UV coordinates.
 
-This function would normally be used after a call to [closestPointPoint](#closestPointToPoint) or [closestPointToGeometry](#closestPointToGeometry).
+This function can be used after a call to [closestPointPoint](#closestPointToPoint) or [closestPointToGeometry](#closestPointToGeometry) to retrieve more detailed result information.
 
 ## SerializedBVH
 

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -83,6 +83,23 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 	tempV2.fromBufferAttribute( positions, b );
 	tempV3.fromBufferAttribute( positions, c );
 
+	// find the associated material index
+	let materialIndex = 0;
+	const groups = geometry.groups;
+	for ( let i = 0, l = groups.length; i < l; i ++ ) {
+
+		const group = groups[ i ];
+		const { offset, count } = group;
+		if ( triangleIndex >= count && triangleIndex < offset + count ) {
+
+			materialIndex = group.materialIndex;
+			break;
+
+		}
+
+	}
+
+	// extract uvs
 	let uv = null;
 	if ( uvs ) {
 
@@ -97,6 +114,7 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 
 	}
 
+	// adjust the provided target or create a new one
 	if ( target ) {
 
 		if ( ! target.point ) target.point = new Vector3();
@@ -106,7 +124,7 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 		target.face.a = a;
 		target.face.b = b;
 		target.face.c = c;
-		target.face.materialIndex = 0;
+		target.face.materialIndex = materialIndex;
 		if ( ! target.face.normal ) target.face.normal = new Vector3();
 		Triangle.getNormal( tempV1, tempV2, tempV3, target.face.normal );
 
@@ -124,7 +142,7 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 				a: a,
 				b: b,
 				c: c,
-				materialIndex: 0,
+				materialIndex: materialIndex,
 				normal: Triangle.getNormal( tempV1, tempV2, tempV3, new Vector3() )
 			},
 			uv: uv

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -118,9 +118,6 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 	// adjust the provided target or create a new one
 	if ( target ) {
 
-		if ( ! target.point ) target.point = new Vector3();
-		target.point.copy( point );
-
 		if ( ! target.face ) target.face = { };
 		target.face.a = a;
 		target.face.b = b;
@@ -129,7 +126,6 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 		if ( ! target.face.normal ) target.face.normal = new Vector3();
 		Triangle.getNormal( tempV1, tempV2, tempV3, target.face.normal );
 
-		target.distance = 0;
 		if ( ! target.uv ) target.uv = new Vector2();
 		target.uv.copy( uv );
 
@@ -138,7 +134,6 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 	} else {
 
 		return {
-			point: point.clone(),
 			face: {
 				a: a,
 				b: b,

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -86,11 +86,12 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 	// find the associated material index
 	let materialIndex = 0;
 	const groups = geometry.groups;
+	const firstVertexIndex = triangleIndex * 3;
 	for ( let i = 0, l = groups.length; i < l; i ++ ) {
 
 		const group = groups[ i ];
 		const { offset, count } = group;
-		if ( triangleIndex >= count && triangleIndex < offset + count ) {
+		if ( firstVertexIndex >= count && firstVertexIndex < offset + count ) {
 
 			materialIndex = group.materialIndex;
 			break;

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -90,8 +90,8 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 	for ( let i = 0, l = groups.length; i < l; i ++ ) {
 
 		const group = groups[ i ];
-		const { offset, count } = group;
-		if ( firstVertexIndex >= count && firstVertexIndex < offset + count ) {
+		const { start, count } = group;
+		if ( firstVertexIndex >= start && firstVertexIndex < start + count ) {
 
 			materialIndex = group.materialIndex;
 			break;


### PR DESCRIPTION
Related to #325

Extracts the material index in the `getTriangleHitPointInfo` using the geometry group ranges.