### PR TITLE
sync index.d.ts MeshBVHOptions with js, add indirect parameter

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,6 +26,7 @@ export interface MeshBVHOptions {
   maxLeafTris?: number;
   setBoundingBox?: boolean;
   useSharedArrayBuffer?: boolean;
+  indirect?: boolean;
   verbose?: boolean;
   onProgress?: ( progress: number ) => void;
   range?: { start: number; count: number };


### PR DESCRIPTION
ts version MeshBVHOptions miss the parameter **indirect** of js version.

now with full list of parameter list.

```ts
export interface MeshBVHOptions {
  strategy?: SplitStrategy;
  maxDepth?: number;
  maxLeafTris?: number;
  setBoundingBox?: boolean;
  useSharedArrayBuffer?: boolean;
  indirect?: boolean;
  verbose?: boolean;
  onProgress?: ( progress: number ) => void;
  range?: { start: number; count: number };
}
```
