### PR TITLE
AcceleratedBatchedMeshRaycast: use `getVisibleAt` instead of `drawInfo` object

### DIFF
--- a/src/utils/ExtensionUtilities.js
+++ b/src/utils/ExtensionUtilities.js
@@ -47,14 +47,16 @@ function acceleratedBatchedMeshRaycast( raycaster, intersects ) {
 
 		}
 
+		// TODO: provide new method to get instances count instead of 'drawInfo.length'
 		for ( let i = 0, l = drawInfo.length; i < l; i ++ ) {
 
-			if ( ! drawInfo[ i ].visible || ! drawInfo[ i ].active ) {
+			if ( ! this.getVisibleAt( i ) ) {
 
 				continue;
 
 			}
 
+			// TODO: use getGeometryIndex
 			const geometryId = drawInfo[ i ].geometryIndex;
 
 			_mesh.geometry.boundsTree = boundsTrees[ geometryId ];


### PR DESCRIPTION
Two questions:

1) It's necessary to create a way to get instances in use count (drawInfo.length). Is an `instancesCount` getter okay?

2) The method `getVisibleAt` and property `instancesCount` (and other future methods) , may not exist if the user is using an older version of three.js. How would you prefer to proceed? 

Adding these methods to `BatchedMesh.prototype`? 
Change the minimum version of three.js?