### PR TITLE
Test on different versions of three

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x]
-        three-version: [0.158.0, 0.168.0, latest]
+        three-version: [0.159.0, 0.168.0, latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x]
+        three-version: [0.158.0, 0.168.0, latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,6 +27,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
+    - run: npm install three@${{ matrix.three-version }}
     - run: npm run build
     - run: npm run benchmark
     - run: npm run lint


### PR DESCRIPTION
Following up on your [request](https://github.com/gkjohnson/three-mesh-bvh/issues/711#issuecomment-2340498304) to add different versions of `three` to your CI pipeline. [Looks like it still doesn't work](https://github.com/dmurvihill/three-mesh-bvh/actions/runs/11046423591/job/30685724723) on 0.158.