### PR TITLE
getTriangleHitPointInfo: Compute Interpolated Normal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,14 +1065,16 @@ target : {
 		materialIndex: Number,
 		normal: Vector3
 	},
-	uv: Vector2
+	uv: Vector2,
+	normal: Vector3
 }
 ```
 
 - `a`, `b`, `c`: Triangle indices
 - `materialIndex`: Face material index or 0 if not available.
 - `normal`: Face normal
-- `uv`: UV coordinates.
+- `uv`: Interpolated UV coordinates.
+- `normal`: Interpolated normal
 
 This function can be used after a call to [closestPointPoint](#closestPointToPoint) or [closestPointToGeometry](#closestPointToGeometry) to retrieve more detailed result information.
 

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -10,6 +10,7 @@ import { GenerateSDFMaterial } from './utils/GenerateSDFMaterial.js';
 import { RenderSDFLayerMaterial } from './utils/RenderSDFLayerMaterial.js';
 import { RayMarchSDFMaterial } from './utils/RayMarchSDFMaterial.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
+import { getTriangleHitPointInfo } from '../src/utils/TriangleUtilities.js';
 
 const params = {
 
@@ -243,6 +244,7 @@ function updateSDF() {
 		const delta = new THREE.Vector3();
 		const tri = new THREE.Triangle();
 		const target = {};
+		const triangleTarget = {};
 
 		// iterate over all pixels and check distance
 		for ( let x = 0; x < dim; x ++ ) {
@@ -263,12 +265,7 @@ function updateSDF() {
 					const dist = bvh.closestPointToPoint( point, target ).distance;
 
 					// get the face normal to determine if the distance should be positive or negative
-					const faceIndex = target.faceIndex;
-					const i0 = indexAttr.getX( faceIndex * 3 + 0 );
-					const i1 = indexAttr.getX( faceIndex * 3 + 1 );
-					const i2 = indexAttr.getX( faceIndex * 3 + 2 );
-					tri.setFromAttributeAndIndices( posAttr, i0, i1, i2 );
-					tri.getNormal( normal );
+					normal.copy( getTriangleHitPointInfo( target.point, geometry, target.faceIndex, triangleTarget ).normal );
 					delta.subVectors( target.point, point );
 
 					// set the distance in the texture data

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -39,12 +39,16 @@ const tempV3 = /* @__PURE__ */ new Vector3();
 const tempUV1 = /* @__PURE__ */ new Vector2();
 const tempUV2 = /* @__PURE__ */ new Vector2();
 const tempUV3 = /* @__PURE__ */ new Vector2();
+const tempNormal1 = /* @__PURE__ */ new Vector3();
+const tempNormal2 = /* @__PURE__ */ new Vector3();
+const tempNormal3 = /* @__PURE__ */ new Vector3();
 
 export function getTriangleHitPointInfo( point, geometry, triangleIndex, target ) {
 
 	const indices = geometry.getIndex().array;
 	const positions = geometry.getAttribute( 'position' );
 	const uvs = geometry.getAttribute( 'uv' );
+	const normals = geometry.getAttribute( 'normal' );
 
 	const a = indices[ triangleIndex * 3 ];
 	const b = indices[ triangleIndex * 3 + 1 ];
@@ -86,6 +90,21 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 
 	}
 
+	// extract uvs
+	let normal = null;
+	if ( normals ) {
+
+		tempNormal1.fromBufferAttribute( normals, a );
+		tempNormal2.fromBufferAttribute( normals, b );
+		tempNormal3.fromBufferAttribute( normals, c );
+
+		if ( target && target.normal ) normal = target.normal;
+		else normal = new Vector3();
+
+		Triangle.getInterpolation( point, tempV1, tempV2, tempV3, tempNormal1, tempNormal2, tempNormal3, normal );
+
+	}
+
 	// adjust the provided target or create a new one
 	if ( target ) {
 
@@ -98,20 +117,22 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 		Triangle.getNormal( tempV1, tempV2, tempV3, target.face.normal );
 
 		if ( uv ) target.uv = uv;
+		target.normal = normal ?? target.face.normal;
 
 		return target;
 
 	} else {
-
+		let faceNormal = Triangle.getNormal( tempV1, tempV2, tempV3, new Vector3() );
 		return {
 			face: {
 				a: a,
 				b: b,
 				c: c,
 				materialIndex: materialIndex,
-				normal: Triangle.getNormal( tempV1, tempV2, tempV3, new Vector3() )
+				normal: faceNormal
 			},
-			uv: uv
+			uv: uv,
+			normal: normal ?? faceNormal
 		};
 
 	}

--- a/src/utils/TriangleUtilities.js
+++ b/src/utils/TriangleUtilities.js
@@ -90,7 +90,7 @@ export function getTriangleHitPointInfo( point, geometry, triangleIndex, target 
 
 	}
 
-	// extract uvs
+	// extract normals
 	let normal = null;
 	if ( normals ) {
 


### PR DESCRIPTION
@gkjohnson This adds normal computation to `getTriangleHitPointInfo` in the spirit of my sister PR to three.js: https://github.com/mrdoob/three.js/pull/25566

Using an interpolated normal significantly improves the insidedness-via-normal heuristic for the ClosestPointToPoint function, especially when the closest point lies along an edge or vertex (and is generally just more correct).  

This is starting to address https://github.com/gkjohnson/three-mesh-bvh/issues/704 with relatively little extra cost.

Before:
![image](https://github.com/user-attachments/assets/8256a29b-f589-4a7e-883a-11b04b3c10b4)

After:
![image](https://github.com/user-attachments/assets/0d82a302-d10b-4ec7-85c2-bb95ac48ad7b)

Also a comparison shot from [my pet project.](https://github.com/zalo/ThreeHydroelasticContacts)

Before:
![BeforeInterpolatedNormals](https://github.com/user-attachments/assets/60883a51-1fb4-402f-bdf2-57a18a5d644f)

After:
![AfterInterpolatedNormals](https://github.com/user-attachments/assets/bcb10536-945f-4730-a50d-11c12815bcf5)

