### PR TITLE
Augment three instead for TypeScript ESM

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -208,15 +208,13 @@ export function acceleratedRaycast(
   intersects: Array<Intersection>
 ): void;
 
-declare module 'three/src/core/BufferGeometry' {
+declare module 'three' {
   export interface BufferGeometry {
     boundsTree?: MeshBVH;
     computeBoundsTree: typeof computeBoundsTree;
     disposeBoundsTree: typeof disposeBoundsTree;
   }
-}
 
-declare module 'three/src/core/Raycaster' {
   export interface Raycaster {
     firstHitOnly?: boolean;
   }


### PR DESCRIPTION
Fixes #682.

`three/src` should never be referenced in library code, but referencing the public export sidesteps the issue entirely.

`.js` file extensions are required when referencing source code, such as examples, but this can create its own issues (e.g., https://github.com/mrdoob/three.js/issues/24593).