### PR TITLE
Fix issue #368

### DIFF
--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -601,6 +601,8 @@ export class MeshBVH {
 		const otherIndexAttr = otherBvh.geometry.index;
 		const otherPositionAttr = otherBvh.geometry.attributes.position;
 
+		tempMatrix.copy( matrixToLocal ).invert();
+
 		const triangle = trianglePool.getPrimitive();
 		const triangle2 = trianglePool.getPrimitive();
 

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -595,20 +595,22 @@ export class MeshBVH {
 			intersectsTriangles,
 		} = callbacks;
 
-		const geometry = otherBvh.geometry;
-		const indexAttr = geometry.index;
-		const positionAttr = geometry.attributes.position;
+		const indexAttr = this.geometry.index;
+		const positionAttr = this.geometry.attributes.position;
 
-		tempMatrix.copy( matrixToLocal ).invert();
+		const otherIndexAttr = otherBvh.geometry.index;
+		const otherPositionAttr = otherBvh.geometry.attributes.position;
+
 		const triangle = trianglePool.getPrimitive();
 		const triangle2 = trianglePool.getPrimitive();
+
 		if ( intersectsTriangles ) {
 
 			function iterateOverDoubleTriangles( offset1, count1, offset2, count2, depth1, index1, depth2, index2 ) {
 
 				for ( let i2 = offset2, l2 = offset2 + count2; i2 < l2; i2 ++ ) {
 
-					setTriangle( triangle2, i2 * 3, indexAttr, positionAttr );
+					setTriangle( triangle2, i2 * 3, otherIndexAttr, otherPositionAttr );
 					triangle2.a.applyMatrix4( matrixToLocal );
 					triangle2.b.applyMatrix4( matrixToLocal );
 					triangle2.c.applyMatrix4( matrixToLocal );

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,14 @@ import { BufferGeometry, Vector3, Side, Material, Ray, Sphere, Matrix4, Color,
   Intersection, Box3, Triangle, Vector2, Raycaster, MeshBasicMaterial, Group,
   LineBasicMaterial, Mesh, DataTexture, BufferAttribute } from 'three';
 
+
+// Utils for typescript types
+// https://stackoverflow.com/questions/40510611/typescript-interface-require-one-of-two-properties-to-exist
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
+    Pick<T, Exclude<keyof T, Keys>> & {
+      [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
+    }[Keys]
+
 // Contants
 export enum SplitStrategy {}
 export const CENTER: SplitStrategy;
@@ -115,7 +123,7 @@ export class MeshBVH {
   bvhcast(
     otherBVH: MeshBVH,
     matrixToLocal: Matrix4,
-    callbacks: {
+    callbacks: RequireAtLeastOne<{
 
       intersectsRanges?: (
         offset1: number,
@@ -128,7 +136,7 @@ export class MeshBVH {
         index2: number
       ) => boolean,
 
-      intersectsTriangles: (
+      intersectsTriangles?: (
         triangle1: Triangle,
         triangle2: Triangle,
         i1: number,
@@ -138,7 +146,7 @@ export class MeshBVH {
         depth2: number,
         index2: number,
       ) => boolean,
-    }
+    }, 'intersectsRanges' | 'intersectsTriangles'>
   ): boolean;
 
   traverse(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -115,7 +115,7 @@ export class MeshBVH {
   bvhcast(
     otherBVH: MeshBVH,
     matrixToLocal: Matrix4,
-    callbacks?: {
+    callbacks: {
 
       intersectsRanges?: (
         offset1: number,
@@ -128,7 +128,7 @@ export class MeshBVH {
         index2: number
       ) => boolean,
 
-      intersectsTriangles?: (
+      intersectsTriangles: (
         triangle1: Triangle,
         triangle2: Triangle,
         i1: number,

--- a/test/ShapeCasts.test.js
+++ b/test/ShapeCasts.test.js
@@ -278,6 +278,58 @@ function runSuiteWithOptions( defaultOptions ) {
 
 	} );
 
+	describe( 'Bvhcast', () => {
+
+		let bvhA = null;
+		let bvhB = null;
+		let matrix;
+
+		beforeAll( () => {
+
+			const cubeA = new BoxBufferGeometry( 2, 2, 2 );
+			bvhA = new MeshBVH( cubeA );
+			const cubeB = new BoxBufferGeometry( 2, 2, 2 );
+			bvhB = new MeshBVH( cubeB );
+			matrix = new Matrix4();
+
+		} );
+
+		it( 'should test all combination of geometries triangles', () => {
+
+			matrix.makeTranslation( 1, 1, 1 );
+			let nbTriangleTests = 0;
+			const intersectsTriangles = function () {
+
+				nbTriangleTests += 1;
+				return false;
+
+			};
+
+			bvhA.bvhcast( bvhB, matrix, { intersectsTriangles: intersectsTriangles } );
+
+			expect( nbTriangleTests ).toBe( 144 );
+
+		} );
+
+		it( 'should stop iterating triangles', () => {
+
+			matrix.makeTranslation( 1, 1, 1 );
+			let nbTriangleTests = 0;
+			const intersectsTriangles = function () {
+
+				nbTriangleTests += 1;
+				return true;
+
+			};
+
+			bvhA.bvhcast( bvhB, matrix, { intersectsTriangles: intersectsTriangles } );
+
+			expect( nbTriangleTests ).toBe( 1 );
+
+		} );
+
+	} );
+
 	describe( 'IntersectsGeometry with BVH', () => {
 
 		let bvh = null;

--- a/test/ShapeCasts.test.js
+++ b/test/ShapeCasts.test.js
@@ -284,47 +284,89 @@ function runSuiteWithOptions( defaultOptions ) {
 		let bvhB = null;
 		let matrix;
 
-		beforeAll( () => {
+		describe( 'Simple intersecting cubes', () => {
 
-			const cubeA = new BoxBufferGeometry( 2, 2, 2 );
-			bvhA = new MeshBVH( cubeA );
-			const cubeB = new BoxBufferGeometry( 2, 2, 2 );
-			bvhB = new MeshBVH( cubeB );
-			matrix = new Matrix4();
+			beforeAll( () => {
+
+				const cubeA = new BoxBufferGeometry( 2, 2, 2 );
+				bvhA = new MeshBVH( cubeA );
+				const cubeB = new BoxBufferGeometry( 2, 2, 2 );
+				bvhB = new MeshBVH( cubeB );
+				matrix = new Matrix4();
+
+			} );
+
+			it( 'should compare all geometries triangles', () => {
+
+				matrix.makeTranslation( 1, 1, 1 );
+				let nbTriangleTests = 0;
+				const intersectsTriangles = function () {
+
+					nbTriangleTests += 1;
+					return false;
+
+				};
+
+				bvhA.bvhcast( bvhB, matrix, { intersectsTriangles: intersectsTriangles } );
+
+				expect( nbTriangleTests ).toBe( 144 );
+
+			} );
+
+			it( 'should stop iterating triangles', () => {
+
+				matrix.makeTranslation( 1, 1, 1 );
+				let nbTriangleTests = 0;
+				const intersectsTriangles = function () {
+
+					nbTriangleTests += 1;
+					return true;
+
+				};
+
+				bvhA.bvhcast( bvhB, matrix, { intersectsTriangles: intersectsTriangles } );
+
+				expect( nbTriangleTests ).toBe( 1 );
+
+			} );
 
 		} );
 
-		it( 'should test all combination of geometries triangles', () => {
+		describe( 'Dense intersecting cubes', () => {
 
-			matrix.makeTranslation( 1, 1, 1 );
-			let nbTriangleTests = 0;
-			const intersectsTriangles = function () {
+			beforeAll( () => {
 
-				nbTriangleTests += 1;
-				return false;
+				const cubeA = new BoxBufferGeometry( 2, 2, 2, 2, 2, 2 );
+				bvhA = new MeshBVH( cubeA, { maxLeafTris: 1 } );
+				const cubeB = new BoxBufferGeometry( 2, 2, 2, 2, 2, 2 );
+				bvhB = new MeshBVH( cubeB, { maxLeafTris: 1 } );
+				matrix = new Matrix4();
 
-			};
+			} );
 
-			bvhA.bvhcast( bvhB, matrix, { intersectsTriangles: intersectsTriangles } );
+			it( 'should not compare all geometries triangles', () => {
 
-			expect( nbTriangleTests ).toBe( 144 );
+				matrix.makeTranslation( 0, 1.5, 0 );
+				let nbTriangleTests = 0;
+				const intersectsTriangles = function () {
 
-		} );
+					nbTriangleTests += 1;
+					return false;
 
-		it( 'should stop iterating triangles', () => {
+				};
 
-			matrix.makeTranslation( 1, 1, 1 );
-			let nbTriangleTests = 0;
-			const intersectsTriangles = function () {
+				bvhA.bvhcast( bvhB, matrix, { intersectsTriangles: intersectsTriangles } );
 
-				nbTriangleTests += 1;
-				return true;
+				// Each cube is composed of 2*2*2*6 = 48 triangles.
+				// Only 1/4 geometry is intersected on 1 axis, so 24 triangles.
+				// Worst case scenario is to compare 24 triangles to the 24 others (i.e. 576)
+				// Since maxLeafTris === 1, triangle bounds have a size of (1,1,1) and
+				// cube size is (2,2,2), each triangle should be compared to a *maximum*
+				// of 16 others (8 on sides, 8 on front), i.e. 24x16 = 384.
 
-			};
+				expect( nbTriangleTests ).toBeLessThanOrEqual( 384 );
 
-			bvhA.bvhcast( bvhB, matrix, { intersectsTriangles: intersectsTriangles } );
-
-			expect( nbTriangleTests ).toBe( 1 );
+			} );
 
 		} );
 


### PR DESCRIPTION
* Takes into account otherBvh.gomeotry in the bvhcast function
* Adds few tests to be sure triangles are iterated
* Fixed the typescript definitions about bvhcast function callbacks
  *  _callbacks_ param cannot be decomposed if undefined
  * Seems like the intersectsTriangles callback is required (otherwise intersectsRanges function can be null when called [here](https://github.com/minitoine/three-mesh-bvh/blob/76e6b68644f50269088add617a4bd294fcbbf1c6/src/core/MeshBVH.js#L677)