### PR TITLE
Use importmap to speed up coding process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ typings/
 .env
 
 example/dev-bundle
+example/bundle
 .parcel-cache
 
 *.generated.js

--- a/example/asyncGenerate.html
+++ b/example/asyncGenerate.html
@@ -49,6 +49,7 @@
 		}
 
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="output"></div>

--- a/example/asyncGenerate.js
+++ b/example/asyncGenerate.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import Stats from 'stats.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import { ParallelMeshBVHWorker } from '../src/workers/ParallelMeshBVHWorker.js';
-import { AVERAGE, CENTER, MeshBVH, MeshBVHHelper, SAH } from '..';
+import { AVERAGE, CENTER, MeshBVH, MeshBVHHelper, SAH } from '../src/index.js';
 
 // Parallel BVH generation is only supported with SharedArrayBuffer
 const sharedArrayBufferSupported = typeof SharedArrayBuffer !== 'undefined';

--- a/example/batchedMesh.html
+++ b/example/batchedMesh.html
@@ -27,6 +27,7 @@
 			padding: 5px 0;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
     <div id="info">

--- a/example/batchedMesh.js
+++ b/example/batchedMesh.js
@@ -5,7 +5,7 @@ import {
 	acceleratedRaycast, computeBoundsTree, disposeBoundsTree,
 	computeBatchedBoundsTree, disposeBatchedBoundsTree,
 	CENTER, SAH, AVERAGE,
-} from '..';
+} from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/characterMovement.html
+++ b/example/characterMovement.html
@@ -30,6 +30,7 @@
 			color: #eee;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/characterMovement.js
+++ b/example/characterMovement.js
@@ -5,7 +5,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import Stats from 'stats.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import { MeshBVH, MeshBVHHelper, StaticGeometryGenerator } from '..';
+import { MeshBVH, MeshBVHHelper, StaticGeometryGenerator } from '../src/index.js';
 
 const params = {
 

--- a/example/clippedEdges.html
+++ b/example/clippedEdges.html
@@ -41,6 +41,7 @@
 			text-align: center;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/clippedEdges.js
+++ b/example/clippedEdges.js
@@ -5,7 +5,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 // import * as BufferGeometryUtils from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 import Stats from 'stats.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import { MeshBVH, MeshBVHHelper, CONTAINED } from '..';
+import { MeshBVH, MeshBVHHelper, CONTAINED } from '../src/index.js';
 
 const params = {
 	useBVH: true,

--- a/example/collectTriangles.html
+++ b/example/collectTriangles.html
@@ -16,6 +16,7 @@
             height: 100%;
         }
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
     <script type="module" src="./collectTriangles.js"></script>

--- a/example/collectTriangles.js
+++ b/example/collectTriangles.js
@@ -2,7 +2,7 @@ import Stats from 'stats.js/src/Stats';
 import * as dat from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CONTAINED, INTERSECTED, NOT_INTERSECTED } from '..';
+import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, CONTAINED, INTERSECTED, NOT_INTERSECTED } from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/collectTriangles.js
+++ b/example/collectTriangles.js
@@ -1,4 +1,4 @@
-import Stats from 'stats.js/src/Stats';
+import Stats from 'stats.js';
 import * as dat from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';

--- a/example/cpuPathTracing.html
+++ b/example/cpuPathTracing.html
@@ -44,6 +44,7 @@
             white-space: pre;
         }
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
     <div id="info">

--- a/example/cpuPathTracing.js
+++ b/example/cpuPathTracing.js
@@ -13,7 +13,7 @@ import {
 	disposeBoundsTree,
 	SAH,
 	CENTER,
-} from '..';
+} from '../src/index.js';
 import {
 	GenerateMeshBVHWorker,
 } from '../src/workers/GenerateMeshBVHWorker.js';

--- a/example/diamond.html
+++ b/example/diamond.html
@@ -32,6 +32,7 @@
 			color: white;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 
 <body>

--- a/example/distancecast.html
+++ b/example/distancecast.html
@@ -25,6 +25,7 @@
 
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="loader"></div>

--- a/example/distancecast.js
+++ b/example/distancecast.js
@@ -5,7 +5,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
 import { MarchingCubes } from './lib/MarchingCubes.js';
 import SimplexNoise from 'simplex-noise';
-import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, MeshBVHHelper } from '..';
+import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, MeshBVHHelper } from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/distancecast.js
+++ b/example/distancecast.js
@@ -1,4 +1,4 @@
-import Stats from 'stats.js/src/Stats';
+import Stats from 'stats.js';
 import * as dat from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';

--- a/example/edgeIntersect.html
+++ b/example/edgeIntersect.html
@@ -16,6 +16,7 @@
             height: 100%;
         }
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
     <script type="module" src="./edgeIntersect.js"></script>

--- a/example/edgeIntersect.js
+++ b/example/edgeIntersect.js
@@ -2,7 +2,7 @@ import Stats from 'stats.js';
 import * as dat from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, SAH } from '..';
+import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, SAH } from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/gpuPathTracing.html
+++ b/example/gpuPathTracing.html
@@ -39,6 +39,7 @@
             padding: 5px 0;
         }
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/gpuPathTracing.js
+++ b/example/gpuPathTracing.js
@@ -8,7 +8,7 @@ import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import {
 	MeshBVH, MeshBVHUniformStruct, FloatVertexAttributeTexture,
 	SAH, BVHShaderGLSL,
-} from '..';
+} from '../src/index.js';
 
 const params = {
 	enableRaytracing: true,

--- a/example/gpuPathTracingSimple.html
+++ b/example/gpuPathTracingSimple.html
@@ -27,6 +27,7 @@
             padding: 5px 0;
         }
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/gpuPathTracingSimple.js
+++ b/example/gpuPathTracingSimple.js
@@ -6,7 +6,7 @@ import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import {
 	MeshBVH, MeshBVHUniformStruct, FloatVertexAttributeTexture,
 	BVHShaderGLSL, SAH,
-} from '..';
+} from '../src/index.js';
 
 const params = {
 	enableRaytracing: true,

--- a/example/importmap.js
+++ b/example/importmap.js
@@ -1,0 +1,14 @@
+const nodeModules = location.href + '/../../node_modules/';
+const imports = {
+  "three": nodeModules + "three/src/Three.js",
+  "three/": nodeModules + "three/",
+  "stats.js": nodeModules + "stats.js/src/Stats.js"
+};
+const importmap = document.createElement("script");
+importmap.type = "importmap";
+importmap.textContent = JSON.stringify({imports});
+const dom = document.body || document.head;
+if (!dom) {
+  throw new Error("neither <body> nor <head> available to append importmap");
+}
+dom.append(importmap);

--- a/example/inspector.html
+++ b/example/inspector.html
@@ -46,6 +46,7 @@
             white-space: pre;
         }
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
     <div id="info">

--- a/example/inspector.js
+++ b/example/inspector.js
@@ -7,7 +7,7 @@ import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import {
 	acceleratedRaycast, computeBoundsTree, disposeBoundsTree, MeshBVHHelper,
 	SAH, CENTER, AVERAGE, getBVHExtremes, estimateMemoryInBytes,
-} from '..';
+} from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/physics.html
+++ b/example/physics.html
@@ -30,6 +30,7 @@
 			color: #eee;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/physics.js
+++ b/example/physics.js
@@ -3,7 +3,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import Stats from 'stats.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import { MeshBVH, MeshBVHHelper, StaticGeometryGenerator } from '..';
+import { MeshBVH, MeshBVHHelper, StaticGeometryGenerator } from '../src/index.js';
 
 const params = {
 

--- a/example/pointCloudIntersection.html
+++ b/example/pointCloudIntersection.html
@@ -40,6 +40,7 @@
 			font-family: monospace;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
     <div id="info">

--- a/example/pointCloudIntersection.js
+++ b/example/pointCloudIntersection.js
@@ -6,7 +6,7 @@ import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import {
 	acceleratedRaycast, computeBoundsTree, disposeBoundsTree, MeshBVHHelper, INTERSECTED, NOT_INTERSECTED,
 	SAH, CENTER, AVERAGE,
-} from '..';
+} from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/pointCloudIntersection.js
+++ b/example/pointCloudIntersection.js
@@ -1,4 +1,4 @@
-import Stats from 'stats.js/src/Stats';
+import Stats from 'stats.js';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader.js';

--- a/example/randomSampleDebug.html
+++ b/example/randomSampleDebug.html
@@ -25,6 +25,7 @@
 			white-space: pre;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="output"></div>

--- a/example/randomSampleDebug.js
+++ b/example/randomSampleDebug.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, AVERAGE, MeshBVHHelper } from '..';
+import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, AVERAGE, MeshBVHHelper } from '../src/index.js';
 
 // Code for debugging issue #180 and other random raycast test associated issues.
 THREE.Mesh.prototype.raycast = acceleratedRaycast;

--- a/example/raycast.html
+++ b/example/raycast.html
@@ -16,6 +16,7 @@
             height: 100%;
         }
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
     <script type="module" src="./raycast.js"></script>

--- a/example/raycast.js
+++ b/example/raycast.js
@@ -4,7 +4,7 @@ import * as THREE from 'three';
 import {
 	acceleratedRaycast, computeBoundsTree, disposeBoundsTree,
 	CENTER, SAH, AVERAGE, MeshBVHHelper,
-} from '..';
+} from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/sculpt.html
+++ b/example/sculpt.html
@@ -30,6 +30,7 @@
 			color: #eee;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/sculpt.js
+++ b/example/sculpt.js
@@ -11,7 +11,7 @@ import {
 	INTERSECTED,
 	NOT_INTERSECTED,
 	MeshBVHHelper,
-} from '..';
+} from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/sculpt.js
+++ b/example/sculpt.js
@@ -151,10 +151,10 @@ function init() {
 	document.body.appendChild( stats.dom );
 
 	// init matcaps
-	matcaps[ 'Clay' ] = new THREE.TextureLoader().load( '../textures/B67F6B_4B2E2A_6C3A34_F3DBC6-256px.png' );
-	matcaps[ 'Red Wax' ] = new THREE.TextureLoader().load( '../textures/763C39_431510_210504_55241C-256px.png' );
-	matcaps[ 'Shiny Green' ] = new THREE.TextureLoader().load( '../textures/3B6E10_E3F2C3_88AC2E_99CE51-256px.png' );
-	matcaps[ 'Normal' ] = new THREE.TextureLoader().load( '../textures/7877EE_D87FC5_75D9C7_1C78C0-256px.png' );
+	matcaps[ 'Clay' ] = new THREE.TextureLoader().load( './textures/B67F6B_4B2E2A_6C3A34_F3DBC6-256px.png' );
+	matcaps[ 'Red Wax' ] = new THREE.TextureLoader().load( './textures/763C39_431510_210504_55241C-256px.png' );
+	matcaps[ 'Shiny Green' ] = new THREE.TextureLoader().load( './textures/3B6E10_E3F2C3_88AC2E_99CE51-256px.png' );
+	matcaps[ 'Normal' ] = new THREE.TextureLoader().load( './textures/7877EE_D87FC5_75D9C7_1C78C0-256px.png' );
 	material = new THREE.MeshMatcapMaterial( {
 		flatShading: params.flatShading,
 	} );

--- a/example/sculpt.js
+++ b/example/sculpt.js
@@ -1,4 +1,4 @@
-import Stats from 'stats.js/src/Stats';
+import Stats from 'stats.js';
 import * as dat from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';

--- a/example/sdfGeneration.html
+++ b/example/sdfGeneration.html
@@ -40,6 +40,7 @@
 			color: white;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -5,7 +5,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import Stats from 'stats.js';
 import { GenerateMeshBVHWorker } from '../src/workers/GenerateMeshBVHWorker.js';
-import { StaticGeometryGenerator } from '..';
+import { StaticGeometryGenerator } from '../src/index.js';
 import { GenerateSDFMaterial } from './utils/GenerateSDFMaterial.js';
 import { RenderSDFLayerMaterial } from './utils/RenderSDFLayerMaterial.js';
 import { RayMarchSDFMaterial } from './utils/RayMarchSDFMaterial.js';

--- a/example/selection.html
+++ b/example/selection.html
@@ -38,6 +38,7 @@
 			opacity: 0.5;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/selection.js
+++ b/example/selection.js
@@ -8,7 +8,7 @@ import {
 	CONTAINED,
 	INTERSECTED,
 	NOT_INTERSECTED,
-} from '..';
+} from '../src/index.js';
 
 const params = {
 

--- a/example/shapecast.html
+++ b/example/shapecast.html
@@ -16,6 +16,7 @@
             height: 100%;
         }
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
     <script type="module" src="./shapecast.js"></script>

--- a/example/shapecast.js
+++ b/example/shapecast.js
@@ -3,7 +3,7 @@ import * as dat from 'three/examples/jsm/libs/lil-gui.module.min.js';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls.js';
-import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, MeshBVHHelper } from '..';
+import { acceleratedRaycast, computeBoundsTree, disposeBoundsTree, MeshBVHHelper } from '../src/index.js';
 
 THREE.Mesh.prototype.raycast = acceleratedRaycast;
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/skinnedMesh.html
+++ b/example/skinnedMesh.html
@@ -41,6 +41,7 @@
 			padding: 5px 0;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/skinnedMesh.js
+++ b/example/skinnedMesh.js
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import Stats from 'stats.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import { computeBoundsTree, MeshBVHHelper, getBVHExtremes, StaticGeometryGenerator } from '..';
+import { computeBoundsTree, MeshBVHHelper, getBVHExtremes, StaticGeometryGenerator } from '../src/index.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 THREE.BufferGeometry.prototype.computeBoundsTree = computeBoundsTree;

--- a/example/triangleIntersect.html
+++ b/example/triangleIntersect.html
@@ -16,6 +16,7 @@
             height: 100%;
         }
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
     <script type="module" src="./triangleIntersect.js"></script>

--- a/example/utils/GenerateSDFMaterial.js
+++ b/example/utils/GenerateSDFMaterial.js
@@ -1,5 +1,5 @@
 import { ShaderMaterial, Matrix4 } from 'three';
-import { BVHShaderGLSL, MeshBVHUniformStruct } from '../..';
+import { BVHShaderGLSL, MeshBVHUniformStruct } from '../../src/index.js';
 
 export class GenerateSDFMaterial extends ShaderMaterial {
 

--- a/example/utils/edgeUtils.js
+++ b/example/utils/edgeUtils.js
@@ -1,5 +1,5 @@
 import { Vector3, Triangle, Line3, MathUtils, Plane, BufferGeometry, BufferAttribute } from 'three';
-import { ExtendedTriangle } from '../..';
+import { ExtendedTriangle } from '../../src/index.js';
 
 const _upVector = new Vector3( 0, 1, 0 );
 const EPSILON = 1e-16;

--- a/example/voxelize.html
+++ b/example/voxelize.html
@@ -41,6 +41,7 @@
 			padding: 5px 0;
 		}
     </style>
+    <script src="importmap.js"></script>
 </head>
 <body>
 	<div id="info">

--- a/example/voxelize.js
+++ b/example/voxelize.js
@@ -3,7 +3,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { MeshoptDecoder } from 'three/examples/jsm/libs/meshopt_decoder.module.js';
 import Stats from 'stats.js';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import { MeshBVH } from '..';
+import { MeshBVH } from '../src/index.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { RoundedBoxGeometry } from 'three/examples/jsm/geometries/RoundedBoxGeometry.js';
 import { GenerateMeshBVHWorker } from '../src/workers/GenerateMeshBVHWorker.js';

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "concurrently \"rollup -w -c rollup-templating.config.js\" \"vite --config ./vite.config.js\"",
     "build": "rollup -c rollup-templating.config.js && rollup -c",
     "build-silent": "rollup -c rollup-templating.config.js --silent && rollup -c --silent",
-    "build-examples": "npm run build && vite build --config ./vite.config.js && cp ./example/coi-serviceworker.js ./example/bundle/",
+    "build-examples": "npm run build && vite build --config ./vite.config.js && cp ./example/coi-serviceworker.js ./example/bundle/ && cp -r ./example/textures ./example/bundle/ && touch ./example/bundle/importmap.js",
     "test": "npm run build-silent && cd test && jest",
     "lint": "eslint \"./src/**/*.{js,ts}\" \"./test/**/*.{js,ts}\" \"./example/*.js\" && tsc --noEmit",
     "benchmark": "npm run build-silent && node benchmark/run-benchmark.js",


### PR DESCRIPTION
Fixes: #427

Now we don't need `npm run build-examples` any longer for *most* examples. There are a few exceptions that don't work yet:

http://127.0.0.1/three-mesh-bvh/example/asyncGenerate.html
http://127.0.0.1/three-mesh-bvh/example/cpuPathTracing.html
http://127.0.0.1/three-mesh-bvh/example/distancecast.html
http://127.0.0.1/three-mesh-bvh/example/sdfGeneration.html
http://127.0.0.1/three-mesh-bvh/example/voxelize.html

For example in `distancecast` we get this error:

```
Uncaught TypeError: Failed to resolve module specifier "simplex-noise". Relative references must start with either "/", "./", or "../".
```

The reason is simply that there is no `simplex-noise` ESM release on NPM. Now there are obviously many ways around such limitations, e.g. either just copy the rather small lib into this repo itself or just publish your own ESM style `simplex-noise` library (and add it to the `importmap.js`). I don't really care too much, I'm only interested in the examples that work currently.

The advantages of this PR are:
 - We don't need `npm run build-examples` any longer for *most* examples
 - Quicker coding iterations with less disruptions from entering shell commands

The disadvantages of this PR are:
 - `vite` is spamming a bit about `importmap.js` not being a module... but it all just builds fine anyway