### PR TITLE
VertexAttributeTexture: Remove use of RGBFormat

### DIFF
--- a/src/gpu/VertexAttributeTexture.js
+++ b/src/gpu/VertexAttributeTexture.js
@@ -14,19 +14,18 @@ import {
 
 	RedIntegerFormat,
 	RGIntegerFormat,
-	RGBIntegerFormat,
 	RGBAIntegerFormat,
 
 	NearestFilter,
 } from 'three';
 
-function countToStringFormat( count, integer = false ) {
+function countToStringFormat( count ) {
 
 	switch ( count ) {
 
 		case 1: return 'R';
 		case 2: return 'RG';
-		case 3: return integer ? 'RGB' : 'RGBA';
+		case 3: return 'RGBA';
 		case 4: return 'RGBA';
 
 	}
@@ -54,7 +53,7 @@ function countToIntFormat( count ) {
 
 		case 1: return RedIntegerFormat;
 		case 2: return RGIntegerFormat;
-		case 3: return RGBIntegerFormat;
+		case 3: return RGBAIntegerFormat;
 		case 4: return RGBAIntegerFormat;
 
 	}
@@ -126,9 +125,8 @@ export class VertexAttributeTexture extends DataTexture {
 		}
 
 		// get the target format to store the texture as
-		const isIntegerType = targetType !== FloatType;
 		let type, format, normalizeValue, targetBufferCons;
-		let internalFormat = countToStringFormat( itemSize, isIntegerType );
+		let internalFormat = countToStringFormat( itemSize );
 		switch ( targetType ) {
 
 			case FloatType:
@@ -212,8 +210,8 @@ export class VertexAttributeTexture extends DataTexture {
 		}
 
 		// there will be a mismatch between format length and final length because
-		// RGBFormat was removed
-		if ( finalStride === 3 && format === RGBAFormat ) {
+		// RGBFormat and RGBIntegerFormat was removed
+		if ( finalStride === 3 && ( format === RGBAFormat || format === RGBAIntegerFormat ) ) {
 
 			finalStride = 4;
 

--- a/test/VertexAttributeTexture.test.js
+++ b/test/VertexAttributeTexture.test.js
@@ -60,6 +60,19 @@ describe( 'VertexAttributeTexture', () => {
 
 	} );
 
+	it( 'should automatically use RGBAFormat when passing in an attribute with a stride of 3.', () => {
+
+		const ba = new BufferAttribute( new Float32Array( 6 ), 3, false );
+		const tex = new FloatVertexAttributeTexture();
+		tex.updateFrom( ba );
+
+		expect( tex.image.data ).toHaveLength( 16 );
+		expect( tex.image.data ).toEqual( new Float32Array( [ 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ] ) );
+		expect( tex.format ).toBe( RGBAFormat );
+		expect( tex.internalFormat ).toBe( 'RGBA32F' );
+
+	} );
+
 	it( 'should create a large enough texture to store all data.', () => {
 
 		{

--- a/test/VertexAttributeTexture.test.js
+++ b/test/VertexAttributeTexture.test.js
@@ -8,7 +8,7 @@ import {
 	RedFormat,
 	RGFormat,
 	RGBAFormat,
-	RGBIntegerFormat,
+	RGIntegerFormat,
 	RGBAIntegerFormat,
 	FloatType,
 	UnsignedShortType,
@@ -23,16 +23,16 @@ describe( 'VertexAttributeTexture', () => {
 
 		it( 'should reset the itemSize if it is set.', () => {
 
-			const ba = new BufferAttribute( new Uint8Array( 6 ), 1, false );
+			const ba = new BufferAttribute( new Uint8Array( 8 ), 1, false );
 			const tex = new UIntVertexAttributeTexture();
-			tex.overrideItemSize = 3;
+			tex.overrideItemSize = 4;
 			tex.updateFrom( ba );
 
 			expect( tex.type ).toBe( UnsignedByteType );
-			expect( tex.format ).toBe( RGBIntegerFormat );
-			expect( tex.internalFormat ).toBe( 'RGB8UI' );
+			expect( tex.format ).toBe( RGBAIntegerFormat );
+			expect( tex.internalFormat ).toBe( 'RGBA8UI' );
 			expect( ba.itemSize ).toBe( 1 );
-			expect( ba.count ).toBe( 6 );
+			expect( ba.count ).toBe( 8 );
 			expect( tex.image.width ).toBe( 2 );
 
 		} );
@@ -62,14 +62,31 @@ describe( 'VertexAttributeTexture', () => {
 
 	it( 'should automatically use RGBAFormat when passing in an attribute with a stride of 3.', () => {
 
-		const ba = new BufferAttribute( new Float32Array( 6 ), 3, false );
-		const tex = new FloatVertexAttributeTexture();
-		tex.updateFrom( ba );
+		{
 
-		expect( tex.image.data ).toHaveLength( 16 );
-		expect( tex.image.data ).toEqual( new Float32Array( [ 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ] ) );
-		expect( tex.format ).toBe( RGBAFormat );
-		expect( tex.internalFormat ).toBe( 'RGBA32F' );
+			const ba = new BufferAttribute( new Float32Array( 6 ), 3, false );
+			const tex = new FloatVertexAttributeTexture();
+			tex.updateFrom( ba );
+
+			expect( tex.image.data ).toHaveLength( 16 );
+			expect( tex.image.data ).toEqual( new Float32Array( [ 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ] ) );
+			expect( tex.format ).toBe( RGBAFormat );
+			expect( tex.internalFormat ).toBe( 'RGBA32F' );
+
+		}
+
+		{
+
+			const ba = new BufferAttribute( new Uint8Array( 6 ), 3, false );
+			const tex = new UIntVertexAttributeTexture();
+			tex.updateFrom( ba );
+
+			expect( tex.image.data ).toHaveLength( 16 );
+			expect( tex.image.data ).toEqual( new Uint8Array( [ 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0 ] ) );
+			expect( tex.format ).toBe( RGBAIntegerFormat );
+			expect( tex.internalFormat ).toBe( 'RGBA8UI' );
+
+		}
 
 	} );
 
@@ -89,13 +106,13 @@ describe( 'VertexAttributeTexture', () => {
 
 		{
 
-			const ba = new BufferAttribute( new Uint8Array( 18 ), 3, false );
+			const ba = new BufferAttribute( new Uint8Array( 20 ), 2, false );
 			const tex = new UIntVertexAttributeTexture();
 			tex.updateFrom( ba );
 
-			expect( tex.image.data ).toHaveLength( 27 );
-			expect( tex.image.width ).toBe( 3 );
-			expect( tex.image.height ).toBe( 3 );
+			expect( tex.image.data ).toHaveLength( 32 );
+			expect( tex.image.width ).toBe( 4 );
+			expect( tex.image.height ).toBe( 4 );
 
 		}
 
@@ -141,13 +158,13 @@ describe( 'VertexAttributeTexture', () => {
 
 		{
 
-			const ba = new BufferAttribute( new Uint16Array( 6 ), 3, false );
+			const ba = new BufferAttribute( new Uint16Array( 6 ), 2, false );
 			const tex = new UIntVertexAttributeTexture();
 			tex.updateFrom( ba );
 
 			expect( tex.type ).toBe( UnsignedShortType );
-			expect( tex.format ).toBe( RGBIntegerFormat );
-			expect( tex.internalFormat ).toBe( 'RGB16UI' );
+			expect( tex.format ).toBe( RGIntegerFormat );
+			expect( tex.internalFormat ).toBe( 'RG16UI' );
 
 		}
 


### PR DESCRIPTION
fix #372 

cc @arpu Sorry this turned out to be more complicated than I anticipated but this should remove the use of RGBFormat from the project. GPU path tracing demos and tests have been been tested here.

**TODO**
- Remove `RGBIntegerType`
