### PR TITLE
Fixes the triangle bounds array size

### DIFF
--- a/src/core/build/computeBoundsUtils.js
+++ b/src/core/build/computeBoundsUtils.js
@@ -82,7 +82,7 @@ export function computeTriangleBounds( geo, target = null, offset = null, count 
 	let triangleBounds;
 	if ( target === null ) {
 
-		triangleBounds = new Float32Array( triCount * 6 * 4 );
+		triangleBounds = new Float32Array( triCount * 6 );
 		offset = 0;
 		count = triCount;
 


### PR DESCRIPTION
The size of the Float32Array for the triangle bounds was x4 too big (possibly the factor of 4 crept in from a raw ArrayBuffer allocation?). 

When processing large number of triangles, this extra size could cause a failed buffer allocation.