### PR TITLE
IntersectUtils: improve intersectRay

### DIFF
--- a/example/inspector.js
+++ b/example/inspector.js
@@ -18,7 +18,7 @@ let benchmarkViz, renderTarget, fsQuad;
 let mouse = new THREE.Vector2();
 const readBuffer = new Float32Array( 1 );
 
-const modelPath = 'https://gkjohnson.github.io/three-mesh-bvh/example/models/DragonAttenuation.glb';
+const modelPath = '../models/DragonAttenuation.glb';
 const params = {
 
 	options: {

--- a/example/inspector.js
+++ b/example/inspector.js
@@ -18,7 +18,7 @@ let benchmarkViz, renderTarget, fsQuad;
 let mouse = new THREE.Vector2();
 const readBuffer = new Float32Array( 1 );
 
-const modelPath = '../models/DragonAttenuation.glb';
+const modelPath = 'https://gkjohnson.github.io/three-mesh-bvh/example/models/DragonAttenuation.glb';
 const params = {
 
 	options: {

--- a/src/core/cast/raycast.template.js
+++ b/src/core/cast/raycast.template.js
@@ -4,9 +4,9 @@ import { BufferStack } from '../utils/BufferStack.js';
 import { intersectTris } from '../utils/iterationUtils.generated.js';
 import { intersectTris_indirect } from '../utils/iterationUtils_indirect.generated.js';
 
-const origin = new Float32Array(3);
-const dirInv = new Float32Array(3);
-const sign = new Uint8Array(3);
+const origin = new Float64Array(3);
+const dirInv = new Float64Array(3);
+const sign = new Int8Array(3);
 
 export function raycast/* @echo INDIRECT_STRING */( bvh, root, side, ray, intersects ) {
 

--- a/src/core/cast/raycast.template.js
+++ b/src/core/cast/raycast.template.js
@@ -4,29 +4,29 @@ import { BufferStack } from '../utils/BufferStack.js';
 import { intersectTris } from '../utils/iterationUtils.generated.js';
 import { intersectTris_indirect } from '../utils/iterationUtils_indirect.generated.js';
 
-const origin = new Float64Array(3);
-const dirInv = new Float64Array(3);
-const sign = new Int8Array(3);
+const origin = new Float64Array( 3 );
+const dirInv = new Float64Array( 3 );
+const sign = new Int8Array( 3 );
 
 export function raycast/* @echo INDIRECT_STRING */( bvh, root, side, ray, intersects ) {
 
     // const distance = raycaster.far;
 
-    origin[0] = ray.origin.x;
-    origin[1] = ray.origin.y;
-    origin[2] = ray.origin.z;
+    origin[ 0 ] = ray.origin.x;
+    origin[ 1 ] = ray.origin.y;
+    origin[ 2 ] = ray.origin.z;
 
-    dirInv[0] = 1 / ray.direction.x;
-    dirInv[1] = 1 / ray.direction.y;
-    dirInv[2] = 1 / ray.direction.z;
+    dirInv[ 0 ] = 1 / ray.direction.x;
+    dirInv[ 1 ] = 1 / ray.direction.y;
+    dirInv[ 2 ] = 1 / ray.direction.z;
 
-    sign[0] = dirInv[0] < 0 ? 3 : 0;
-    sign[1] = dirInv[1] < 0 ? 3 : 0;
-    sign[2] = dirInv[2] < 0 ? 3 : 0;
+    sign[ 0 ] = dirInv[ 0 ] < 0 ? 3 : 0;
+    sign[ 1 ] = dirInv[ 1 ] < 0 ? 3 : 0;
+    sign[ 2 ] = dirInv[ 2 ] < 0 ? 3 : 0;
 
 
 	BufferStack.setBuffer( bvh._roots[ root ] );
-	_raycast( 0, bvh, side, ray, intersects);
+	_raycast( 0, bvh, side, ray, intersects );
 	BufferStack.clearBuffer();
 
 }

--- a/src/core/cast/raycast.template.js
+++ b/src/core/cast/raycast.template.js
@@ -1,15 +1,32 @@
-import { Vector3 } from 'three';
 import { intersectRay } from '../utils/intersectUtils.js';
 import { COUNT, OFFSET, LEFT_NODE, RIGHT_NODE, IS_LEAF } from '../utils/nodeBufferUtils.js';
 import { BufferStack } from '../utils/BufferStack.js';
 import { intersectTris } from '../utils/iterationUtils.generated.js';
 import { intersectTris_indirect } from '../utils/iterationUtils_indirect.generated.js';
 
-const _boxIntersection = /* @__PURE__ */ new Vector3();
+const origin = new Float32Array(3);
+const dirInv = new Float32Array(3);
+const sign = new Uint8Array(3);
+
 export function raycast/* @echo INDIRECT_STRING */( bvh, root, side, ray, intersects ) {
 
+    // const distance = raycaster.far;
+
+    origin[0] = ray.origin.x;
+    origin[1] = ray.origin.y;
+    origin[2] = ray.origin.z;
+
+    dirInv[0] = 1 / ray.direction.x;
+    dirInv[1] = 1 / ray.direction.y;
+    dirInv[2] = 1 / ray.direction.z;
+
+    sign[0] = dirInv[0] < 0 ? 3 : 0;
+    sign[1] = dirInv[1] < 0 ? 3 : 0;
+    sign[2] = dirInv[2] < 0 ? 3 : 0;
+
+
 	BufferStack.setBuffer( bvh._roots[ root ] );
-	_raycast( 0, bvh, side, ray, intersects );
+	_raycast( 0, bvh, side, ray, intersects);
 	BufferStack.clearBuffer();
 
 }
@@ -37,14 +54,14 @@ function _raycast( nodeIndex32, bvh, side, ray, intersects ) {
 	} else {
 
 		const leftIndex = LEFT_NODE( nodeIndex32 );
-		if ( intersectRay( leftIndex, float32Array, ray, _boxIntersection ) ) {
+		if ( intersectRay( leftIndex, float32Array, origin, dirInv, sign ) ) {
 
 			_raycast( leftIndex, bvh, side, ray, intersects );
 
 		}
 
 		const rightIndex = RIGHT_NODE( nodeIndex32, uint32Array );
-		if ( intersectRay( rightIndex, float32Array, ray, _boxIntersection ) ) {
+		if ( intersectRay( rightIndex, float32Array, origin, dirInv, sign ) ) {
 
 			_raycast( rightIndex, bvh, side, ray, intersects );
 

--- a/src/core/cast/raycastFirst.template.js
+++ b/src/core/cast/raycastFirst.template.js
@@ -5,25 +5,25 @@ import { intersectClosestTri } from '../utils/iterationUtils.generated.js';
 import { intersectClosestTri_indirect } from '../utils/iterationUtils_indirect.generated.js';
 const _xyzFields = [ 'x', 'y', 'z' ];
 
-const origin = new Float64Array(3);
-const dirInv = new Float64Array(3);
-const sign = new Int8Array(3);
+const origin = new Float64Array(3 );
+const dirInv = new Float64Array( 3 );
+const sign = new Int8Array( 3 );
 
 export function raycastFirst/* @echo INDIRECT_STRING */( bvh, root, side, ray ) {
 
     // const distance = raycaster.far;
 
-    origin[0] = ray.origin.x;
-    origin[1] = ray.origin.y;
-    origin[2] = ray.origin.z;
+    origin[ 0 ] = ray.origin.x;
+    origin[ 1 ] = ray.origin.y;
+    origin[ 2 ] = ray.origin.z;
 
-    dirInv[0] = 1 / ray.direction.x;
-    dirInv[1] = 1 / ray.direction.y;
-    dirInv[2] = 1 / ray.direction.z;
+    dirInv[ 0 ] = 1 / ray.direction.x;
+    dirInv[ 1 ] = 1 / ray.direction.y;
+    dirInv[ 2 ] = 1 / ray.direction.z;
 
-    sign[0] = dirInv[0] < 0 ? 3 : 0;
-    sign[1] = dirInv[1] < 0 ? 3 : 0;
-    sign[2] = dirInv[2] < 0 ? 3 : 0;
+    sign[ 0 ] = dirInv[ 0 ] < 0 ? 3 : 0;
+    sign[ 1 ] = dirInv[ 1 ] < 0 ? 3 : 0;
+    sign[ 2 ] = dirInv[ 2 ] < 0 ? 3 : 0;
 
 	BufferStack.setBuffer( bvh._roots[ root ] );
 	const result = _raycastFirst( 0, bvh, side, ray );

--- a/src/core/cast/raycastFirst.template.js
+++ b/src/core/cast/raycastFirst.template.js
@@ -5,10 +5,9 @@ import { intersectClosestTri } from '../utils/iterationUtils.generated.js';
 import { intersectClosestTri_indirect } from '../utils/iterationUtils_indirect.generated.js';
 const _xyzFields = [ 'x', 'y', 'z' ];
 
-const origin = new Float32Array(3);
-const dirInv = new Float32Array(3);
-const sign = new Uint8Array(3);
-
+const origin = new Float64Array(3);
+const dirInv = new Float64Array(3);
+const sign = new Int8Array(3);
 
 export function raycastFirst/* @echo INDIRECT_STRING */( bvh, root, side, ray ) {
 

--- a/src/core/utils/intersectUtils.js
+++ b/src/core/utils/intersectUtils.js
@@ -1,37 +1,37 @@
 export function intersectRay(nodeIndex32, array, origin, dirInv, sign) {
 
-	let bmin = array[nodeIndex32 + sign[0]];
-	let bmax = array[nodeIndex32 + (sign[0] + 3) % 6];
+	let bmin = array[ nodeIndex32 + sign[ 0 ] ];
+	let bmax = array[ nodeIndex32 + ( sign[ 0 ] + 3 ) % 6 ];
 
-	let tmin = (bmin - origin[0]) * dirInv[0];
-	let tmax = (bmax - origin[0]) * dirInv[0];
+	let tmin = ( bmin - origin[ 0 ] ) * dirInv[ 0 ];
+	let tmax = ( bmax - origin[ 0 ] ) * dirInv[ 0 ];
 
-	bmin = array[nodeIndex32 + sign[1] + 1];
-	bmax = array[nodeIndex32 + (sign[1] + 3) % 6 + 1];
+	bmin = array[ nodeIndex32 + sign[ 1 ] + 1 ];
+	bmax = array[ nodeIndex32 + ( sign[ 1 ] + 3 ) % 6 + 1 ];
 
-	const tymin = (bmin - origin[1]) * dirInv[1];
-	if (tymin > tmax) return false;
+	const tymin = ( bmin - origin[ 1 ] ) * dirInv[ 1 ];
+	if ( tymin > tmax ) return false;
 
-	const tymax = (bmax - origin[1]) * dirInv[1];
-	if (tmin > tymax) return false;
+	const tymax = ( bmax - origin[ 1 ] ) * dirInv[ 1 ];
+	if ( tmin > tymax ) return false;
 
-	if (tymin > tmin) tmin = tymin;
+	if ( tymin > tmin ) tmin = tymin;
 
-	bmin = array[nodeIndex32 + sign[2] + 2];
-	bmax = array[nodeIndex32 + (sign[2] + 3) % 6 + 2];
+	bmin = array[ nodeIndex32 + sign[ 2 ] + 2 ];
+	bmax = array[ nodeIndex32 + ( sign[ 2 ] + 3 ) % 6 + 2 ];
 
-	const tzmax = (bmax - origin[2]) * dirInv[2];
-	if (tmin > tzmax) return false;
+	const tzmax = ( bmax - origin[ 2 ] ) * dirInv[ 2 ];
+	if ( tmin > tzmax ) return false;
 
-	if (tymax < tmax) tmax = tymax;
-	if (tzmax < tmax) tmax = tzmax;
+	if ( tymax < tmax ) tmax = tymax;
+	if ( tzmax < tmax ) tmax = tzmax;
 
-	if (tmax < 0) return false;
+	if ( tmax < 0 ) return false;
 
-	const tzmin = (bmin - origin[2]) * dirInv[2];
-	if (tzmin > tmax) return false;
+	const tzmin = ( bmin - origin[ 2 ] ) * dirInv[ 2 ];
+	if ( tzmin > tmax ) return false;
 
-	if (tzmin > tmin) tmin = tzmin;
+	if ( tzmin > tmin ) tmin = tzmin;
 
 	return tmin <= tmax /* && distance >= tmin */;
 

--- a/src/core/utils/intersectUtils.js
+++ b/src/core/utils/intersectUtils.js
@@ -1,10 +1,35 @@
-import { Box3 } from 'three';
-import { arrayToBox } from '../../utils/ArrayBoxUtilities.js';
+export function intersectRay(nodeIndex32, array, origin, dirInv, sign) {
 
-const _boundingBox = /* @__PURE__ */ new Box3();
-export function intersectRay( nodeIndex32, array, ray, target ) {
+	let tmin = 0, tmax = Infinity;
 
-	arrayToBox( nodeIndex32, array, _boundingBox );
-	return ray.intersectBox( _boundingBox, target );
+	let bmin = array[nodeIndex32 + sign[0]];
+	let bmax = array[nodeIndex32 + (sign[0] + 3) % 6];
+
+	let dmin = (bmin - origin[0]) * dirInv[0];
+	let dmax = (bmax - origin[0]) * dirInv[0];
+
+	if (dmin > tmin) tmin = dmin; // check if we can skip this if
+	if (dmax < tmax) tmax = dmax; // check if we can skip this if
+
+	bmin = array[nodeIndex32 + sign[1] + 1];
+	bmax = array[nodeIndex32 + (sign[1] + 3) % 6 + 1];
+
+	dmin = (bmin - origin[1]) * dirInv[1];
+	dmax = (bmax - origin[1]) * dirInv[1];
+
+	if (dmin > tmin) tmin = dmin;
+	if (dmax < tmax) tmax = dmax;
+
+
+	bmin = array[nodeIndex32 + sign[2] + 2];
+	bmax = array[nodeIndex32 + (sign[2] + 3) % 6 + 2];
+
+	dmin = (bmin - origin[2]) * dirInv[2];
+	dmax = (bmax - origin[2]) * dirInv[2];
+
+	if (dmin > tmin) tmin = dmin;
+	if (dmax < tmax) tmax = dmax;
+
+	return tmin <= tmax /* && distance >= tmin */;
 
 }

--- a/src/core/utils/intersectUtils.js
+++ b/src/core/utils/intersectUtils.js
@@ -1,34 +1,37 @@
 export function intersectRay(nodeIndex32, array, origin, dirInv, sign) {
 
-	let tmin = 0, tmax = Infinity;
-
 	let bmin = array[nodeIndex32 + sign[0]];
 	let bmax = array[nodeIndex32 + (sign[0] + 3) % 6];
 
-	let dmin = (bmin - origin[0]) * dirInv[0];
-	let dmax = (bmax - origin[0]) * dirInv[0];
-
-	if (dmin > tmin) tmin = dmin; // check if we can skip this if
-	if (dmax < tmax) tmax = dmax; // check if we can skip this if
+	let tmin = (bmin - origin[0]) * dirInv[0];
+	let tmax = (bmax - origin[0]) * dirInv[0];
 
 	bmin = array[nodeIndex32 + sign[1] + 1];
 	bmax = array[nodeIndex32 + (sign[1] + 3) % 6 + 1];
 
-	dmin = (bmin - origin[1]) * dirInv[1];
-	dmax = (bmax - origin[1]) * dirInv[1];
+	const tymin = (bmin - origin[1]) * dirInv[1];
+	if (tymin > tmax) return false;
 
-	if (dmin > tmin) tmin = dmin;
-	if (dmax < tmax) tmax = dmax;
+	const tymax = (bmax - origin[1]) * dirInv[1];
+	if (tmin > tymax) return false;
 
+	if (tymin > tmin) tmin = tymin;
 
 	bmin = array[nodeIndex32 + sign[2] + 2];
 	bmax = array[nodeIndex32 + (sign[2] + 3) % 6 + 2];
 
-	dmin = (bmin - origin[2]) * dirInv[2];
-	dmax = (bmax - origin[2]) * dirInv[2];
+	const tzmax = (bmax - origin[2]) * dirInv[2];
+	if (tmin > tzmax) return false;
 
-	if (dmin > tmin) tmin = dmin;
-	if (dmax < tmax) tmax = dmax;
+	if (tymax < tmax) tmax = tymax;
+	if (tzmax < tmax) tmax = tzmax;
+
+	if (tmax < 0) return false;
+
+	const tzmin = (bmin - origin[2]) * dirInv[2];
+	if (tzmin > tmax) return false;
+
+	if (tzmin > tmin) tmin = tzmin;
 
 	return tmin <= tmax /* && distance >= tmin */;
 


### PR DESCRIPTION
Hi :)

I tried to implement a more suitable function to control the box - ray intersection (following [this article](https://tavianator.com/2022/ray_box_boundary.html)), even if it is obviously less clean than the current implementation.

There is a slight improvement on my pc, but I would like to do some more testing as well. 

Do you think this approach could be valid?

I used global variables instead of passing the same arrays recursively. Obviously I don't like it, I should modify it. 

Would it make sense to implement a distance control directly here to discard nodes that are too far away? (I left the check commented out)

![image](https://github.com/gkjohnson/three-mesh-bvh/assets/47436453/189926ab-803f-412b-a554-b10cc1c3e2a5)