### PR TITLE
Added final onProgress call on full MeshBVH building completion

### DIFF
--- a/src/core/buildFunctions.js
+++ b/src/core/buildFunctions.js
@@ -646,7 +646,7 @@ export function buildTree( geo, options ) {
 		// early out if we've met our capacity
 		if ( count <= maxLeafTris || depth >= maxDepth ) {
 
-			triggerProgress( offset );
+			triggerProgress( offset + count );
 			node.offset = offset;
 			node.count = count;
 			return node;
@@ -657,7 +657,7 @@ export function buildTree( geo, options ) {
 		const split = getOptimalSplit( node.boundingData, centroidBoundingData, triangleBounds, offset, count, strategy );
 		if ( split.axis === - 1 ) {
 
-			triggerProgress( offset );
+			triggerProgress( offset + count );
 			node.offset = offset;
 			node.count = count;
 			return node;
@@ -669,7 +669,7 @@ export function buildTree( geo, options ) {
 		// create the two new child nodes
 		if ( splitOffset === offset || splitOffset === offset + count ) {
 
-			triggerProgress( offset );
+			triggerProgress( offset + count );
 			node.offset = offset;
 			node.count = count;
 

--- a/src/workers/generateAsync.worker.js
+++ b/src/workers/generateAsync.worker.js
@@ -10,7 +10,7 @@ global.onmessage = function ( { data } ) {
 	function onProgressCallback( progress ) {
 
 		const currTime = global.performance.now();
-		if ( currTime - prevTime >= 10 ) {
+		if ( currTime - prevTime >= 10 || progress === 1.0 ) {
 
 			global.postMessage( {
 

--- a/test/MeshBVH.test.js
+++ b/test/MeshBVH.test.js
@@ -319,7 +319,7 @@ describe( 'Options', () => {
 			} );
 
 			const leafNodeCount = getBVHExtremes( bvh )[ 0 ].leafNodeCount;
-			expect( maxProgress ).toBeGreaterThan( 0.999 );
+			expect( maxProgress ).toEqual( 1.0 );
 			expect( minProgress ).toBeLessThan( 0.001 );
 			expect( count ).toBe( leafNodeCount );
 


### PR DESCRIPTION
When using the `MeshBVH` constructor with the `onProgress` callback provided in the `options` dictionary: there's currently no point in execution at which it gets called with `1.0` to signify the true finalization of the building process.

The matter is: we may get values nearing `1.0` going as high as something like `9.9445486` if the total amount of triangles allows it, but when the faces are too few we will have trouble determining a reasonable threshold to consider that the progression has reached it's peak.

Let's assume we have a geometry of only two triangles (a quad, typically), then the highest value provided by the `progress` argument will likely by something like `0.5` and we will never get to (or near) `1.0` at any point, so even using something like `progress > 0.9` for thresholding won't work.

This change just ensures that, if and when a callback is provided with `onProgress`, it gets called with `1.0` at last.