### PR TITLE
Add gpu distance to point functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Casting 500 rays against an 80,000 polygon model at 60fps!
 
 [Geometry edge intersection](https://gkjohnson.github.io/three-mesh-bvh/example/bundle/edgeIntersect.html)
 
+[SDF generation](https://gkjohnson.github.io/three-mesh-bvh/example/bundle/sdfGeneration.html)
+
 [WebWorker generation](https://gkjohnson.github.io/three-mesh-bvh/example/bundle/asyncGenerate.html)
 
 [BVH options inspector](https://gkjohnson.github.io/three-mesh-bvh/example/bundle/inspector.html)
@@ -60,7 +62,6 @@ Casting 500 rays against an 80,000 polygon model at 60fps!
 [CPU Path Tracing](https://gkjohnson.github.io/three-mesh-bvh/example/bundle/cpuPathTracing.html)
 
 [Gem Refraction Path Tracing](https://gkjohnson.github.io/three-mesh-bvh/example/bundle/diamond.html)
-
 
 **External Projects**
 

--- a/example/gpuPathTracingSimple.js
+++ b/example/gpuPathTracingSimple.js
@@ -11,7 +11,7 @@ import {
 const params = {
 	enableRaytracing: true,
 	animate: true,
-	resolutionScale: 0.5 / window.devicePixelRatio,
+	resolutionScale: 1.0 / window.devicePixelRatio,
 	smoothNormals: true,
 };
 

--- a/example/sdfGeneration.html
+++ b/example/sdfGeneration.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>three-mesh-bvh - Async BVH Generation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+    <style type="text/css">
+        html, body {
+            padding: 0;
+            margin: 0;
+            overflow: hidden;
+			font-family: monospace;
+        }
+
+        canvas {
+            width: 100%;
+            height: 100%;
+        }
+
+		#output {
+			color: #ffffff;
+			position: absolute;
+			left: 10px;
+			bottom: 10px;
+			white-space: pre;
+		}
+
+    </style>
+</head>
+<body>
+	<div id="output"></div>
+    <script type="module" src="./sdfGeneration.js"></script>
+</body>
+</html>

--- a/example/sdfGeneration.html
+++ b/example/sdfGeneration.html
@@ -10,6 +10,7 @@
             margin: 0;
             overflow: hidden;
 			font-family: monospace;
+			background-color: #111;
         }
 
         canvas {

--- a/example/sdfGeneration.html
+++ b/example/sdfGeneration.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>three-mesh-bvh - Async BVH Generation</title>
+    <title>three-mesh-bvh - Fast SDF Generation</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
     <style type="text/css">

--- a/example/sdfGeneration.html
+++ b/example/sdfGeneration.html
@@ -10,7 +10,7 @@
             margin: 0;
             overflow: hidden;
 			font-family: monospace;
-			background-color: #111;
+			background-color: #440727;
         }
 
         canvas {

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -88,41 +88,11 @@ function init() {
 
 	bvhGenerationWorker = new GenerateMeshBVHWorker();
 
-	// new GLTFLoader()
-	// 	.loadAsync( 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Suzanne/glTF/Suzanne.gltf' )
-	// 	.then( gltf => {
+	new GLTFLoader()
+		.loadAsync( 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Suzanne/glTF/Suzanne.gltf' )
+		.then( gltf => {
 
-	// 		const staticGen = new StaticGeometryGenerator( gltf.scene );
-	// 		staticGen.attributes = [ 'position', 'normal' ];
-	// 		staticGen.useGroups = false;
-
-	// 		geometry = staticGen.generate().center();
-
-	// 		return bvhGenerationWorker.generate( geometry, { maxLeafTris: 1 } );
-
-	// 	} )
-	// 	.then( result => {
-
-	// 		bvh = result;
-
-	// 		const mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
-	// 		scene.add( mesh );
-
-	// 		updateSDF();
-
-	// 	} );
-
-	Promise.resolve()
-		.then( () => {
-
-			const scene = new THREE.Scene();
-			const mesh = new THREE.Mesh(
-				new THREE.TorusKnotGeometry(),
-				new THREE.MeshStandardMaterial(),
-			);
-			scene.add( mesh );
-
-			const staticGen = new StaticGeometryGenerator( scene );
+			const staticGen = new StaticGeometryGenerator( gltf.scene );
 			staticGen.attributes = [ 'position', 'normal' ];
 			staticGen.useGroups = false;
 
@@ -135,12 +105,42 @@ function init() {
 
 			bvh = result;
 
-			mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
+			const mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 			scene.add( mesh );
 
 			updateSDF();
 
 		} );
+
+	// Promise.resolve()
+	// 	.then( () => {
+
+	// 		const scene = new THREE.Scene();
+	// 		const mesh = new THREE.Mesh(
+	// 			new THREE.TorusKnotGeometry(),
+	// 			new THREE.MeshStandardMaterial(),
+	// 		);
+	// 		scene.add( mesh );
+
+	// 		const staticGen = new StaticGeometryGenerator( scene );
+	// 		staticGen.attributes = [ 'position', 'normal' ];
+	// 		staticGen.useGroups = false;
+
+	// 		geometry = staticGen.generate().center();
+
+	// 		return bvhGenerationWorker.generate( geometry, { maxLeafTris: 1 } );
+
+	// 	} )
+	// 	.then( result => {
+
+	// 		bvh = result;
+
+	// 		mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
+	// 		scene.add( mesh );
+
+	// 		updateSDF();
+
+	// 	} );
 
 	rebuildGUI();
 

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -117,7 +117,7 @@ function init() {
 
 			const scene = new THREE.Scene();
 			const mesh = new THREE.Mesh(
-				new THREE.TorusKnotBufferGeometry(),
+				new THREE.TorusKnotGeometry(),
 				new THREE.MeshStandardMaterial(),
 			);
 			scene.add( mesh );
@@ -244,7 +244,6 @@ function updateSDF() {
 		sdfTex.minFilter = THREE.LinearFilter;
 		sdfTex.magFilter = THREE.LinearFilter;
 		sdfTex.needsUpdate = true;
-		window.SDFTEX = sdfTex;
 
 		const posAttr = geometry.attributes.position;
 		const indexAttr = geometry.index;
@@ -259,6 +258,8 @@ function updateSDF() {
 
 				for ( let z = 0; z < dim; z ++ ) {
 
+					// adjust by half width of the pixel so we sample the pixel center
+					// and offset by half the box size.
 					point.set(
 						halfWidth + x * pxWidth - 0.5,
 						halfWidth + y * pxWidth - 0.5,
@@ -299,7 +300,11 @@ function render() {
 	stats.update();
 	requestAnimationFrame( render );
 
-	if ( ! sdfTex || params.mode === 'geometry' ) {
+	if ( ! sdfTex ) {
+
+		return;
+
+	} else if ( params.mode === 'geometry' ) {
 
 		renderer.render( scene, camera );
 

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -35,21 +35,18 @@ render();
 
 function init() {
 
-	const bgColor = 0x111111;
-
 	outputContainer = document.getElementById( 'output' );
 
 	// renderer setup
 	renderer = new THREE.WebGLRenderer( { antialias: true } );
 	renderer.setPixelRatio( window.devicePixelRatio );
 	renderer.setSize( window.innerWidth, window.innerHeight );
-	renderer.setClearColor( bgColor, 1 );
+	renderer.setClearColor( 0, 0 );
 	renderer.outputEncoding = THREE.sRGBEncoding;
 	document.body.appendChild( renderer.domElement );
 
 	// scene setup
 	scene = new THREE.Scene();
-	scene.fog = new THREE.Fog( 0x111111, 20, 60 );
 
 	const light = new THREE.DirectionalLight( 0xffffff, 1 );
 	light.position.set( 1, 1, 1 );

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -163,7 +163,7 @@ function rebuildGUI() {
 
 	}
 
-	params.layer = 0;
+	params.layer = Math.min( params.size, params.layer );
 
 	gui = new GUI();
 

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -1,0 +1,215 @@
+import * as THREE from 'three';
+import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import Stats from 'stats.js';
+import { GenerateMeshBVHWorker } from '../src/workers/GenerateMeshBVHWorker.js';
+import { StaticGeometryGenerator } from '..';
+import { GenerateSDFMaterial } from './utils/GenerateSDFMaterial.js';
+
+const params = {
+
+	gpuGeneration: true,
+	size: 50,
+	margin: 0.1,
+	regenerate: () => updateSDF(),
+
+};
+
+let renderer, camera, scene, knot, clock, gui, helper, group, stats;
+let outputContainer, loadContainer, loadBar, loadText, bvh, geometry, sdfTex, sdfPass;
+let bvhGenerationWorker;
+
+init();
+render();
+
+function init() {
+
+	const bgColor = 0x111111;
+
+	outputContainer = document.getElementById( 'output' );
+	loadContainer = document.getElementById( 'loading-container' );
+	loadBar = document.querySelector( '#loading-container .bar' );
+	loadText = document.querySelector( '#loading-container .text' );
+
+	// renderer setup
+	renderer = new THREE.WebGLRenderer( { antialias: true } );
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.setClearColor( bgColor, 1 );
+	renderer.outputEncoding = THREE.sRGBEncoding;
+	document.body.appendChild( renderer.domElement );
+
+	// scene setup
+	scene = new THREE.Scene();
+	scene.fog = new THREE.Fog( 0x111111, 20, 60 );
+
+	const light = new THREE.DirectionalLight( 0xffffff, 1 );
+	light.position.set( 1, 1, 1 );
+	scene.add( light );
+	scene.add( new THREE.AmbientLight( 0xffffff, 0.2 ) );
+
+	// camera setup
+	camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 50 );
+	camera.position.set( 0, 0, 4 );
+	camera.far = 100;
+	camera.updateProjectionMatrix();
+
+	new OrbitControls( camera, renderer.domElement );
+
+	clock = new THREE.Clock();
+
+	// stats setup
+	stats = new Stats();
+	document.body.appendChild( stats.dom );
+
+	sdfPass = new FullScreenQuad( new GenerateSDFMaterial() );
+
+	bvhGenerationWorker = new GenerateMeshBVHWorker();
+
+	new GLTFLoader()
+		.setMeshoptDecoder( MeshoptDecoder )
+		.loadAsync( 'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/main/models/vino-bike/scene.gltf' )
+		.then( gltf => {
+
+			const staticGen = new StaticGeometryGenerator( gltf.scene );
+			staticGen.attributes = [ 'position', 'normal' ];
+			staticGen.useGroups = false;
+
+			geometry = staticGen.generate().center();
+
+			return bvhGenerationWorker.generate( geometry, { maxLeafTris: 1 } );
+
+		} )
+		.then( result => {
+
+			bvh = result;
+
+			const mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
+			scene.add( mesh );
+
+			updateSDF();
+
+		} );
+
+	gui = new GUI();
+
+	const generation = gui.addFolder( 'generation' );
+	generation.add( params, 'gpuGeneration' );
+	generation.add( params, 'size', 10, 200, 1 );
+	generation.add( params, 'margin', 0, 1 );
+	generation.add( params, 'regenerate' );
+
+	window.addEventListener( 'resize', function () {
+
+		camera.aspect = window.innerWidth / window.innerHeight;
+		camera.updateProjectionMatrix();
+
+		renderer.setSize( window.innerWidth, window.innerHeight );
+
+	}, false );
+
+}
+
+function updateSDF() {
+
+	const dim = params.size;
+	const matrix = new THREE.Matrix4();
+	const center = new THREE.Vector3();
+	const quat = new THREE.Quaternion();
+	const scale = new THREE.Vector3();
+
+	geometry.boundingBox.getCenter( center );
+	scale.subVectors( geometry.boundingBox.max, geometry.boundingBox.min );
+	scale.x += params.margin;
+	scale.y += params.margin;
+	scale.z += params.margin;
+	matrix.compose( center, quat, scale ).invert();
+
+	if ( sdfTex ) {
+
+		sdfTex.dispose();
+
+	}
+
+	const pxWidth = 1 / dim;
+	const halfWidth = 0.5 * pxWidth;
+
+	const startTime = window.performance.now();
+	if ( params.gpuGeneration ) {
+
+		sdfTex = new THREE.WebGL3DRenderTarget( dim, dim, dim );
+		sdfTex.texture.format = THREE.RedFormat;
+		sdfTex.texture.type = THREE.FloatType;
+		sdfTex.texture.minFilter = THREE.LinearFilter;
+		sdfTex.texture.magFilter = THREE.LinearFilter;
+
+		sdfPass.material.uniforms.bvh.value.updateFrom( bvh );
+		sdfPass.material.uniforms.matrix.value.copy( matrix );
+
+		for ( let i = 0; i < dim; i ++ ) {
+
+			sdfPass.material.uniforms.zValue.value = i * pxWidth + halfWidth;
+
+			renderer.setRenderTarget( sdfTex, i );
+			sdfPass.render( renderer );
+
+		}
+
+		// initiate readback to get a rough estimate of time taken to generate the sdf
+		renderer.readRenderTargetPixels( sdfTex, 0, 0, 1, 1, new Float32Array( 4 ) );
+		renderer.setRenderTarget( null );
+
+	} else {
+
+		sdfTex = new THREE.Data3DTexture( new Float32Array( dim ** 3 ), dim, dim, dim );
+		sdfTex.format = THREE.RedFormat;
+		sdfTex.type = THREE.FloatType;
+		sdfTex.minFilter = THREE.LinearFilter;
+		sdfTex.magFilter = THREE.LinearFilter;
+
+		const point = new THREE.Vector3();
+		for ( let x = 0; x < dim; x ++ ) {
+
+			for ( let y = 0; y < dim; y ++ ) {
+
+				for ( let z = 0; z < dim; z ++ ) {
+
+					point.set(
+						halfWidth + x * pxWidth - 0.5,
+						halfWidth + y * pxWidth - 0.5,
+						halfWidth + z * pxWidth - 0.5,
+					).applyMatrix4( matrix );
+
+					const index = x + y * dim + z * dim * dim;
+					sdfTex.image.data[ index ] = bvh.closestPointToPoint( point );
+
+				}
+
+			}
+
+		}
+
+	}
+
+	const delta = window.performance.now() - startTime;
+	outputContainer.innerText = `${ delta.toFixed( 2 ) }ms`;
+
+}
+
+function render() {
+
+	stats.update();
+	requestAnimationFrame( render );
+
+	if ( helper ) {
+
+		helper.visible = params.displayHelper;
+
+	}
+
+	renderer.render( scene, camera );
+
+}

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -8,10 +8,9 @@ import { GenerateMeshBVHWorker } from '../src/workers/GenerateMeshBVHWorker.js';
 import { StaticGeometryGenerator } from '..';
 import { GenerateSDFMaterial } from './utils/GenerateSDFMaterial.js';
 import { RenderSDFLayerMaterial } from './utils/RenderSDFLayerMaterial.js';
-import { RenderSDFMaterial } from './utils/RenderSDFMaterial.js';
+import { RayMarchSDFMaterial } from './utils/RayMarchSDFMaterial.js';
 
 // TODO
-// fix rendering gpu sdf
 // raymarching
 // visuals
 // use gltf model instead of torus knot
@@ -24,7 +23,7 @@ const params = {
 	margin: 0.1,
 	regenerate: () => updateSDF(),
 
-	mode: 'layer',
+	mode: 'raymarching',
 	layer: 0,
 
 };
@@ -84,7 +83,7 @@ function init() {
 
 	layerPass = new FullScreenQuad( new RenderSDFLayerMaterial() );
 
-	raymarchPass = new FullScreenQuad( new RenderSDFMaterial() );
+	raymarchPass = new FullScreenQuad( new RayMarchSDFMaterial() );
 
 	bvhGenerationWorker = new GenerateMeshBVHWorker();
 
@@ -105,7 +104,7 @@ function init() {
 
 			bvh = result;
 
-			const mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
+			mesh = new THREE.Mesh( geometry, new THREE.MeshStandardMaterial() );
 			scene.add( mesh );
 
 			updateSDF();
@@ -332,6 +331,7 @@ function render() {
 		raymarchPass.material.uniforms.sdfTex.value = sdfTex;
 		raymarchPass.material.uniforms.projectionInverse.value.copy( camera.projectionMatrixInverse );
 		raymarchPass.material.uniforms.sdfTransformInverse.value.copy( mesh.matrixWorld ).multiply( camera.matrixWorldInverse );
+		raymarchPass.render( renderer );
 
 	}
 

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -19,7 +19,7 @@ import { RenderSDFMaterial } from './utils/RenderSDFMaterial.js';
 
 const params = {
 
-	gpuGeneration: false,
+	gpuGeneration: true,
 	size: 50,
 	margin: 0.1,
 	regenerate: () => updateSDF(),
@@ -310,9 +310,18 @@ function render() {
 
 	} else if ( params.mode === 'layer' ) {
 
-		const size = sdfTex.isData3DTexture ? sdfTex.image.width : sdfTex.width;
-		layerPass.material.uniforms.sdfTex.value = sdfTex;
-		layerPass.material.uniforms.layer.value = params.layer / size;
+		if ( sdfTex.isData3DTexture ) {
+
+			layerPass.material.uniforms.layer.value = params.layer / sdfTex.image.width;
+			layerPass.material.uniforms.sdfTex.value = sdfTex;
+
+		} else {
+
+			layerPass.material.uniforms.layer.value = params.layer / sdfTex.width;
+			layerPass.material.uniforms.sdfTex.value = sdfTex.texture;
+
+		}
+
 		layerPass.render( renderer );
 
 	} else if ( params.mode === 'raymarching' ) {

--- a/example/utils/GenerateSDFMaterial.js
+++ b/example/utils/GenerateSDFMaterial.js
@@ -45,17 +45,20 @@ export class GenerateSDFMaterial extends ShaderMaterial {
 
 				void main() {
 
+					// compute the point in space to check
 					vec3 point = vec3( vUv, zValue );
 					point -= vec3( 0.5 );
 					point = ( matrix * vec4( point, 1.0 ) ).xyz;
 
+					// retrieve the distance and other values
 					uvec4 faceIndices;
 					vec3 faceNormal;
 					vec3 barycoord;
 					float side;
 					vec3 outPoint;
-
 					float dist = bvhClosestPointToPoint( bvh, point.xyz, faceIndices, faceNormal, barycoord, side, outPoint );
+
+					// if the triangle side is the back then it must be on the inside and the value negative
 					gl_FragColor = vec4( side * dist, 0, 0, 0 );
 
 				}

--- a/example/utils/GenerateSDFMaterial.js
+++ b/example/utils/GenerateSDFMaterial.js
@@ -56,7 +56,7 @@ export class GenerateSDFMaterial extends ShaderMaterial {
 					vec3 outPoint;
 
 					float dist = bvhClosestPointToPoint( bvh, point.xyz, faceIndices, faceNormal, barycoord, side, outPoint );
-					gl_FragColor = vec4( dist, 0, 0, 0 );
+					gl_FragColor = vec4( side * dist, 0, 0, 0 );
 
 				}
 

--- a/example/utils/GenerateSDFMaterial.js
+++ b/example/utils/GenerateSDFMaterial.js
@@ -1,0 +1,62 @@
+import { ShaderMaterial, Matrix4 } from 'three';
+import { shaderIntersectFunction, shaderDistanceFunction, shaderStructs, MeshBVHUniformStruct } from '../..';
+
+export class GenerateSDFMaterial extends ShaderMaterial {
+
+	constructor( params ) {
+
+		super( {
+
+			uniforms: {
+
+				matrix: { value: new Matrix4() },
+				zValue: { value: 0 },
+				bvh: { value: new MeshBVHUniformStruct() }
+
+			},
+
+			vertexShader: /* glsl */`
+
+				varying vec2 vUv;
+
+				void main() {
+
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+				}
+
+			`,
+
+			fragmentShader: /* glsl */`
+
+				precision highp isampler2D;
+				precision highp usampler2D;
+
+				${ shaderStructs }
+				${ shaderIntersectFunction }
+				${ shaderDistanceFunction }
+
+				varying vec2 vUv;
+
+				uniform BVH bvh;
+				uniform float zValue;
+				uniform mat4 matrix;
+
+				void main() {
+
+					vec4 point = matrix * vec4( vUv, zValue, 1.0 );
+					float dist = bvhClosestPointToPoint( bvh, point.xyz );
+					gl_FragColor = vec4( dist, 0, 0, 0 );
+
+				}
+
+			`
+
+		} );
+
+		this.setValues( params );
+
+	}
+
+}

--- a/example/utils/GenerateSDFMaterial.js
+++ b/example/utils/GenerateSDFMaterial.js
@@ -49,7 +49,13 @@ export class GenerateSDFMaterial extends ShaderMaterial {
 					point -= vec3( 0.5 );
 					point = ( matrix * vec4( point, 1.0 ) ).xyz;
 
-					float dist = bvhClosestPointToPoint( bvh, point.xyz );
+					uvec4 faceIndices;
+					vec3 faceNormal;
+					vec3 barycoord;
+					float side;
+					vec3 outPoint;
+
+					float dist = bvhClosestPointToPoint( bvh, point.xyz, faceIndices, faceNormal, barycoord, side, outPoint );
 					gl_FragColor = vec4( dist, 0, 0, 0 );
 
 				}

--- a/example/utils/GenerateSDFMaterial.js
+++ b/example/utils/GenerateSDFMaterial.js
@@ -45,7 +45,10 @@ export class GenerateSDFMaterial extends ShaderMaterial {
 
 				void main() {
 
-					vec4 point = matrix * vec4( vUv, zValue, 1.0 );
+					vec3 point = vec3( vUv, zValue );
+					point -= vec3( 0.5 );
+					point = ( matrix * vec4( point, 1.0 ) ).xyz;
+
 					float dist = bvhClosestPointToPoint( bvh, point.xyz );
 					gl_FragColor = vec4( dist, 0, 0, 0 );
 

--- a/example/utils/RayMarchSDFMaterial.js
+++ b/example/utils/RayMarchSDFMaterial.js
@@ -1,6 +1,6 @@
 import { ShaderMaterial, Matrix4 } from 'three';
 
-export class RenderSDFMaterial extends ShaderMaterial {
+export class RayMarchSDFMaterial extends ShaderMaterial {
 
 	constructor( params ) {
 
@@ -69,7 +69,7 @@ export class RenderSDFMaterial extends ShaderMaterial {
 				void main() {
 
 					// get world ray direction
-					vec3 rayOrigin = vec4( 0.0 );
+					vec3 rayOrigin = vec3( 0.0 );
 					vec4 homogenousDirection = projectionInverse * vec3( vUv, 0.0, 1.0 );
 					vec3 rayDirection = normalize( homogenousDirection.xyz / homogenousDirection.w );
 

--- a/example/utils/RayMarchSDFMaterial.js
+++ b/example/utils/RayMarchSDFMaterial.js
@@ -1,4 +1,4 @@
-import { ShaderMaterial, Matrix4 } from 'three';
+import { ShaderMaterial, Matrix4, Vector3 } from 'three';
 
 export class RayMarchSDFMaterial extends ShaderMaterial {
 
@@ -15,8 +15,9 @@ export class RayMarchSDFMaterial extends ShaderMaterial {
 
 			uniforms: {
 
+				surface: { value: 0 },
 				sdfTex: { value: null },
-				normalStep: { value: 0.01 },
+				normalStep: { value: new Vector3() },
 				projectionInverse: { value: new Matrix4() },
 				sdfTransformInverse: { value: new Matrix4() }
 
@@ -40,16 +41,15 @@ export class RayMarchSDFMaterial extends ShaderMaterial {
 
 				varying vec2 vUv;
 
+				uniform float surface;
 				uniform sampler3D sdfTex;
-				uniform float normalStep;
+				uniform vec3 normalStep;
 				uniform mat4 projectionInverse;
 				uniform mat4 sdfTransformInverse;
 
 				#include <common>
 
 				// distance to box bounds
-				// TODO: find comment describing algorithm
-				// TODO: update output values
 				vec2 rayBoxDist( vec3 boundsMin, vec3 boundsMax, vec3 rayOrigin, vec3 rayDir ) {
 
 					vec3 t0 = ( boundsMin - rayOrigin ) / rayDir;
@@ -68,65 +68,85 @@ export class RayMarchSDFMaterial extends ShaderMaterial {
 
 				void main() {
 
+					// get the inverse of the sdf box transform
+					mat4 sdfTransform = inverse( sdfTransformInverse );
+
+					// convert the uv to clip space for ray transformation
+					vec2 clipSpace = 2.0 * vUv - vec2( 1.0 );
+
 					// get world ray direction
 					vec3 rayOrigin = vec3( 0.0 );
-					vec4 homogenousDirection = projectionInverse * vec3( vUv, 0.0, 1.0 );
+					vec4 homogenousDirection = projectionInverse * vec4( clipSpace, - 1.0, 1.0 );
 					vec3 rayDirection = normalize( homogenousDirection.xyz / homogenousDirection.w );
 
-					// transform ray into local coordinates of box
-					rayOrigin = ( sdfTransformInverse * vec4( rayOrigin, 1.0 ) ).xyz;
-					rayDirection = normalize( ( sdfTransformInverse * vec4( rayDirection, 0.0 ) ).xyz );
+					// transform ray into local coordinates of sdf bounds
+					vec3 sdfRayOrigin = ( sdfTransformInverse * vec4( rayOrigin, 1.0 ) ).xyz;
+					vec3 sdfRayDirection = normalize( ( sdfTransformInverse * vec4( rayDirection, 0.0 ) ).xyz );
 
-					// TODO: just make this a "hit box" flag / output location
-					vec2 boxIntersectionInfo = rayBoxDist( vec3( - 0.5 ), vec3( 0.5 ), rayOrigin, rayDirection );
+					// find whether our ray hits the box bounds in the local box space
+					vec2 boxIntersectionInfo = rayBoxDist( vec3( - 0.5 ), vec3( 0.5 ), sdfRayOrigin, sdfRayDirection );
 					float distToBox = boxIntersectionInfo.x;
 					float distInsideBox = boxIntersectionInfo.y;
-					bool intersectsBox = distInsideBox > 0.0 && distToBox < linDepth - 0.1;
+					bool intersectsBox = distInsideBox > 0.0;
 
 					gl_FragColor = vec4( 0.0 );
 					if ( intersectsBox ) {
 
-
+						// find the surface point in world space
 						bool intersectsSurface = false;
-						vec3 point = origin + rayDirection * distToBox;
+						vec4 localPoint = vec4( sdfRayOrigin + sdfRayDirection * ( distToBox + 1e-5 ), 1.0 );
+						vec4 point = sdfTransform * localPoint;
+
+						// ray march
 						for ( int i = 0; i < MAX_STEPS; i ++ ) {
 
 							// sdf box extends from - 0.5 to 0.5
-							vec3 uv = point + vex3( 0.5 );
+							// transform into the local bounds space [ 0, 1 ] and check if we're inside the bounds
+							vec3 uv = ( sdfTransformInverse * point ).xyz + vec3( 0.5 );
 							if ( uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 || uv.z < 0.0 || uv.z > 1.0 ) {
 
 								break;
 
 							}
 
-							// sample the sdf texture
-							float distanceToSurface = texture( sdfTex, uv );
-							if ( abs( distanceToSurface ) < SURFACE_EPSILON ) {
+							// get the distance to surface and exit the loop if we're close to the surface
+							float distanceToSurface = texture2D( sdfTex, uv ).r - surface;
+							if ( distanceToSurface < SURFACE_EPSILON ) {
 
 								intersectsSurface = true;
 								break;
 
 							}
 
-							point += rayDirection * distanceToSurface;
+							// step the ray
+							point.xyz += rayDirection * abs( distanceToSurface );
 
 						}
 
-						// find the surface
+						// find the surface normal
 						if ( intersectsSurface ) {
 
-							float dx = texture( sdfTex, samplePoint + vec3( normalStep, 0.0, 0.0 ) ) - texture( sdfTex, samplePoint - vec3( normalStep, 0.0, 0.0 ) );
-							float dy = texture( sdfTex, samplePoint + vec3( 0.0, normalStep, 0.0 ) ) - texture( sdfTex, samplePoint - vec3( 0.0, normalStep, 0.0 ) );
-							float dz = texture( sdfTex, samplePoint + vec3( 0.0, 0.0, normalStep ) ) - texture( sdfTex, samplePoint - vec3( 0.0, 0.0, normalStep ) );
+							// compute the surface normal
+							vec3 uv = ( sdfTransformInverse * point ).xyz + vec3( 0.5 );
+							float dx = texture( sdfTex, uv + vec3( normalStep.x, 0.0, 0.0 ) ).r - texture( sdfTex, uv - vec3( normalStep.x, 0.0, 0.0 ) ).r;
+							float dy = texture( sdfTex, uv + vec3( 0.0, normalStep.y, 0.0 ) ).r - texture( sdfTex, uv - vec3( 0.0, normalStep.y, 0.0 ) ).r;
+							float dz = texture( sdfTex, uv + vec3( 0.0, 0.0, normalStep.z ) ).r - texture( sdfTex, uv - vec3( 0.0, 0.0, normalStep.z ) ).r;
 							vec3 normal = normalize( vec3( dx, dy, dz ) );
 
-							// NOTE: could handle lighting from light objects here
+							// compute some basic lighting effects
 							vec3 lightDirection = normalize( vec3( 1.0 ) );
-							gl_FragColor = vec4( dot( normal, lightDirection ), 1.0 ) ;
+							float lightIntensity =
+								saturate( dot( normal, lightDirection ) ) +
+								saturate( dot( normal, - lightDirection ) ) * 0.05 +
+								0.1;
+							gl_FragColor.rgb = vec3( lightIntensity );
+							gl_FragColor.a = 1.0;
 
 						}
 
 					}
+
+					#include <encodings_fragment>
 
 				}
 			`

--- a/example/utils/RenderSDFLayerMaterial.js
+++ b/example/utils/RenderSDFLayerMaterial.js
@@ -1,0 +1,51 @@
+import { ShaderMaterial } from 'three';
+
+export class RenderSDFLayerMaterial extends ShaderMaterial {
+
+	constructor( params ) {
+
+		super( {
+
+			uniforms: {
+
+				sdfTex: { value: null },
+				layer: { value: 0 },
+
+			},
+
+			vertexShader: /* glsl */`
+
+				varying vec2 vUv;
+
+				void main() {
+
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+				}
+
+			`,
+
+			fragmentShader: /* glsl */`
+				precision highp sampler3D;
+
+				varying vec2 vUv;
+				uniform sampler3D sdfTex;
+				uniform float layer;
+
+				void main() {
+
+					float dist = texture( sdfTex, vec3( vUv, layer ) ).r;
+					gl_FragColor.rgb = dist > 0.0 ? vec3( 0, dist, 0 ) : vec3( - dist, 0, 0 );
+					gl_FragColor.a = 1.0;
+
+				}
+			`
+
+		} );
+
+		this.setValues( params );
+
+	}
+
+}

--- a/example/utils/RenderSDFMaterial.js
+++ b/example/utils/RenderSDFMaterial.js
@@ -1,4 +1,4 @@
-import { ShaderMaterial, Matrix4, Vector3, Vector2 } from 'three';
+import { ShaderMaterial, Matrix4 } from 'three';
 
 export class RenderSDFMaterial extends ShaderMaterial {
 
@@ -6,16 +6,19 @@ export class RenderSDFMaterial extends ShaderMaterial {
 
 		super( {
 
+			defines: {
+
+				MAX_STEPS: 500,
+				SURFACE_EPSILON: 0.001,
+
+			},
+
 			uniforms: {
 
-				sdfTexture: { value: null },
-				projectionMatrixInv: { value: new Matrix4() },
-				viewMatrixInv: { value: new Matrix4() },
-				cameraPos: { value: new Vector3() },
-				normalStep: { value: new Vector3() },
-				sdfMat: { value: new Matrix4() },
-				sdfMatInv: { value: new Matrix4() },
-				resolution: { value: new Vector2() }
+				sdfTex: { value: null },
+				normalStep: { value: 0.01 },
+				projectionInverse: { value: new Matrix4() },
+				sdfTransformInverse: { value: new Matrix4() }
 
 			},
 
@@ -37,31 +40,16 @@ export class RenderSDFMaterial extends ShaderMaterial {
 
 				varying vec2 vUv;
 
-				uniform sampler2D sceneDepth;
-				uniform sampler3D sdfTexture;
-				uniform mat4 projectionMatrixInv;
-				uniform mat4 viewMatrixInv;
-				uniform mat4 sdfMat;
-				uniform mat4 sdfMatInv;
-				uniform vec3 cameraPos;
-				uniform vec2 resolution;
+				uniform sampler3D sdfTex;
+				uniform float normalStep;
+				uniform mat4 projectionInverse;
+				uniform mat4 sdfTransformInverse;
 
 				#include <common>
 
-				vec3 getWorldPos( float depth, vec2 coord ) {
-
-					float z = depth * 2.0 - 1.0;
-					vec4 clipSpacePosition = vec4( coord * 2.0 - 1.0, z, 1.0 );
-					vec4 viewSpacePosition = projectionMatrixInv * clipSpacePosition;
-
-					// Perspective division
-					viewSpacePosition /= viewSpacePosition.w;
-
-					vec4 worldSpacePosition = viewMatrixInv * viewSpacePosition;
-					return worldSpacePosition.xyz;
-
-				}
-
+				// distance to box bounds
+				// TODO: find comment describing algorithm
+				// TODO: update output values
 				vec2 rayBoxDist( vec3 boundsMin, vec3 boundsMax, vec3 rayOrigin, vec3 rayDir ) {
 
 					vec3 t0 = ( boundsMin - rayOrigin ) / rayDir;
@@ -78,230 +66,63 @@ export class RenderSDFMaterial extends ShaderMaterial {
 
 				}
 
-				vec3 toSDFSpace( vec3 point ) {
-
-					return ( sdfMatInv * vec4( point, 1.0 ) ).xyz;
-
-				}
-
-				vec3 texCoord( vec3 samplePoint ) {
-
-					samplePoint = samplePoint;
-					return ( samplePoint + ( boxSize / 2.0 ) - boxCenter ) / boxSize;
-
-				}
-
-				float map( vec3 texCoord ) {
-
-					float timePeriod = mod( time * 0.2, 3.0 );
-					float dist = texture( sdfTexture1, texCoord ).x;
-					return dist;
-
-				}
-
-				vec4 colorMap( vec3 texCoord ) {
-
-					return texture( sdfTexture2, texCoord );
-
-				}
-
-				vec3 colorMapSampleSmart( vec3 p, vec3 n ) {
-
-					vec4 initialSample = colorMap( texCoord( p ) );
-					vec3 col = vec3( 0.0 );
-					if ( initialSample.w < 1.0 ) {
-
-						float maxW = initialSample.w;
-						vec3 total = initialSample.w * initialSample.rgb;
-						vec4 c = colorMap( texCoord( p + n ) );
-						maxW += c.w;
-						total += c.xyz * c.w;
-						c = colorMap( texCoord( p - n ) );
-						maxW += c.w;
-						total += c.xyz * c.w;
-
-						if ( maxW < 1.0 ) {
-
-							float weight = 1.0 - clamp( ( maxW - 0.75 ) / 0.25, 0.0, 1.0 );
-							for( float x = -1.0; x <= 1.0; x += 2.0 ) {
-
-								for( float y = -1.0; y <= 1.0; y+= 2.0 ) {
-
-									for( float z = -1.0; z <= 1.0; z+= 2.0 ) {
-
-										vec4 c = colorMap(texCoord(p + vec3( x, y, z ) ) );
-										maxW += c.w * weight;
-										total += c.xyz * c.w * weight;
-
-									}
-
-								}
-
-							}
-
-						}
-
-						col = mix( initialSample.xyz, total / maxW, 1.0 - clamp( ( initialSample.w ) / 1.0, 0.0, 1.0 ) );
-
-					} else {
-
-						col = initialSample.xyz;
-
-					}
-					return col;
-
-				}
-
-
-				vec3 getNormal( vec3 samplePoint ) {
-
-					return normalize( vec3(
-						map( texCoord( samplePoint + vec3( normalStep, 0.0, 0.0 ) ) ) - map( texCoord( samplePoint - vec3( normalStep, 0.0, 0.0 ) ) ),
-						map( texCoord( samplePoint + vec3( 0.0, normalStep, 0.0 ) ) ) - map( texCoord( samplePoint - vec3( 0.0, normalStep, 0.0 ) ) ),
-						map( texCoord( samplePoint + vec3( 0.0, 0.0, normalStep ) ) ) - map( texCoord( samplePoint - vec3( 0.0, 0.0, normalStep ) ) )
-					));
-
-				}
-
-				vec3 computeNormal( vec3 worldPos ) {
-
-					vec2 downUv = vUv + vec2( 0.0, 1.0 / resolution.y );
-					vec3 downPos = getWorldPos( texture2D( sceneDepth, downUv ).x, downUv ).xyz;
-					vec2 rightUv = vUv + vec2( 1.0 / resolution.x, 0.0 );
-					vec3 rightPos = getWorldPos( texture2D( sceneDepth, rightUv ).x, rightUv ).xyz;
-					vec2 upUv = vUv - vec2( 0.0, 1.0 / resolution.y );
-					vec3 upPos = getWorldPos( texture2D( sceneDepth, upUv ).x, upUv ).xyz;
-					vec2 leftUv = vUv - vec2( 1.0 / resolution.x, 0.0 );
-					vec3 leftPos = getWorldPos( texture2D( sceneDepth, leftUv ).x, leftUv ).xyz;
-					int hChoice;
-					int vChoice;
-					if ( length( leftPos - worldPos ) < length( rightPos - worldPos ) ) {
-
-						hChoice = 0;
-
-					} else {
-
-						hChoice = 1;
-
-					}
-
-					if ( length( upPos - worldPos ) < length( downPos - worldPos ) ) {
-
-						vChoice = 0;
-
-					} else {
-
-						vChoice = 1;
-
-					}
-
-					vec3 hVec;
-					vec3 vVec;
-					if ( hChoice == 0 && vChoice == 0 ) {
-
-						hVec = leftPos - worldPos;
-						vVec = upPos - worldPos;
-
-					} else if ( hChoice == 0 && vChoice == 1 ) {
-
-						hVec = leftPos - worldPos;
-						vVec = worldPos - downPos;
-
-					} else if ( hChoice == 1 && vChoice == 1 ) {
-
-						hVec = rightPos - worldPos;
-						vVec = downPos - worldPos;
-
-					} else if ( hChoice == 1 && vChoice == 0 ) {
-
-						hVec = rightPos - worldPos;
-						vVec = worldPos - upPos;
-
-					}
-
-					return normalize( cross( hVec, vVec ) );
-
-				}
-
 				void main() {
 
-					vec4 diffuse = texture2D( sceneDiffuse, vUv );
-					float depth = texture2D( sceneDepth, vUv ).x;
-					vec3 worldPos = getWorldPos( depth, vUv );
-					vec3 normal = ( viewMatrixInv * normalize( vec4( ( texture2D(normalTexture, vUv).rgb - 0.5 ) * 2.0, 0.0 ) ) ).xyz;
-					vec3 origin = cameraPos;
-					float linDepth = length( origin - worldPos );
-					vec3 rayDir = normalize( worldPos - origin );
-					origin = ( sdfMatInv * vec4( origin, 1.0 ) ).xyz;
-					rayDir = normalize( ( sdfMatInv * vec4( rayDir, 0.0 ) ).xyz );
-					vec2 boxIntersectionInfo = rayBoxDist( boxCenter - boxSize / 2.0, boxCenter + boxSize / 2.0, origin, rayDir );
+					// get world ray direction
+					vec3 rayOrigin = vec4( 0.0 );
+					vec4 homogenousDirection = projectionInverse * vec3( vUv, 0.0, 1.0 );
+					vec3 rayDirection = normalize( homogenousDirection.xyz / homogenousDirection.w );
+
+					// transform ray into local coordinates of box
+					rayOrigin = ( sdfTransformInverse * vec4( rayOrigin, 1.0 ) ).xyz;
+					rayDirection = normalize( ( sdfTransformInverse * vec4( rayDirection, 0.0 ) ).xyz );
+
+					// TODO: just make this a "hit box" flag / output location
+					vec2 boxIntersectionInfo = rayBoxDist( vec3( - 0.5 ), vec3( 0.5 ), rayOrigin, rayDirection );
 					float distToBox = boxIntersectionInfo.x;
 					float distInsideBox = boxIntersectionInfo.y;
 					bool intersectsBox = distInsideBox > 0.0 && distToBox < linDepth - 0.1;
-					gl_FragColor = vec4( diffuse.rgb, 1.0 );
-					vec3 lightDir = normalize( vec3( 150.0, 200.0, 50.0 ) );
-					bool intersectedSDF = false;
-					vec3 col = vec3( 0.0 );
 
+					gl_FragColor = vec4( 0.0 );
 					if ( intersectsBox ) {
 
-						vec3 startPos = origin + distToBox * rayDir;
-						float distanceAlongRay = 0.01;
-						bool hit = false;
-						for( int i = 0; i < 2048; i ++ ) {
 
-							vec3 samplePoint = startPos + rayDir * distanceAlongRay;
-							if ( distance( samplePoint, origin ) > linDepth ) {
+						bool intersectsSurface = false;
+						vec3 point = origin + rayDirection * distToBox;
+						for ( int i = 0; i < MAX_STEPS; i ++ ) {
 
-								break;
-
-							}
-
-							vec3 tex = texCoord( samplePoint );
-							//samplePoint = (samplePoint + (boxSize / 2.0) - boxCenter) / boxSize;
-							if ( tex.x < 0.0 || tex.x > 1.0 || tex.y < 0.0 || tex.y > 1.0 || tex.z < 0.0 || tex.z > 1.0 ) {
+							// sdf box extends from - 0.5 to 0.5
+							vec3 uv = point + vex3( 0.5 );
+							if ( uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0 || uv.z < 0.0 || uv.z > 1.0 ) {
 
 								break;
 
 							}
 
-							float distToSurface = map( tex );
-							distanceAlongRay += distToSurface;
-							if ( distToSurface < 0.01 ) {
+							// sample the sdf texture
+							float distanceToSurface = texture( sdfTex, uv );
+							if ( abs( distanceToSurface ) < SURFACE_EPSILON ) {
 
-								hit = true;
+								intersectsSurface = true;
 								break;
 
 							}
+
+							point += rayDirection * distanceToSurface;
 
 						}
 
-						if ( hit ) {
+						// find the surface
+						if ( intersectsSurface ) {
 
-							vec3 p = startPos + rayDir * distanceAlongRay;
-							vec3 n = getNormal( p );
+							float dx = texture( sdfTex, samplePoint + vec3( normalStep, 0.0, 0.0 ) ) - texture( sdfTex, samplePoint - vec3( normalStep, 0.0, 0.0 ) );
+							float dy = texture( sdfTex, samplePoint + vec3( 0.0, normalStep, 0.0 ) ) - texture( sdfTex, samplePoint - vec3( 0.0, normalStep, 0.0 ) );
+							float dz = texture( sdfTex, samplePoint + vec3( 0.0, 0.0, normalStep ) ) - texture( sdfTex, samplePoint - vec3( 0.0, 0.0, normalStep ) );
+							vec3 normal = normalize( vec3( dx, dy, dz ) );
 
-							col =  colorMapSampleSmart( p, n );
-							normal = normalize( ( sdfMat * vec4( n, 0.0 ) ) ).xyz;
-							worldPos = ( sdfMat * vec4( p, 1.0 ) ).xyz;
-							intersectedSDF = true;
-
-						}
-
-					}
-
-					float shadow = 0.0;
-					if ( intersectedSDF ) {
-
-						float specular = clamp( dot( rayDir, reflect( lightDir, normal ) ), 0.0, 1.0 );
-						gl_FragColor = vec4( vec3( 0.25 + 0.35 * max( dot( normal, lightDir ), 0.0 ) * ( 1.0 - shadow )
-						+ 0.1 * max( dot( normal, - lightDir ), 0.0 ) ) * col, 1.0 );
-
-					} else {
-
-						if ( distance( worldPos, cameraPos ) < 1000.0 && shadow > 0.0 ) {
-
-							gl_FragColor.rgb *= ( 1.0 - 0.7 * max( dot( normal, lightDir ), 0.0 ) * shadow );
+							// NOTE: could handle lighting from light objects here
+							vec3 lightDirection = normalize( vec3( 1.0 ) );
+							gl_FragColor = vec4( dot( normal, lightDirection ), 1.0 ) ;
 
 						}
 

--- a/example/utils/RenderSDFMaterial.js
+++ b/example/utils/RenderSDFMaterial.js
@@ -1,0 +1,319 @@
+import { ShaderMaterial, Matrix4, Vector3, Vector2 } from 'three';
+
+export class RenderSDFMaterial extends ShaderMaterial {
+
+	constructor( params ) {
+
+		super( {
+
+			uniforms: {
+
+				sdfTexture: { value: null },
+				projectionMatrixInv: { value: new Matrix4() },
+				viewMatrixInv: { value: new Matrix4() },
+				cameraPos: { value: new Vector3() },
+				normalStep: { value: new Vector3() },
+				sdfMat: { value: new Matrix4() },
+				sdfMatInv: { value: new Matrix4() },
+				resolution: { value: new Vector2() }
+
+			},
+
+			vertexShader: /* glsl */`
+
+				varying vec2 vUv;
+
+				void main() {
+
+					vUv = uv;
+					gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+
+				}
+
+			`,
+
+			fragmentShader: /* glsl */`
+				precision highp sampler3D;
+
+				varying vec2 vUv;
+
+				uniform sampler2D sceneDepth;
+				uniform sampler3D sdfTexture;
+				uniform mat4 projectionMatrixInv;
+				uniform mat4 viewMatrixInv;
+				uniform mat4 sdfMat;
+				uniform mat4 sdfMatInv;
+				uniform vec3 cameraPos;
+				uniform vec2 resolution;
+
+				#include <common>
+
+				vec3 getWorldPos( float depth, vec2 coord ) {
+
+					float z = depth * 2.0 - 1.0;
+					vec4 clipSpacePosition = vec4( coord * 2.0 - 1.0, z, 1.0 );
+					vec4 viewSpacePosition = projectionMatrixInv * clipSpacePosition;
+
+					// Perspective division
+					viewSpacePosition /= viewSpacePosition.w;
+
+					vec4 worldSpacePosition = viewMatrixInv * viewSpacePosition;
+					return worldSpacePosition.xyz;
+
+				}
+
+				vec2 rayBoxDist( vec3 boundsMin, vec3 boundsMax, vec3 rayOrigin, vec3 rayDir ) {
+
+					vec3 t0 = ( boundsMin - rayOrigin ) / rayDir;
+					vec3 t1 = ( boundsMax - rayOrigin ) / rayDir;
+					vec3 tmin = min( t0, t1 );
+					vec3 tmax = max( t0, t1 );
+
+					float distA = max( max( tmin.x, tmin.y ), tmin.z );
+					float distB = min( tmax.x, min( tmax.y, tmax.z ) );
+
+					float distToBox = max( 0.0, distA );
+					float distInsideBox = max( 0.0, distB - distToBox );
+					return vec2( distToBox, distInsideBox );
+
+				}
+
+				vec3 toSDFSpace( vec3 point ) {
+
+					return ( sdfMatInv * vec4( point, 1.0 ) ).xyz;
+
+				}
+
+				vec3 texCoord( vec3 samplePoint ) {
+
+					samplePoint = samplePoint;
+					return ( samplePoint + ( boxSize / 2.0 ) - boxCenter ) / boxSize;
+
+				}
+
+				float map( vec3 texCoord ) {
+
+					float timePeriod = mod( time * 0.2, 3.0 );
+					float dist = texture( sdfTexture1, texCoord ).x;
+					return dist;
+
+				}
+
+				vec4 colorMap( vec3 texCoord ) {
+
+					return texture( sdfTexture2, texCoord );
+
+				}
+
+				vec3 colorMapSampleSmart( vec3 p, vec3 n ) {
+
+					vec4 initialSample = colorMap( texCoord( p ) );
+					vec3 col = vec3( 0.0 );
+					if ( initialSample.w < 1.0 ) {
+
+						float maxW = initialSample.w;
+						vec3 total = initialSample.w * initialSample.rgb;
+						vec4 c = colorMap( texCoord( p + n ) );
+						maxW += c.w;
+						total += c.xyz * c.w;
+						c = colorMap( texCoord( p - n ) );
+						maxW += c.w;
+						total += c.xyz * c.w;
+
+						if ( maxW < 1.0 ) {
+
+							float weight = 1.0 - clamp( ( maxW - 0.75 ) / 0.25, 0.0, 1.0 );
+							for( float x = -1.0; x <= 1.0; x += 2.0 ) {
+
+								for( float y = -1.0; y <= 1.0; y+= 2.0 ) {
+
+									for( float z = -1.0; z <= 1.0; z+= 2.0 ) {
+
+										vec4 c = colorMap(texCoord(p + vec3( x, y, z ) ) );
+										maxW += c.w * weight;
+										total += c.xyz * c.w * weight;
+
+									}
+
+								}
+
+							}
+
+						}
+
+						col = mix( initialSample.xyz, total / maxW, 1.0 - clamp( ( initialSample.w ) / 1.0, 0.0, 1.0 ) );
+
+					} else {
+
+						col = initialSample.xyz;
+
+					}
+					return col;
+
+				}
+
+
+				vec3 getNormal( vec3 samplePoint ) {
+
+					return normalize( vec3(
+						map( texCoord( samplePoint + vec3( normalStep, 0.0, 0.0 ) ) ) - map( texCoord( samplePoint - vec3( normalStep, 0.0, 0.0 ) ) ),
+						map( texCoord( samplePoint + vec3( 0.0, normalStep, 0.0 ) ) ) - map( texCoord( samplePoint - vec3( 0.0, normalStep, 0.0 ) ) ),
+						map( texCoord( samplePoint + vec3( 0.0, 0.0, normalStep ) ) ) - map( texCoord( samplePoint - vec3( 0.0, 0.0, normalStep ) ) )
+					));
+
+				}
+
+				vec3 computeNormal( vec3 worldPos ) {
+
+					vec2 downUv = vUv + vec2( 0.0, 1.0 / resolution.y );
+					vec3 downPos = getWorldPos( texture2D( sceneDepth, downUv ).x, downUv ).xyz;
+					vec2 rightUv = vUv + vec2( 1.0 / resolution.x, 0.0 );
+					vec3 rightPos = getWorldPos( texture2D( sceneDepth, rightUv ).x, rightUv ).xyz;
+					vec2 upUv = vUv - vec2( 0.0, 1.0 / resolution.y );
+					vec3 upPos = getWorldPos( texture2D( sceneDepth, upUv ).x, upUv ).xyz;
+					vec2 leftUv = vUv - vec2( 1.0 / resolution.x, 0.0 );
+					vec3 leftPos = getWorldPos( texture2D( sceneDepth, leftUv ).x, leftUv ).xyz;
+					int hChoice;
+					int vChoice;
+					if ( length( leftPos - worldPos ) < length( rightPos - worldPos ) ) {
+
+						hChoice = 0;
+
+					} else {
+
+						hChoice = 1;
+
+					}
+
+					if ( length( upPos - worldPos ) < length( downPos - worldPos ) ) {
+
+						vChoice = 0;
+
+					} else {
+
+						vChoice = 1;
+
+					}
+
+					vec3 hVec;
+					vec3 vVec;
+					if ( hChoice == 0 && vChoice == 0 ) {
+
+						hVec = leftPos - worldPos;
+						vVec = upPos - worldPos;
+
+					} else if ( hChoice == 0 && vChoice == 1 ) {
+
+						hVec = leftPos - worldPos;
+						vVec = worldPos - downPos;
+
+					} else if ( hChoice == 1 && vChoice == 1 ) {
+
+						hVec = rightPos - worldPos;
+						vVec = downPos - worldPos;
+
+					} else if ( hChoice == 1 && vChoice == 0 ) {
+
+						hVec = rightPos - worldPos;
+						vVec = worldPos - upPos;
+
+					}
+
+					return normalize( cross( hVec, vVec ) );
+
+				}
+
+				void main() {
+
+					vec4 diffuse = texture2D( sceneDiffuse, vUv );
+					float depth = texture2D( sceneDepth, vUv ).x;
+					vec3 worldPos = getWorldPos( depth, vUv );
+					vec3 normal = ( viewMatrixInv * normalize( vec4( ( texture2D(normalTexture, vUv).rgb - 0.5 ) * 2.0, 0.0 ) ) ).xyz;
+					vec3 origin = cameraPos;
+					float linDepth = length( origin - worldPos );
+					vec3 rayDir = normalize( worldPos - origin );
+					origin = ( sdfMatInv * vec4( origin, 1.0 ) ).xyz;
+					rayDir = normalize( ( sdfMatInv * vec4( rayDir, 0.0 ) ).xyz );
+					vec2 boxIntersectionInfo = rayBoxDist( boxCenter - boxSize / 2.0, boxCenter + boxSize / 2.0, origin, rayDir );
+					float distToBox = boxIntersectionInfo.x;
+					float distInsideBox = boxIntersectionInfo.y;
+					bool intersectsBox = distInsideBox > 0.0 && distToBox < linDepth - 0.1;
+					gl_FragColor = vec4( diffuse.rgb, 1.0 );
+					vec3 lightDir = normalize( vec3( 150.0, 200.0, 50.0 ) );
+					bool intersectedSDF = false;
+					vec3 col = vec3( 0.0 );
+
+					if ( intersectsBox ) {
+
+						vec3 startPos = origin + distToBox * rayDir;
+						float distanceAlongRay = 0.01;
+						bool hit = false;
+						for( int i = 0; i < 2048; i ++ ) {
+
+							vec3 samplePoint = startPos + rayDir * distanceAlongRay;
+							if ( distance( samplePoint, origin ) > linDepth ) {
+
+								break;
+
+							}
+
+							vec3 tex = texCoord( samplePoint );
+							//samplePoint = (samplePoint + (boxSize / 2.0) - boxCenter) / boxSize;
+							if ( tex.x < 0.0 || tex.x > 1.0 || tex.y < 0.0 || tex.y > 1.0 || tex.z < 0.0 || tex.z > 1.0 ) {
+
+								break;
+
+							}
+
+							float distToSurface = map( tex );
+							distanceAlongRay += distToSurface;
+							if ( distToSurface < 0.01 ) {
+
+								hit = true;
+								break;
+
+							}
+
+						}
+
+						if ( hit ) {
+
+							vec3 p = startPos + rayDir * distanceAlongRay;
+							vec3 n = getNormal( p );
+
+							col =  colorMapSampleSmart( p, n );
+							normal = normalize( ( sdfMat * vec4( n, 0.0 ) ) ).xyz;
+							worldPos = ( sdfMat * vec4( p, 1.0 ) ).xyz;
+							intersectedSDF = true;
+
+						}
+
+					}
+
+					float shadow = 0.0;
+					if ( intersectedSDF ) {
+
+						float specular = clamp( dot( rayDir, reflect( lightDir, normal ) ), 0.0, 1.0 );
+						gl_FragColor = vec4( vec3( 0.25 + 0.35 * max( dot( normal, lightDir ), 0.0 ) * ( 1.0 - shadow )
+						+ 0.1 * max( dot( normal, - lightDir ), 0.0 ) ) * col, 1.0 );
+
+					} else {
+
+						if ( distance( worldPos, cameraPos ) < 1000.0 && shadow > 0.0 ) {
+
+							gl_FragColor.rgb *= ( 1.0 - 0.7 * max( dot( normal, lightDir ), 0.0 ) * shadow );
+
+						}
+
+					}
+
+				}
+			`
+
+		} );
+
+		this.setValues( params );
+
+	}
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "simplex-noise": "^2.4.0",
         "static-server": "^2.2.1",
         "stats.js": "^0.17.0",
-        "three": "^0.145.0",
+        "three": "^0.146.0",
         "typescript": "^4.4.3"
       },
       "peerDependencies": {
@@ -15230,9 +15230,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.145.0.tgz",
-      "integrity": "sha512-EKoHQEtEJ4CB6b2BGMBgLZrfwLjXcSUfoI/MiIXUuRpeYsfK5aPWbYhdtIVWOH+x6X0TouldHKHBuc/LAiFzAw==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.146.0.tgz",
+      "integrity": "sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A==",
       "dev": true
     },
     "node_modules/throat": {
@@ -27552,9 +27552,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.145.0.tgz",
-      "integrity": "sha512-EKoHQEtEJ4CB6b2BGMBgLZrfwLjXcSUfoI/MiIXUuRpeYsfK5aPWbYhdtIVWOH+x6X0TouldHKHBuc/LAiFzAw==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.146.0.tgz",
+      "integrity": "sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A==",
       "dev": true
     },
     "throat": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "simplex-noise": "^2.4.0",
     "static-server": "^2.2.1",
     "stats.js": "^0.17.0",
-    "three": "^0.145.0",
+    "three": "^0.146.0",
     "typescript": "^4.4.3"
   }
 }

--- a/src/gpu/shaderFunctions.js
+++ b/src/gpu/shaderFunctions.js
@@ -293,9 +293,14 @@ float distSquared( vec3 a, vec3 b ) {
 
 float udTriangle( vec3 p, vec3 a, vec3 b, vec3 c ) {
 
-	vec3 ba = b - a; vec3 pa = p - a;
-	vec3 cb = c - b; vec3 pb = p - b;
-	vec3 ac = a - c; vec3 pc = p - c;
+	vec3 ba = b - a;
+	vec3 cb = c - b;
+	vec3 ac = a - c;
+
+	vec3 pa = p - a;
+	vec3 pb = p - b;
+	vec3 pc = p - c;
+
 	vec3 nor = cross( ba, ac );
 	return
 		(

--- a/src/gpu/shaderFunctions.js
+++ b/src/gpu/shaderFunctions.js
@@ -409,14 +409,19 @@ float distanceToTriangles(
 
 }
 
+float distanceSqToBounds( vec3 point, vec3 boundsMin, vec3 boundsMax ) {
+
+	vec3 clampedPoint = clamp( point, boundsMin, boundsMax );
+	vec3 delta = point - clampedPoint;
+	return dot( delta, delta );
+
+}
+
 float distanceSqToBVHNodeBoundsPoint( vec3 point, BVH bvh, uint currNodeIndex ) {
 
 	vec3 boundsMin = texelFetch1D( bvh.bvhBounds, currNodeIndex * 2u + 0u ).xyz;
 	vec3 boundsMax = texelFetch1D( bvh.bvhBounds, currNodeIndex * 2u + 1u ).xyz;
-	vec3 clampedPoint = clamp( point, boundsMin, boundsMax );
-
-	vec3 delta = point - clampedPoint;
-	return dot( delta, delta );
+	return distanceSqToBounds( point, boundsMin, boundsMax );
 
 }
 

--- a/src/gpu/shaderFunctions.js
+++ b/src/gpu/shaderFunctions.js
@@ -1,3 +1,6 @@
+// Note that a struct cannot be used for the hit record including faceIndices, faceNormal, barycoord,
+// side, and dist because on some mobile GPUS (such as Adreno) numbers are afforded less precision specifically
+// when in a struct leading to inaccurate hit results. See KhronosGroup/WebGL#3351 for more details.
 export const shaderStructs = /* glsl */`
 #ifndef TRI_INTERSECT_EPSILON
 #define TRI_INTERSECT_EPSILON 1e-5
@@ -16,10 +19,6 @@ struct BVH {
 	usampler2D bvhContents;
 
 };
-
-// Note that a struct cannot be used for the hit record including faceIndices, faceNormal, barycoord,
-// side, and dist because on some mobile GPUS (such as Adreno) numbers are afforded less precision specifically
-// when in a struct leading to inaccurate hit results. See KhronosGroup/WebGL#3351 for more details.
 `;
 
 export const shaderIntersectFunction = /* glsl */`
@@ -274,8 +273,11 @@ bool bvhIntersectFirstHit(
 	return found;
 
 }
+`;
 
 // Distance to Point
+export const shaderDistanceFunction = /* glsl */`
+
 float dot2( in vec3 v ) {
 
 	return dot( v, v );

--- a/src/gpu/shaderFunctions.js
+++ b/src/gpu/shaderFunctions.js
@@ -326,29 +326,6 @@ vec3 closestPointToTriangle( vec3 p, vec3 v0, vec3 v1, vec3 v2, out vec3 barycoo
 
     vec3 nor = cross( v10, v02 );
 
-#if 0
-
-    // method 1, in 3D space
-    if( dot( cross( v10, nor ), p0 ) < 0.0 ) {
-
-		return v0 + v10 * clamp( dot( p0, v10 ) / dot2( v10 ), 0.0, 1.0 );
-
-	} else if( dot( cross( v21, nor ), p1 ) < 0.0 ) {
-
-		return v1 + v21 * clamp( dot( p1, v21 ) / dot2( v21 ), 0.0, 1.0 );
-
-	} else if( dot( cross( v02, nor ), p2 ) < 0.0 ) {
-
-		return v2 + v02 * clamp( dot( p2, v02 ) / dot2( v02 ), 0.0, 1.0 );
-
-	} else {
-
-	    return p - nor * dot( nor, p0 ) / dot2( nor );
-
-	}
-
-#else
-
     // method 2, in barycentric space
     vec3  q = cross( nor, p0 );
     float d = 1.0 / dot2( nor );
@@ -377,10 +354,7 @@ vec3 closestPointToTriangle( vec3 p, vec3 v0, vec3 v1, vec3 v2, out vec3 barycoo
 	}
 
 	barycoord = vec3( u, v, w );
-
     return u * v1 + v * v2 + w * v0;
-
-#endif
 
 }
 
@@ -421,7 +395,7 @@ float distanceToTriangles(
 			faceIndices = uvec4( indices.xyz, i );
 			faceNormal = normalize( cross( a - b, b - c ) );
 			barycoord = localBarycoord;
-			outPoint = a * barycoord.x + b * barycoord.y + c * barycoord.z;
+			outPoint = closestPoint;
 
 		}
 

--- a/src/gpu/shaderFunctions.js
+++ b/src/gpu/shaderFunctions.js
@@ -361,7 +361,7 @@ vec3 closestPointToTriangle( vec3 p, vec3 v0, vec3 v1, vec3 v2, out vec3 barycoo
 float distanceToTriangles(
 	BVH bvh, vec3 point, uint offset, uint count, float closestDistanceSquared,
 
-	out uvec4 faceIndices, out vec3 faceNormal, out vec3 barycoord, out vec3 outPoint
+	out uvec4 faceIndices, out vec3 faceNormal, out vec3 barycoord, out float side, out vec3 outPoint
 ) {
 
 	bool found = false;
@@ -388,7 +388,8 @@ float distanceToTriangles(
 		#else
 
 		vec3 closestPoint = closestPointToTriangle( point, a, b, c, localBarycoord );
-		float sqDist = dot2( point - closestPoint );
+		vec3 delta = point - closestPoint;
+		float sqDist = dot2( delta );
 		if ( sqDist < closestDistanceSquared ) {
 
 			closestDistanceSquared = sqDist;
@@ -396,6 +397,7 @@ float distanceToTriangles(
 			faceNormal = normalize( cross( a - b, b - c ) );
 			barycoord = localBarycoord;
 			outPoint = closestPoint;
+			side = sign( dot( faceNormal, delta ) );
 
 		}
 
@@ -456,7 +458,7 @@ float bvhClosestPointToPoint(
 				bvh, point, offset, count, closestDistanceSquared,
 
 				// outputs
-				faceIndices, faceNormal, barycoord, outPoint
+				faceIndices, faceNormal, barycoord, side, outPoint
 			);
 
 		} else {

--- a/src/gpu/shaderFunctions.js
+++ b/src/gpu/shaderFunctions.js
@@ -319,7 +319,11 @@ float distanceToTriangle( vec3 p, vec3 a, vec3 b, vec3 c ) {
 
 }
 
-float distanceToTriangles( BVH bvh, vec3 point, uint offset, uint count, float closestDistanceSquared ) {
+float distanceToTriangles(
+	BVH bvh, vec3 point, uint offset, uint count, float closestDistanceSquared,
+
+	out uvec4 faceIndices, out vec3 faceNormal, out vec3 barycoord, out float side, out vec3 outPoint
+) {
 
 	bool found = false;
 	for ( uint i = offset, l = offset + count; i < l; i ++ ) {
@@ -328,9 +332,10 @@ float distanceToTriangles( BVH bvh, vec3 point, uint offset, uint count, float c
 		vec3 a = texelFetch1D( bvh.position, indices.x ).rgb;
 		vec3 b = texelFetch1D( bvh.position, indices.y ).rgb;
 		vec3 c = texelFetch1D( bvh.position, indices.z ).rgb;
-		float dist = distanceToTriangle(point, a, b, c);
+		float dist = distanceToTriangle( point, a, b, c );
 		if ( dist < closestDistanceSquared ) {
 
+			// TODO: get the indices, normal, barycoord, side, and point out
 			closestDistanceSquared = dist;
 
 		}
@@ -350,7 +355,13 @@ float distanceToBVHNodeBoundsPoint( vec3 point, BVH bvh, uint currNodeIndex ) {
 
 }
 
-float bvhClosestPointToPoint( BVH bvh, vec3 point ) {
+float bvhClosestPointToPoint(
+	BVH bvh, vec3 point,
+
+	// output variables
+	out uvec4 faceIndices, out vec3 faceNormal, out vec3 barycoord,
+	out float side, out vec3 outPoint
+ ) {
 
 	// stack needs to be twice as long as the deepest tree we expect because
 	// we push both the left and right child onto the stack every traversal
@@ -379,7 +390,10 @@ float bvhClosestPointToPoint( BVH bvh, vec3 point ) {
 			uint count = boundsInfo.x & 0x0000ffffu;
 			uint offset = boundsInfo.y;
 			closestDistanceSquared = distanceToTriangles(
-				bvh, point, offset, count, closestDistanceSquared
+				bvh, point, offset, count, closestDistanceSquared,
+
+				// outputs
+				faceIndices, faceNormal, barycoord, side, outPoint
 			);
 
 		} else {

--- a/src/utils/StaticGeometryGenerator.js
+++ b/src/utils/StaticGeometryGenerator.js
@@ -330,7 +330,7 @@ export class StaticGeometryGenerator {
 		this.meshes = finalMeshes;
 		this.useGroups = true;
 		this.applyWorldTransforms = true;
-		this.attributes = [ 'position', 'normal', 'tangent', 'uv', 'uv2' ];
+		this.attributes = [ 'position', 'normal', 'color', 'tangent', 'uv', 'uv2' ];
 		this._intermediateGeometry = new Array( finalMeshes.length ).fill().map( () => new BufferGeometry() );
 
 	}


### PR DESCRIPTION
Fix #348 
Related to #411 

**TODO**
- [x] Add GPU SDF generation demo
  - ~gpu / cpu toggle~
  - ~margin adjustment~
  - ~extract barycoord, face indices, face normal, distance~
  - pick water-tight model
  - raymarching
  - distance adjustment
- [x] Optimize function
  - remove need to read the bounds texture multiple times per box
  - try skipping adding the bound to the stack if it's outside the current closest distance
- [ ] Function adjustments (#484)
  - add normal extraction for inside / outside determination