### PR TITLE
Add overload from the docs to MeshBVHHelper type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -190,6 +190,7 @@ export class MeshBVHHelper extends Group {
   meshMaterial: MeshBasicMaterial;
 
   constructor( mesh: Mesh, depth?: number );
+  constructor( mesh: Mesh, bvh: MeshBVH, depth?: number)
 
   update(): void;
 


### PR DESCRIPTION
I was trying to construct a `MeshBVHHelper` via a `MeshBVH` that i constructed via `BufferGeometry` not a `Mesh`. The type doesn't support the overload thats listed in the docs. 

```
constructor(
	mesh = null : THREE.Mesh,
	bvh = null : MeshBVH,
	depth = 10 : Number
)
```
With this change, i seem to be able to pass these three arguments without TS complaining and i see the results. I'm also confused with the default parameters of `null` since the type doesnt seem to be nullable. This makes it sound like its `mesh?: THREE.Mesh | null`. 


However, if i try to construct this with `MeshBVH` instead of `THREE.Mesh`
```
constructor(
	meshOrBvh: THREE.Mesh | MeshBVH,
	depth = 10 : Number
)
```

I run into an issue here:
<img width="555" alt="image" src="https://github.com/user-attachments/assets/e8ed0a50-28b2-4c60-b0b7-51cdd4aa5b0a">

Because of this i believe:
https://github.com/gkjohnson/three-mesh-bvh/blob/8f642cb8a01ead8ac679209f402d89a6fbb81b09/src/objects/MeshBVHHelper.js#L239

If you provide `MeshBVH` instead, it will set `this.mesh = null` and then accessing a property on it fails. 

I couldn't dig deeper into this at this point. The quickest thing may be to remove the `Mesh|BVHMesh` from the first argument in that signature and update the docs accordingly.

