### PR TITLE
BatchedMesh raycasting example: fix `splitStrategy` param

### DIFF
--- a/example/batchedMesh.js
+++ b/example/batchedMesh.js
@@ -286,6 +286,7 @@ function updateFromOptions() {
 	) {
 
 		batchedMesh.disposeBoundsTree();
+		batchedMesh.boundsTrees = null;
 
 	}
 


### PR DESCRIPTION
related: #709 

This is the quickest way to fix the example, however I don't know if the most correct one.

This condition was alway `false` after change `splitStrategy`, and the BVH was no longer rebuilt.

![image](https://github.com/user-attachments/assets/44c89edf-954f-44a6-a209-81d872eb3ae0)
 