### PR TITLE
Add "indirectBuffer" option

### DIFF
--- a/src/core/Constants.js
+++ b/src/core/Constants.js
@@ -24,3 +24,5 @@ export const IS_LEAFNODE_FLAG = 0xFFFF;
 // https://en.wikipedia.org/wiki/Machine_epsilon#Values_for_standard_hardware_floating_point_arithmetics
 export const FLOAT32_EPSILON = Math.pow( 2, - 24 );
 
+export const SKIP_GENERATION = Symbol( 'SKIP_GENERATION' );
+export const INDIRECT_BUFFER = Symbol( 'INDIRECT_BUFFER' );

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -165,7 +165,11 @@ export class MeshBVH {
 			if ( options.indirectBuffer ) {
 
 				const triCount = ( geometry.index ? geometry.index.count : geometry.attributes.position.count ) / 3;
-				const indirectBuffer = triCount > 2 ** 16 ? new Uint32Array( triCount ) : new Uint16Array( triCount );
+				const useUint32 = triCount > 2 ** 16;
+				const byteCount = useUint32 ? 4 : 2;
+
+				const buffer = options.useSharedArrayBuffer ? new SharedArrayBuffer( triCount * byteCount ) : new ArrayBuffer( triCount * byteCount );
+				const indirectBuffer = useUint32 ? new Uint32Array( buffer ) : new Uint16Array( buffer );
 				for ( let i = 0, l = indirectBuffer.length; i < l; i ++ ) {
 
 					indirectBuffer[ i ] = i;

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -54,12 +54,14 @@ export class MeshBVH {
 		const geometry = bvh.geometry;
 		const rootData = bvh._roots;
 		const indexAttribute = geometry.getIndex();
+		const indirectBuffer = bvh.indirectBuffer;
 		let result;
 		if ( options.cloneBuffers ) {
 
 			result = {
 				roots: rootData.map( root => root.slice() ),
-				index: indexAttribute.array.slice(),
+				index: indexAttribute ? indexAttribute.array.slice() : null,
+				indirectBuffer: indirectBuffer ? indirectBuffer.slice() : null,
 			};
 
 		} else {
@@ -67,6 +69,7 @@ export class MeshBVH {
 			result = {
 				roots: rootData,
 				index: indexAttribute.array,
+				indirectBuffer: indirectBuffer,
 			};
 
 		}
@@ -96,9 +99,10 @@ export class MeshBVH {
 			...options,
 		};
 
-		const { index, roots } = data;
+		const { index, roots, indirectBuffer } = data;
 		const bvh = new MeshBVH( geometry, { ...options, [ SKIP_GENERATION ]: true } );
 		bvh._roots = roots;
+		bvh.indirectBuffer = indirectBuffer;
 
 		if ( options.setIndex ) {
 

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -412,6 +412,7 @@ export class MeshBVH {
 
 		const roots = this._roots;
 		const geometry = this.geometry;
+		const indirectBuffer = this.indirectBuffer;
 		const intersects = [];
 		const isMaterial = materialOrSide.isMaterial;
 		const isArrayMaterial = Array.isArray( materialOrSide );
@@ -424,7 +425,7 @@ export class MeshBVH {
 			const startCount = intersects.length;
 
 			setBuffer( roots[ i ] );
-			raycast( 0, geometry, materialSide, ray, intersects );
+			raycast( 0, geometry, materialSide, ray, indirectBuffer, intersects );
 			clearBuffer();
 
 			if ( isArrayMaterial ) {
@@ -448,6 +449,7 @@ export class MeshBVH {
 
 		const roots = this._roots;
 		const geometry = this.geometry;
+		const indirectBuffer = this.indirectBuffer;
 		const isMaterial = materialOrSide.isMaterial;
 		const isArrayMaterial = Array.isArray( materialOrSide );
 
@@ -460,7 +462,7 @@ export class MeshBVH {
 			const materialSide = isArrayMaterial ? materialOrSide[ groups[ i ].materialIndex ].side : side;
 
 			setBuffer( roots[ i ] );
-			const result = raycastFirst( 0, geometry, materialSide, ray );
+			const result = raycastFirst( 0, geometry, materialSide, ray, indirectBuffer );
 			clearBuffer();
 
 			if ( result != null && ( closestResult == null || result.distance < closestResult.distance ) ) {

--- a/src/core/castFunctions.js
+++ b/src/core/castFunctions.js
@@ -13,7 +13,7 @@ const boundingBox = new Box3();
 const boxIntersection = new Vector3();
 const xyzFields = [ 'x', 'y', 'z' ];
 
-export function raycast( nodeIndex32, geometry, side, ray, intersects ) {
+export function raycast( nodeIndex32, geometry, side, ray, indirectBuffer, intersects ) {
 
 	let nodeIndex16 = nodeIndex32 * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
 
@@ -23,21 +23,21 @@ export function raycast( nodeIndex32, geometry, side, ray, intersects ) {
 		const offset = OFFSET( nodeIndex32, uint32Array );
 		const count = COUNT( nodeIndex16, uint16Array );
 
-		intersectTris( geometry, side, ray, offset, count, intersects );
+		intersectTris( geometry, side, ray, offset, count, indirectBuffer, intersects );
 
 	} else {
 
 		const leftIndex = LEFT_NODE( nodeIndex32 );
 		if ( intersectRay( leftIndex, float32Array, ray, boxIntersection ) ) {
 
-			raycast( leftIndex, geometry, side, ray, intersects );
+			raycast( leftIndex, geometry, side, ray, indirectBuffer, intersects );
 
 		}
 
 		const rightIndex = RIGHT_NODE( nodeIndex32, uint32Array );
 		if ( intersectRay( rightIndex, float32Array, ray, boxIntersection ) ) {
 
-			raycast( rightIndex, geometry, side, ray, intersects );
+			raycast( rightIndex, geometry, side, ray, indirectBuffer, intersects );
 
 		}
 
@@ -45,7 +45,7 @@ export function raycast( nodeIndex32, geometry, side, ray, intersects ) {
 
 }
 
-export function raycastFirst( nodeIndex32, geometry, side, ray ) {
+export function raycastFirst( nodeIndex32, geometry, side, ray, indirectBuffer ) {
 
 	let nodeIndex16 = nodeIndex32 * 2, float32Array = _float32Array, uint16Array = _uint16Array, uint32Array = _uint32Array;
 
@@ -80,7 +80,7 @@ export function raycastFirst( nodeIndex32, geometry, side, ray ) {
 		}
 
 		const c1Intersection = intersectRay( c1, float32Array, ray, boxIntersection );
-		const c1Result = c1Intersection ? raycastFirst( c1, geometry, side, ray ) : null;
+		const c1Result = c1Intersection ? raycastFirst( c1, geometry, side, ray, indirectBuffer ) : null;
 
 		// if we got an intersection in the first node and it's closer than the second node's bounding
 		// box, we don't need to consider the second node because it couldn't possibly be a better result
@@ -104,7 +104,7 @@ export function raycastFirst( nodeIndex32, geometry, side, ray ) {
 		// either there was no intersection in the first node, or there could still be a closer
 		// intersection in the second, so check the second node and then take the better of the two
 		const c2Intersection = intersectRay( c2, float32Array, ray, boxIntersection );
-		const c2Result = c2Intersection ? raycastFirst( c2, geometry, side, ray ) : null;
+		const c2Result = c2Intersection ? raycastFirst( c2, geometry, side, ray, indirectBuffer ) : null;
 
 		if ( c1Result && c2Result ) {
 

--- a/src/utils/GeometryRayIntersectUtilities.js
+++ b/src/utils/GeometryRayIntersectUtilities.js
@@ -4,7 +4,7 @@ export function intersectTris( geo, side, ray, offset, count, indirectBuffer, in
 
 	for ( let i = offset, end = offset + count; i < end; i ++ ) {
 
-		const tri = i;
+		let tri = i;
 		if ( indirectBuffer ) {
 
 			tri = indirectBuffer[ tri ];
@@ -23,7 +23,7 @@ export function intersectClosestTri( geo, side, ray, offset, count, indirectBuff
 	let res = null;
 	for ( let i = offset, end = offset + count; i < end; i ++ ) {
 
-		const tri = i;
+		let tri = i;
 		if ( indirectBuffer ) {
 
 			tri = indirectBuffer[ tri ];

--- a/src/utils/GeometryRayIntersectUtilities.js
+++ b/src/utils/GeometryRayIntersectUtilities.js
@@ -1,22 +1,36 @@
 import { intersectTri } from './ThreeRayIntersectUtilities.js';
 
-export function intersectTris( geo, side, ray, offset, count, intersections ) {
+export function intersectTris( geo, side, ray, offset, count, indirectBuffer, intersections ) {
 
 	for ( let i = offset, end = offset + count; i < end; i ++ ) {
 
-		intersectTri( geo, side, ray, i, intersections );
+		const tri = i;
+		if ( indirectBuffer ) {
+
+			tri = indirectBuffer[ tri ];
+
+		}
+
+		intersectTri( geo, side, ray, tri, intersections );
 
 	}
 
 }
 
-export function intersectClosestTri( geo, side, ray, offset, count ) {
+export function intersectClosestTri( geo, side, ray, offset, count, indirectBuffer ) {
 
 	let dist = Infinity;
 	let res = null;
 	for ( let i = offset, end = offset + count; i < end; i ++ ) {
 
-		const intersection = intersectTri( geo, side, ray, i );
+		const tri = i;
+		if ( indirectBuffer ) {
+
+			tri = indirectBuffer[ tri ];
+
+		}
+
+		const intersection = intersectTri( geo, side, ray, tri );
 		if ( intersection && intersection.distance < dist ) {
 
 			res = intersection;

--- a/src/workers/generateAsync.worker.js
+++ b/src/workers/generateAsync.worker.js
@@ -57,6 +57,19 @@ onmessage = function ( { data } ) {
 
 		const bvh = new MeshBVH( geometry, options );
 		const serialized = MeshBVH.serialize( bvh, { copyIndexBuffer: false } );
+		const transferBuffers = serialized.roots.map( arr => arr.buffer );
+		transferBuffers.push( position.buffer );
+		if ( serialized.index ) {
+
+			transferBuffers.push( serialized.index.buffer );
+
+		}
+
+		if ( serialized.indirectBuffer ) {
+
+			transferBuffers.push( serialized.indirectBuffer.buffer );
+
+		}
 
 		postMessage( {
 
@@ -65,7 +78,7 @@ onmessage = function ( { data } ) {
 			position,
 			progress: 1,
 
-		}, [ serialized.index.buffer, position.buffer ] );
+		}, transferBuffers );
 
 	} catch ( error ) {
 

--- a/test/RandomRaycasts.test.js
+++ b/test/RandomRaycasts.test.js
@@ -165,3 +165,5 @@ describe( 'Random Interleaved AVERAGE intersections', () => runRandomTests( { st
 
 describe( 'Random SAH intersections', () => runRandomTests( { strategy: SAH } ) );
 describe( 'Random Interleaved SAH intersections', () => runRandomTests( { strategy: SAH, interleaved: true } ) );
+
+describe( 'Random Indirect intersections', () => runRandomTests( { indirectBuffer: true } ) );

--- a/test/ShapeCasts.test.js
+++ b/test/ShapeCasts.test.js
@@ -32,6 +32,7 @@ BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;
 BufferGeometry.prototype.disposeBoundsTree = disposeBoundsTree;
 
 runSuiteWithOptions( {} );
+runSuiteWithOptions( { indirectBuffer: true } );
 
 function runSuiteWithOptions( defaultOptions ) {
 


### PR DESCRIPTION
Fix #294

Also fixed web worker not transferring root buffers.

**TODO**
- [x] Index no longer has to be ensured (`buildTree` function)
- [x] Instead of bookkeeping an index array we keep an indirect "triangleIndex" array that is 1/3 the size (`buildTree` function)
- [x] "partition" function needs to sort an array that is 1 / 3 the size (`partition` function)
- [x] "raycast" function needs to be adjusted to take an indirect array or take function for running intersections (`raycast` cast function)
- [x] "raycastFirst" function needs to be adjusted to take an indirect array or take function for running intersections (`raycastFirst` cast function)
- [x] Worker generation / serialization
- [ ] "shapecast" functions needs to be adjusted to take an indirect array or it can be wrapped in MeshBVH call (`MeshBVH.shapecast` or `shapecast` cast function)
- [ ] ~Fix "bvhcast" function~
- [ ] Shader BVH packing needs to know about the indirect storage.
  - deindex the buffer here
- [ ] Adjust code to be agnostic to index presence.
- [ ] Tests
  - [x] Randomized tests
  - [ ] Serialized tests
  - [ ] Removed index tests
  - [ ] Option tests
- [ ] Performance
