### PR TITLE
Update to r178

### DIFF
--- a/example/diamond.html
+++ b/example/diamond.html
@@ -1,46 +1,60 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <title>Total Internal Refraction</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+	<head>
+		<meta charset="UTF-8"/>
+		<link rel="shortcut icon" href="#">	<!--avoid favicon error in the console-->
+		<title>Total Internal Refraction</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
-    <style type="text/css">
-        html,
-        body {
-            padding: 0;
-            margin: 0;
-            overflow: hidden;
-        }
+		<style type="text/css">
+			html,
+			body {
+				padding: 0;
+				margin: 0;
+				overflow: hidden;
+			}
 
-        canvas {
-            width: 100%;
-            height: 100%;
-        }
+			canvas {
+				width: 100%;
+				height: 100%;
+			}
 
-		#info {
-			position: absolute;
-			top: 0;
-			width: 100%;
-			color: white;
-			font-family: monospace;
-			text-align: center;
-			padding: 5px 0;
+			#info {
+				position: absolute;
+				top: 0;
+				width: 100%;
+				color: white;
+				font-family: monospace;
+				text-align: center;
+				padding: 5px 0;
+			}
+
+			a {
+				color: white;
+			}
+		</style>
+
+		<script type="importmap"> {
+			"imports": {
+				"three": "../node_modules/three/build/three.module.js",
+				"three/addons/": "../node_modules/three/examples/jsm/"
+			}
 		}
+		</script>
 
-		a {
-			color: white;
-		}
-    </style>
-</head>
+	</head>
 
-<body>
-	<div id="info">
-		Using shader ray tracing to model internal reflection for a diamond material.
-		<br/>
-		Model from <a href="https://sketchfab.com/3d-models/diamond-low-poly-405cc8175019452daa01999fd1466731">Sketchfab</a>. Full material implementation available <a href="https://github.com/pmndrs/drei/blob/master/src/materials/MeshRefractionMaterial.tsx">here</a>.
-	</div>
-    <script type="module" src="./diamond.js"></script>
-</body>
+	<body>
+
+		<div id="info">
+			Using shader ray tracing to model internal reflection for a diamond material.
+			<br/>
+			Model from <a href="https://sketchfab.com/3d-models/diamond-low-poly-405cc8175019452daa01999fd1466731">Sketchfab</a>. Full material implementation available <a href="https://github.com/pmndrs/drei/blob/master/src/materials/MeshRefractionMaterial.tsx">here</a>.
+		</div>
+
+		<script type="module" src="./diamond.js"></script>
+
+	</body>
 
 </html>

--- a/example/diamond.js
+++ b/example/diamond.js
@@ -1,9 +1,9 @@
 import * as THREE from 'three';
-import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
-import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
-import Stats from 'three/examples/jsm/libs/stats.module.js';
+import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
+import Stats from 'three/addons/libs/stats.module.js';
 import {
 	MeshBVH,
 	MeshBVHUniformStruct,

--- a/example/gpuPathTracing.html
+++ b/example/gpuPathTracing.html
@@ -1,50 +1,67 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <title>three-mesh-bvh - GPU Path Tracing</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
-    <style type="text/css">
-        html, body {
-            padding: 0;
-            margin: 0;
-            overflow: hidden;
-            font-family: monospace;
-        }
+	<head>
+		<meta charset="UTF-8"/>
+		<link rel="shortcut icon" href="#">	<!--avoid favicon error in the console-->
+		<title>three-mesh-bvh - GPU Path Tracing</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
-        canvas {
-            width: 100%;
-            height: 100%;
-        }
+		<style type="text/css">
+			html, body {
+				padding: 0;
+				margin: 0;
+				overflow: hidden;
+				font-family: monospace;
+			}
 
-        #output {
-            position: absolute;
-            bottom: 0;
-            left: 0;
-            padding: 5px;
-            color: #777;
-            opacity: 0.75;
-            font-family: monospace;
-            pointer-events: none;
-            white-space: pre;
-        }
+			canvas {
+				width: 100%;
+				height: 100%;
+			}
 
-        #info {
-            position: absolute;
-            top: 0;
-            width: 100%;
-            color: #777;
-            font-family: monospace;
-            text-align: center;
-            padding: 5px 0;
-        }
-    </style>
-</head>
-<body>
-	<div id="info">
-		Lambertian material Path Tracer implemented using BVH intersections on the GPU.
-	</div>
-	<div id="output"></div>
-    <script type="module" src="./gpuPathTracing.js"></script>
-</body>
+			#output {
+				position: absolute;
+				bottom: 0;
+				left: 0;
+				padding: 5px;
+				color: #777;
+				opacity: 0.75;
+				font-family: monospace;
+				pointer-events: none;
+				white-space: pre;
+			}
+
+			#info {
+				position: absolute;
+				top: 0;
+				width: 100%;
+				color: #777;
+				font-family: monospace;
+				text-align: center;
+				padding: 5px 0;
+			}
+		</style>
+
+		<script type="importmap"> {
+			"imports": {
+				"three": "../node_modules/three/build/three.module.js",
+				"three/addons/": "../node_modules/three/examples/jsm/"
+			}
+		}
+		</script>
+
+	</head>
+
+	<body>
+
+		<div id="info">
+			Lambertian material Path Tracer implemented using BVH intersections on the GPU.
+		</div>
+		<div id="output"></div>
+
+		<script type="module" src="./gpuPathTracing.js"></script>
+
+	</body>
+
 </html>

--- a/example/gpuPathTracing.js
+++ b/example/gpuPathTracing.js
@@ -1,14 +1,14 @@
 import * as THREE from 'three';
-import { FullScreenQuad } from 'three/examples/jsm/postprocessing/Pass.js';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
-import Stats from 'stats.js';
-import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
+import { FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import Stats from 'three/addons/libs/stats.module.js';
+import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
 import {
 	MeshBVH, MeshBVHUniformStruct, FloatVertexAttributeTexture,
 	SAH, BVHShaderGLSL,
-} from '..';
+} from '../src/index.js';
 
 const params = {
 	enableRaytracing: true,

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "simplex-noise": "^2.4.0",
     "static-server": "^2.2.1",
     "stats.js": "^0.17.0",
-    "three": "^0.170.0",
+    "three": "^0.178.0",
     "typescript": "^5.1.3",
     "vite": "^5.2.13"
   }


### PR DESCRIPTION
@gkjohnson 
This is just to illustrate what I did to get it running on r178.
I simply set threejs to r178 in the package.json.
Then I inserted the import maps into 

diamonds.html 
gpuPathTracing.html 

and adjusted the paths in the corresponding js files.

But doing it this way is a matter of taste. Importmaps offer the advantage that the global path to the threejs files only needs to be changed in the HTML, not in the many js files where threejs files can be used everywhere. 

As soon as the project is running with r178, I'll create a PR for the WebGPU example. gpuPathTracingSimple was a great idea, thanks. The example was very clear


