### PR TITLE
Update OrientedBox type to extend Box3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,14 @@ Set of shader functions used for interacting with the packed BVH in a shader and
 - A separate bounds tree is generated for each [geometry group](https://threejs.org/docs/#api/en/objects/Group), which could result in less than optimal raycast performance on geometry with lots of groups.
 - Due to errors related to floating point precision it is recommended that geometry be centered using `BufferGeometry.center()` before creating the BVH if the geometry is sufficiently large or off center so bounds tightly contain the geometry as much as possible.
 
+# Running Examples Locally
+
+To run the examples locally:
+- Run `npm start`
+- Then visit `localhost:9080/example/dev-bundle/<demo-name>.html`
+
+Where `<demo-name>` is the name of the HTML file from `example` folder.
+
 
 # Used and Supported by
 

--- a/README.md
+++ b/README.md
@@ -1072,14 +1072,6 @@ Set of shader functions used for interacting with the packed BVH in a shader and
 - A separate bounds tree is generated for each [geometry group](https://threejs.org/docs/#api/en/objects/Group), which could result in less than optimal raycast performance on geometry with lots of groups.
 - Due to errors related to floating point precision it is recommended that geometry be centered using `BufferGeometry.center()` before creating the BVH if the geometry is sufficiently large or off center so bounds tightly contain the geometry as much as possible.
 
-# Running Examples Locally
-
-To run the examples locally:
-- Run `npm start`
-- Then visit `localhost:9080/example/dev-bundle/<demo-name>.html`
-
-Where `<demo-name>` is the name of the HTML file from `example` folder.
-
 
 # Used and Supported by
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -318,7 +318,7 @@ export class OrientedBox extends Box3 {
   needsUpdate : boolean;
 
   constructor( min : Vector3, max : Vector3 );
-  set(min : Vector3, max : Vector3) : this
+  set( min : Vector3, max : Vector3 ) : this
   set( min : Vector3, max : Vector3, matrix? : Matrix4 ) : OrientedBox;
   intersectsBox( box : Box3 ) : boolean;
   intersectsTriangle( tri : Triangle ) : boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -312,13 +312,14 @@ export class ExtendedTriangle extends Triangle {
 
 }
 
-export class OrientedBox {
+export class OrientedBox extends Box3 {
 
   matrix : Matrix4;
   needsUpdate : boolean;
 
   constructor( min : Vector3, max : Vector3 );
-  set( min : Vector3, max : Vector3, matrix : Matrix4 ) : OrientedBox;
+  set(min : Vector3, max : Vector3) : this
+  set( min : Vector3, max : Vector3, matrix? : Matrix4 ) : OrientedBox;
   intersectsBox( box : Box3 ) : boolean;
   intersectsTriangle( tri : Triangle ) : boolean;
   closestPointToPoint( point : Vector3, target? : Vector3 ) : number;

--- a/src/math/OrientedBox.js
+++ b/src/math/OrientedBox.js
@@ -23,7 +23,7 @@ export class OrientedBox extends Box3 {
 	set( min, max, matrix ) {
 
 		super.set( min, max );
-		this.matrix.copy( matrix );
+		if ( matrix ) this.matrix.copy( matrix );
 		this.needsUpdate = true;
 
 	}


### PR DESCRIPTION
This PR updates the `OrientedBox` type to extend `Box3`. Typescript does not allow overloading where there is different arity so to work around this `OrientedBox` supports both the original` Box3` `set()` and the `OrientedBox` `set()`. To do this, `OrientedBox` `set()` is updated to make the matrix optional.