### PR TITLE
Support normalized attributes

### DIFF
--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -189,6 +189,16 @@ export class MeshBVH {
 		const geometry = this.geometry;
 		const indexArr = geometry.index.array;
 		const posAttr = geometry.attributes.position;
+		const posArr = posAttr.array;
+
+		// support for an interleaved position buffer
+		const bufferOffset = posAttr.offset || 0;
+		let stride = 3;
+		if ( posAttr.isInterleavedBufferAttribute ) {
+
+			stride = posAttr.data.stride;
+
+		}
 
 		let buffer, uint32Array, uint16Array, float32Array;
 		let byteOffset = 0;
@@ -223,10 +233,25 @@ export class MeshBVH {
 
 				for ( let i = 3 * offset, l = 3 * ( offset + count ); i < l; i ++ ) {
 
-					const index = indexArr[ i ];
-					const x = posAttr.getX( index );
-					const y = posAttr.getY( index );
-					const z = posAttr.getZ( index );
+					let x;
+					let y;
+					let z;
+
+					if ( posAttr.normalized ) {
+
+						const index = indexArr[ i ];
+						x = posAttr.getX( index );
+						y = posAttr.getY( index );
+						z = posAttr.getZ( index );
+
+					} else {
+
+						const index = indexArr[ i ] * stride + bufferOffset;
+						x = posArr[ index + 0 ];
+						y = posArr[ index + 1 ];
+						z = posArr[ index + 2 ];
+
+					}
 
 					if ( x < minx ) minx = x;
 					if ( x > maxx ) maxx = x;

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -189,17 +189,7 @@ export class MeshBVH {
 		const geometry = this.geometry;
 		const indexArr = geometry.index.array;
 		const posAttr = geometry.attributes.position;
-		const posArr = posAttr.array;
-
-		// support for an interleaved position buffer
-		const bufferOffset = posAttr.offset || 0;
-		let stride = 3;
-		if ( posAttr.isInterleavedBufferAttribute ) {
-
-			stride = posAttr.data.stride;
-
-		}
-
+		
 		let buffer, uint32Array, uint16Array, float32Array;
 		let byteOffset = 0;
 		const roots = this._roots;
@@ -231,11 +221,10 @@ export class MeshBVH {
 				let maxy = - Infinity;
 				let maxz = - Infinity;
 				for ( let i = 3 * offset, l = 3 * ( offset + count ); i < l; i ++ ) {
-
-					const index = indexArr[ i ] * stride + bufferOffset;
-					const x = posArr[ index + 0 ];
-					const y = posArr[ index + 1 ];
-					const z = posArr[ index + 2 ];
+					const index = indexArr[ i ];
+					const x = posAttr.getX(index);
+					const y = posAttr.getY(index);
+					const z = posAttr.getZ(index);
 
 					if ( x < minx ) minx = x;
 					if ( x > maxx ) maxx = x;

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -189,7 +189,7 @@ export class MeshBVH {
 		const geometry = this.geometry;
 		const indexArr = geometry.index.array;
 		const posAttr = geometry.attributes.position;
-		
+
 		let buffer, uint32Array, uint16Array, float32Array;
 		let byteOffset = 0;
 		const roots = this._roots;
@@ -220,11 +220,13 @@ export class MeshBVH {
 				let maxx = - Infinity;
 				let maxy = - Infinity;
 				let maxz = - Infinity;
+
 				for ( let i = 3 * offset, l = 3 * ( offset + count ); i < l; i ++ ) {
+
 					const index = indexArr[ i ];
-					const x = posAttr.getX(index);
-					const y = posAttr.getY(index);
-					const z = posAttr.getZ(index);
+					const x = posAttr.getX( index );
+					const y = posAttr.getY( index );
+					const z = posAttr.getZ( index );
 
 					if ( x < minx ) minx = x;
 					if ( x > maxx ) maxx = x;

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -190,6 +190,7 @@ export class MeshBVH {
 		const indexArr = geometry.index.array;
 		const posAttr = geometry.attributes.position;
 		const posArr = posAttr.array;
+		const normalized = posAttr.normalized;
 
 		// support for an interleaved position buffer
 		const bufferOffset = posAttr.offset || 0;
@@ -233,11 +234,9 @@ export class MeshBVH {
 
 				for ( let i = 3 * offset, l = 3 * ( offset + count ); i < l; i ++ ) {
 
-					let x;
-					let y;
-					let z;
+					let x, y, z;
 
-					if ( posAttr.normalized ) {
+					if ( normalized ) {
 
 						const index = indexArr[ i ];
 						x = posAttr.getX( index );

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -189,17 +189,6 @@ export class MeshBVH {
 		const geometry = this.geometry;
 		const indexArr = geometry.index.array;
 		const posAttr = geometry.attributes.position;
-		const posArr = posAttr.array;
-		const normalized = posAttr.normalized;
-
-		// support for an interleaved position buffer
-		const bufferOffset = posAttr.offset || 0;
-		let stride = 3;
-		if ( posAttr.isInterleavedBufferAttribute ) {
-
-			stride = posAttr.data.stride;
-
-		}
 
 		let buffer, uint32Array, uint16Array, float32Array;
 		let byteOffset = 0;
@@ -234,23 +223,10 @@ export class MeshBVH {
 
 				for ( let i = 3 * offset, l = 3 * ( offset + count ); i < l; i ++ ) {
 
-					let x, y, z;
-
-					if ( normalized ) {
-
-						const index = indexArr[ i ];
-						x = posAttr.getX( index );
-						y = posAttr.getY( index );
-						z = posAttr.getZ( index );
-
-					} else {
-
-						const index = indexArr[ i ] * stride + bufferOffset;
-						x = posArr[ index + 0 ];
-						y = posArr[ index + 1 ];
-						z = posArr[ index + 2 ];
-
-					}
+					const index = indexArr[ i ];
+					const x = posAttr.getX( index );
+					const y = posAttr.getY( index );
+					const z = posAttr.getZ( index );
 
 					if ( x < minx ) minx = x;
 					if ( x > maxx ) maxx = x;

--- a/src/core/buildFunctions.js
+++ b/src/core/buildFunctions.js
@@ -563,6 +563,7 @@ function computeTriangleBounds( geo, fullBounds ) {
 	const index = geo.index.array;
 	const triCount = index.length / 3;
 	const triangleBounds = new Float32Array( triCount * 6 );
+	const normalized = posAttr.normalized;
 
 	// used for non-normalized positions
 	const posArr = posAttr.array;
@@ -584,11 +585,9 @@ function computeTriangleBounds( geo, fullBounds ) {
 		const tri3 = tri * 3;
 		const tri6 = tri * 6;
 
-		let ai;
-		let bi;
-		let ci;
+		let ai, bi, ci;
 
-		if ( posAttr.normalized ) {
+		if ( normalized ) {
 
 			ai = index[ tri3 + 0 ];
 			bi = index[ tri3 + 1 ];
@@ -604,11 +603,9 @@ function computeTriangleBounds( geo, fullBounds ) {
 
 		for ( let el = 0; el < 3; el ++ ) {
 
-			let a;
-			let b;
-			let c;
+			let a, b, c;
 
-			if ( posAttr.normalized ) {
+			if ( normalized ) {
 
 				a = posAttr[ getters[ el ] ]( ai );
 				b = posAttr[ getters[ el ] ]( bi );

--- a/src/core/buildFunctions.js
+++ b/src/core/buildFunctions.js
@@ -563,22 +563,64 @@ function computeTriangleBounds( geo, fullBounds ) {
 	const index = geo.index.array;
 	const triCount = index.length / 3;
 	const triangleBounds = new Float32Array( triCount * 6 );
-	const getter = [ posAttr.getX.bind( posAttr ), posAttr.getY.bind( posAttr ), posAttr.getZ.bind( posAttr ) ];
+
+	// used for non-normalized positions
+	const posArr = posAttr.array;
+
+	// support for an interleaved position buffer
+	const bufferOffset = posAttr.offset || 0;
+	let stride = 3;
+	if ( posAttr.isInterleavedBufferAttribute ) {
+
+		stride = posAttr.data.stride;
+
+	}
+
+	// used for normalized positions
+	const getters = [ 'getX', 'getY', 'getZ' ];
 
 	for ( let tri = 0; tri < triCount; tri ++ ) {
 
 		const tri3 = tri * 3;
 		const tri6 = tri * 6;
 
-		const ai = index[ tri3 + 0 ];
-		const bi = index[ tri3 + 1 ];
-		const ci = index[ tri3 + 2 ];
+		let ai;
+		let bi;
+		let ci;
+
+		if ( posAttr.normalized ) {
+
+			ai = index[ tri3 + 0 ];
+			bi = index[ tri3 + 1 ];
+			ci = index[ tri3 + 2 ];
+
+		} else {
+
+			ai = index[ tri3 + 0 ] * stride + bufferOffset;
+			bi = index[ tri3 + 1 ] * stride + bufferOffset;
+			ci = index[ tri3 + 2 ] * stride + bufferOffset;
+
+		}
 
 		for ( let el = 0; el < 3; el ++ ) {
 
-			const a = getter[ el ]( ai );
-			const b = getter[ el ]( bi );
-			const c = getter[ el ]( ci );
+			let a;
+			let b;
+			let c;
+
+			if ( posAttr.normalized ) {
+
+				a = posAttr[ getters[ el ] ]( ai );
+				b = posAttr[ getters[ el ] ]( bi );
+				c = posAttr[ getters[ el ] ]( ci );
+
+			} else {
+
+				a = posArr[ ai + el ];
+				b = posArr[ bi + el ];
+				c = posArr[ ci + el ];
+
+			}
 
 			let min = a;
 			if ( b < min ) min = b;

--- a/src/core/buildFunctions.js
+++ b/src/core/buildFunctions.js
@@ -560,33 +560,25 @@ function getAverage( triangleBounds, offset, count, axis ) {
 function computeTriangleBounds( geo, fullBounds ) {
 
 	const posAttr = geo.attributes.position;
-	const posArr = posAttr.array;
 	const index = geo.index.array;
 	const triCount = index.length / 3;
 	const triangleBounds = new Float32Array( triCount * 6 );
-
-	// support for an interleaved position buffer
-	const bufferOffset = posAttr.offset || 0;
-	let stride = 3;
-	if ( posAttr.isInterleavedBufferAttribute ) {
-
-		stride = posAttr.data.stride;
-
-	}
+	const getter = [ posAttr.getX.bind( posAttr ), posAttr.getY.bind( posAttr ), posAttr.getZ.bind( posAttr ) ];
 
 	for ( let tri = 0; tri < triCount; tri ++ ) {
 
 		const tri3 = tri * 3;
 		const tri6 = tri * 6;
-		const ai = index[ tri3 + 0 ] * stride + bufferOffset;
-		const bi = index[ tri3 + 1 ] * stride + bufferOffset;
-		const ci = index[ tri3 + 2 ] * stride + bufferOffset;
+
+		const ai = index[ tri3 + 0 ];
+		const bi = index[ tri3 + 1 ];
+		const ci = index[ tri3 + 2 ];
 
 		for ( let el = 0; el < 3; el ++ ) {
 
-			const a = posArr[ ai + el ];
-			const b = posArr[ bi + el ];
-			const c = posArr[ ci + el ];
+			const a = getter[ el ]( ai );
+			const b = getter[ el ]( bi );
+			const c = getter[ el ]( ci );
 
 			let min = a;
 			if ( b < min ) min = b;


### PR DESCRIPTION
Initial pass at trying to add support for normalized attributes to `three-mesh-bvh`, to address #448. I only found a single instance in the code of an obvious, direct position attribute array access, so I changed it to use the setter. I'm assuming that `geometry.index` will never be normalized, so didn't touch any direct array accesses for that.

With this change, `shapecast` worked again with my small examples I'd created to debug this issue. I didn't yet test raycasting, or any other feature. All unit tests continue to pass.

The `MeshBVHVisualizer` is still broken, and doesn't display at all on meshes with normalized position attributes. I also still don't have as complete of an idea of how `three-mesh-bvh`'s internals work as I like, so any feedback or pointers are welcome. I also have done no performance testing.