### PR TITLE
fix resolveTriangleIndex from wrong condition

### DIFF
--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -160,7 +160,7 @@ export class MeshBVH {
 
 		}
 
-		this.resolveTriangleIndex = this._indirectBuffer ? i => this._indirectBuffer[ i ] : i => i;
+		this.resolveTriangleIndex = options.indirect ? i => this._indirectBuffer[ i ] : i => i;
 
 	}
 


### PR DESCRIPTION
Hi I found a bug in constructor of MeshBVH.js

```ts
  //previous
  // In constructor this._indirectBuffer initialized null
  // then this.resolveTriangleIndex use the latter of conditional operator 
  // result of this.resolveTriangleIndex(i) returns i, even indirect is true
  this.resolveTriangleIndex = this._indirectBuffer ? i => this._indirectBuffer[ i ] : i => i;
  //fixed
  this.resolveTriangleIndex = options.indirect ? i => this._indirectBuffer[ i ] : i => i;

```

this bug affects three-mesh-pathtracer
[scenario] initialize pathtracer => disable pathtracer => move model => enable pathtracer
previous version

https://github.com/gkjohnson/three-mesh-bvh/assets/108255990/18428557-8969-4433-841b-22b737fd87e8

For your Information log
<img width="567" alt="image" src="https://github.com/gkjohnson/three-mesh-bvh/assets/108255990/647792f6-6d12-4d33-8bc0-74648d053c5a">


<img width="427" alt="image" src="https://github.com/gkjohnson/three-mesh-bvh/assets/108255990/de6f2853-665c-40da-a605-550b1d0fcded">

<img width="656" alt="image" src="https://github.com/gkjohnson/three-mesh-bvh/assets/108255990/bfb308d6-935b-4f3f-8dc9-7c14ccbca5fd">


P.S : always thanks fast feedback & amazing library