### PR TITLE
Remove unused variable from SkinnedMesh example

### DIFF
--- a/example/skinnedMesh.js
+++ b/example/skinnedMesh.js
@@ -91,7 +91,6 @@ function init() {
 
 		// prep the model and add it to the scene
 		model = gltf.scene;
-		const meshes = [];
 		model.traverse( object => {
 
 			if ( object.isMesh ) {
@@ -99,7 +98,6 @@ function init() {
 				object.castShadow = true;
 				object.receiveShadow = true;
 				object.frustumCulled = false;
-				meshes.push( object );
 
 			}
 


### PR DESCRIPTION
`meshes` array seems unused and is confusing at first read (I thought this how the geometry is being initialized)