### PR TITLE
Extend _bvhClosestPointToPoint to accept maxDistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1136,18 +1136,29 @@ Dispose of the associated textures.
 ### shaderStructs
 
 ```js
+BVHShaderGLSL.bvh_struct_definitions : string
+
+or equivalent, legacy:
+
 shaderStructs : string
 ```
 
-Set of shaders structs and defined constants used for interacting with the packed BVH in a shader. See [src/gpu/shaderFunctions.js](https://github.com/gkjohnson/three-mesh-bvh/blob/master/src/gpu/shaderFunctions.js) for full implementations and declarations.
+Set of shaders structs and defined constants used for interacting with the packed BVH in a shader. See [src/gpu/bvh_struct_definitions.glsl.js](https://github.com/gkjohnson/three-mesh-bvh/blob/master/src/gpu/bvh_struct_definitions.glsl.js) for full implementations and declarations.
 
 ### shaderFunctions
 
 ```js
-shaderFunctions : string
+BVHShaderGLSL.bvh_distance_functions : string
+BVHShaderGLSL.bvh_ray_functions : string
+BVHShaderGLSL.common_functions : string
+
+or equivalent, bundled for specific usage (legacy):
+
+shaderDistanceFunction : string
+shaderIntersectFunction : string
 ```
 
-Set of shader functions used for interacting with the packed BVH in a shader and sampling [VertexAttributeTextures](#VertexAttributeTexture). See [src/gpu/shaderFunctions.js](https://github.com/gkjohnson/three-mesh-bvh/blob/master/src/gpu/shaderFunctions.js) for full implementations and declarations.
+Set of shader functions used for interacting with the packed BVH in a shader and sampling [VertexAttributeTextures](#VertexAttributeTexture). See [src/gpu/glsl](https://github.com/gkjohnson/three-mesh-bvh/tree/master/src/gpu/glsl) for full implementations and declarations.
 
 ## Gotchas
 

--- a/example/utils/GenerateSDFMaterial.js
+++ b/example/utils/GenerateSDFMaterial.js
@@ -64,7 +64,7 @@ export class GenerateSDFMaterial extends ShaderMaterial {
 					float side;
 					float rayDist;
 					vec3 outPoint;
-					float dist = bvhClosestPointToPoint( bvh, point.xyz, faceIndices, faceNormal, barycoord, side, outPoint );
+					float dist = bvhClosestPointToPoint( bvh, point.xyz, 100000.0, faceIndices, faceNormal, barycoord, side, outPoint );
 
 					// This currently causes issues on some devices when rendering to 3d textures and texture arrays
 					#if USE_SHADER_RAYCAST

--- a/src/gpu/glsl/bvh_distance_functions.glsl.js
+++ b/src/gpu/glsl/bvh_distance_functions.glsl.js
@@ -113,23 +113,13 @@ float distanceSqToBVHNodeBoundsPoint( vec3 point, sampler2D bvhBounds, uint curr
 
 // use a macro to hide the fact that we need to expand the struct into separate fields
 #define\
-	bvhClosestPointToPointClamped(\
-		bvh,\
-		point, maxDistance, faceIndices, faceNormal, barycoord, side, outPoint\
-	)\
-	_bvhClosestPointToPoint(\
-		bvh.position, bvh.index, bvh.bvhBounds, bvh.bvhContents,\
-		point, maxDistance, faceIndices, faceNormal, barycoord, side, outPoint\
-	)
-
-#define\
 	bvhClosestPointToPoint(\
 		bvh,\
-		point, faceIndices, faceNormal, barycoord, side, outPoint\
+		point, maxDistance, faceIndices, faceNormal, barycoord, side, outPoint\
 	)\
 	_bvhClosestPointToPoint(\
 		bvh.position, bvh.index, bvh.bvhBounds, bvh.bvhContents,\
-		point, 100000.0, faceIndices, faceNormal, barycoord, side, outPoint\
+		point, maxDistance, faceIndices, faceNormal, barycoord, side, outPoint\
 	)
 
 float _bvhClosestPointToPoint(

--- a/src/gpu/glsl/bvh_distance_functions.glsl.js
+++ b/src/gpu/glsl/bvh_distance_functions.glsl.js
@@ -113,13 +113,23 @@ float distanceSqToBVHNodeBoundsPoint( vec3 point, sampler2D bvhBounds, uint curr
 
 // use a macro to hide the fact that we need to expand the struct into separate fields
 #define\
+	bvhClosestPointToPointClamped(\
+		bvh,\
+		point, maxDistance, faceIndices, faceNormal, barycoord, side, outPoint\
+	)\
+	_bvhClosestPointToPoint(\
+		bvh.position, bvh.index, bvh.bvhBounds, bvh.bvhContents,\
+		point, maxDistance, faceIndices, faceNormal, barycoord, side, outPoint\
+	)
+
+#define\
 	bvhClosestPointToPoint(\
 		bvh,\
 		point, faceIndices, faceNormal, barycoord, side, outPoint\
 	)\
 	_bvhClosestPointToPoint(\
 		bvh.position, bvh.index, bvh.bvhBounds, bvh.bvhContents,\
-		point, faceIndices, faceNormal, barycoord, side, outPoint\
+		point, 100000.0, faceIndices, faceNormal, barycoord, side, outPoint\
 	)
 
 float _bvhClosestPointToPoint(
@@ -127,7 +137,7 @@ float _bvhClosestPointToPoint(
 	sampler2D bvh_position, usampler2D bvh_index, sampler2D bvh_bvhBounds, usampler2D bvh_bvhContents,
 
 	// point to check
-	vec3 point,
+	vec3 point, float maxDistance,
 
 	// output variables
 	inout uvec4 faceIndices, inout vec3 faceNormal, inout vec3 barycoord,
@@ -140,7 +150,7 @@ float _bvhClosestPointToPoint(
 	uint stack[ BVH_STACK_DEPTH ];
 	stack[ 0 ] = 0u;
 
-	float closestDistanceSquared = pow( 100000.0, 2.0 );
+	float closestDistanceSquared = maxDistance * maxDistance;
 	bool found = false;
 	while ( ptr > - 1 && ptr < BVH_STACK_DEPTH ) {
 


### PR DESCRIPTION
Recently I needed to find a closest mesh to the point on the gpu. It was pretty fast, considering the complexity. But it could be faster, if we allowed setting lower starting closestDistanceSquared thus skipping a lot of useless variants. Also, this would allow finding distances farther than 100000 (if this could in fact happen at all)

The change will not disrupt existing usage, but add a new possibility for situational performance improvement.

If you are ok with the change, should I document this somewhere? I couldn't find explicit documentation for shader function 