### PR TITLE
MeshBVHHelper: Update BVH Helper for instances and batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,14 @@ displayEdges = true : Boolean
 
 If true displays the bounds as edges other displays the bounds as solid meshes.
 
+### .objectIndex
+
+```js
+objectIndex = 0 : Number
+```
+
+When using an `InstancedMesh` or a `BatchedMesh` this refers to the item index to use for the BVH and / or matrix transformation to use.
+
 ### .edgeMaterial
 
 ```js


### PR DESCRIPTION
Fix #701

Adds `MeshBVHHelper.objectIndex` to support displaying a BVH for an individual BVH in an InstancedMesh or BatchedMesh.

cc @agargaro 