### PR TITLE
Add return type for computeBoundsTree

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -198,7 +198,7 @@ export class MeshBVHVisualizer extends Group {
 
 // THREE.js Extensions
 
-export function computeBoundsTree( options?: MeshBVHOptions ): void;
+export function computeBoundsTree( options?: MeshBVHOptions ): MeshBVH;
 
 export function disposeBoundsTree(): void;
 

--- a/test/MeshBVH.test.js
+++ b/test/MeshBVH.test.js
@@ -52,6 +52,14 @@ describe( 'Bounds Tree', () => {
 
 	} );
 
+	it( 'should return a MeshBVH', () => {
+
+		const geom = new SphereBufferGeometry( 1, 1, 1 );
+
+		expect( geom.computeBoundsTree() ).toBeInstanceOf( MeshBVH );
+
+	} );
+
 	it( 'should throw an error if InterleavedBufferAttributes are used', () => {
 
 		const indexAttr = new InterleavedBufferAttribute( new InterleavedBuffer( new Uint32Array( [ 1, 2, 3 ] ), 1 ), 4, 0, false );


### PR DESCRIPTION
👋 noticed that the `computeBoundsTree` extension method Typescript description doesn't denote that `MeshBVH` is returned. Added it to the description file and added a test for regressions.