### PR TITLE
Make SDF Generation more Robust

### DIFF
--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -262,10 +262,10 @@ function updateSDF() {
 					ray.origin.copy( point );
 					ray.direction.set( 0, 0, 1 );
 					const hit = bvh.raycastFirst( ray, THREE.DoubleSide );
-					let isInside = hit && hit.face.normal.dot( ray.direction ) > 0.0;
+					const isInside = hit && hit.face.normal.dot( ray.direction ) > 0.0;
 
 					// set the distance in the texture data
-					sdfTex.image.data[ index ] = isInside > 0.0 ? - dist : dist;
+					sdfTex.image.data[ index ] = isInside ? - dist : dist;
 
 				}
 

--- a/example/sdfGeneration.js
+++ b/example/sdfGeneration.js
@@ -236,12 +236,8 @@ function updateSDF() {
 		sdfTex.magFilter = THREE.LinearFilter;
 		sdfTex.needsUpdate = true;
 
-		const posAttr = geometry.attributes.position;
-		const indexAttr = geometry.index;
 		const point = new THREE.Vector3();
-		const normal = new THREE.Vector3();
-		const delta = new THREE.Vector3();
-		const tri = new THREE.Triangle();
+		const ray = new THREE.Ray();
 		const target = {};
 
 		// iterate over all pixels and check distance
@@ -262,17 +258,14 @@ function updateSDF() {
 					const index = x + y * dim + z * dim * dim;
 					const dist = bvh.closestPointToPoint( point, target ).distance;
 
-					// get the face normal to determine if the distance should be positive or negative
-					const faceIndex = target.faceIndex;
-					const i0 = indexAttr.getX( faceIndex * 3 + 0 );
-					const i1 = indexAttr.getX( faceIndex * 3 + 1 );
-					const i2 = indexAttr.getX( faceIndex * 3 + 2 );
-					tri.setFromAttributeAndIndices( posAttr, i0, i1, i2 );
-					tri.getNormal( normal );
-					delta.subVectors( target.point, point );
+					// raycast inside the mesh to determine if the distance should be positive or negative
+					ray.origin.copy( point );
+					ray.direction.set( 0, 0, 1 );
+					const hit = bvh.raycastFirst( ray, THREE.DoubleSide );
+					let isInside = hit && hit.face.normal.dot( ray.direction ) > 0.0;
 
 					// set the distance in the texture data
-					sdfTex.image.data[ index ] = normal.dot( delta ) > 0.0 ? - dist : dist;
+					sdfTex.image.data[ index ] = isInside > 0.0 ? - dist : dist;
 
 				}
 

--- a/example/utils/GenerateSDFMaterial.js
+++ b/example/utils/GenerateSDFMaterial.js
@@ -60,8 +60,8 @@ export class GenerateSDFMaterial extends ShaderMaterial {
 					vec3 outPoint;
 					float dist = bvhClosestPointToPoint( bvh, point.xyz, faceIndices, faceNormal, barycoord, side, outPoint );
 
-					//bool hit = bvhIntersectFirstHit( bvh, point.xyz, vec3(0.0, 0.0, 1.0), faceIndices, faceNormal, barycoord, side, rayDist );
-					//side = ( hit && side > 0.0 ) ? 1.0 : -1.0;
+					side = 1.0;
+					bvhIntersectFirstHit( bvh, point.xyz, vec3( 0.0, 0.0, 1.0 ), faceIndices, faceNormal, barycoord, side, rayDist );
 
 					// if the triangle side is the back then it must be on the inside and the value negative
 					gl_FragColor = vec4( side * dist, 0, 0, 0 );

--- a/example/utils/GenerateSDFMaterial.js
+++ b/example/utils/GenerateSDFMaterial.js
@@ -56,8 +56,12 @@ export class GenerateSDFMaterial extends ShaderMaterial {
 					vec3 faceNormal;
 					vec3 barycoord;
 					float side;
+					float rayDist;
 					vec3 outPoint;
 					float dist = bvhClosestPointToPoint( bvh, point.xyz, faceIndices, faceNormal, barycoord, side, outPoint );
+
+					//bool hit = bvhIntersectFirstHit( bvh, point.xyz, vec3(0.0, 0.0, 1.0), faceIndices, faceNormal, barycoord, side, rayDist );
+					//side = ( hit && side > 0.0 ) ? 1.0 : -1.0;
 
 					// if the triangle side is the back then it must be on the inside and the value negative
 					gl_FragColor = vec4( side * dist, 0, 0, 0 );


### PR DESCRIPTION
This PR addresses the findings of https://github.com/gkjohnson/three-mesh-bvh/pull/705 by adding a CPU workaround to the flaky insided-ness check of the SDF generation.

It doesn't seem like the GPU SDF Generation works on Windows (Chrome AND Firefox) right now, so I've tried to add it while testing on my iOS device... but it seems like adding the raycast function crashes the renderer in my iOS device and I can't access any error messages from Windows😅 