### PR TITLE
Fix NPE when intersecting degenerate triangle

### DIFF
--- a/src/utils/ThreeRayIntersectUtilities.js
+++ b/src/utils/ThreeRayIntersectUtilities.js
@@ -55,16 +55,19 @@ function checkBufferGeometryIntersection( ray, position, normal, uv, uv1, a, b, 
 
 	if ( intersection ) {
 
-		const barycoord = new Vector3();
-		Triangle.getBarycoord( _intersectionPoint, _vA, _vB, _vC, barycoord );
-
 		if ( uv ) {
 
 			_uvA.fromBufferAttribute( uv, a );
 			_uvB.fromBufferAttribute( uv, b );
 			_uvC.fromBufferAttribute( uv, c );
 
-			intersection.uv = Triangle.getInterpolation( _intersectionPoint, _vA, _vB, _vC, _uvA, _uvB, _uvC, new Vector2() );
+			intersection.uv = new Vector2();
+			const res = Triangle.getInterpolation( _intersectionPoint, _vA, _vB, _vC, _uvA, _uvB, _uvC, intersection.uv );
+			if ( ! IS_GT_REVISION_169 ) {
+
+				intersection.uv = res;
+
+			}
 
 		}
 
@@ -74,7 +77,13 @@ function checkBufferGeometryIntersection( ray, position, normal, uv, uv1, a, b, 
 			_uvB.fromBufferAttribute( uv1, b );
 			_uvC.fromBufferAttribute( uv1, c );
 
-			intersection.uv1 = Triangle.getInterpolation( _intersectionPoint, _vA, _vB, _vC, _uvA, _uvB, _uvC, new Vector2() );
+			intersection.uv1 = new Vector2();
+			const res = Triangle.getInterpolation( _intersectionPoint, _vA, _vB, _vC, _uvA, _uvB, _uvC, intersection.uv1 );
+			if ( ! IS_GT_REVISION_169 ) {
+
+				intersection.uv1 = res;
+
+			}
 
 		}
 
@@ -84,10 +93,17 @@ function checkBufferGeometryIntersection( ray, position, normal, uv, uv1, a, b, 
 			_normalB.fromBufferAttribute( normal, b );
 			_normalC.fromBufferAttribute( normal, c );
 
-			intersection.normal = Triangle.getInterpolation( _intersectionPoint, _vA, _vB, _vC, _normalA, _normalB, _normalC, new Vector3() );
+			intersection.normal = new Vector3();
+			const res = Triangle.getInterpolation( _intersectionPoint, _vA, _vB, _vC, _normalA, _normalB, _normalC, intersection.normal );
 			if ( intersection.normal.dot( ray.direction ) > 0 ) {
 
 				intersection.normal.multiplyScalar( - 1 );
+
+			}
+
+			if ( ! IS_GT_REVISION_169 ) {
+
+				intersection.normal = res;
 
 			}
 
@@ -107,6 +123,9 @@ function checkBufferGeometryIntersection( ray, position, normal, uv, uv1, a, b, 
 		intersection.faceIndex = a;
 
 		if ( IS_GT_REVISION_169 ) {
+
+			const barycoord = new Vector3();
+			Triangle.getBarycoord( _intersectionPoint, _vA, _vB, _vC, barycoord );
 
 			intersection.barycoord = barycoord;
 

--- a/src/utils/ThreeRayIntersectUtilities.js
+++ b/src/utils/ThreeRayIntersectUtilities.js
@@ -1,6 +1,7 @@
 import { Vector3, Vector2, Triangle, DoubleSide, BackSide, REVISION } from 'three';
 
 const IS_GT_REVISION_169 = parseInt( REVISION ) >= 169;
+const IS_LT_REVISION_161 = parseInt( REVISION ) <= 161;
 
 // Ripped and modified From THREE.js Mesh raycast
 // https://github.com/mrdoob/three.js/blob/0aa87c999fe61e216c1133fba7a95772b503eddf/src/objects/Mesh.js#L115
@@ -82,6 +83,12 @@ function checkBufferGeometryIntersection( ray, position, normal, uv, uv1, a, b, 
 			if ( ! IS_GT_REVISION_169 ) {
 
 				intersection.uv1 = res;
+
+			}
+
+			if ( IS_LT_REVISION_161 ) {
+
+				intersection.uv2 = intersection.uv1;
 
 			}
 

--- a/test/Utils.geometryUtils.test.js
+++ b/test/Utils.geometryUtils.test.js
@@ -1,5 +1,6 @@
-import { SphereGeometry, BoxGeometry } from 'three';
+import { SphereGeometry, BoxGeometry, Ray, Vector3, Triangle, BufferGeometry, DoubleSide, REVISION, BufferAttribute } from 'three';
 import { getVertexCount, hasGroupGaps } from '../src/core/build/geometryUtils.js';
+import { intersectTri } from '../src/utils/ThreeRayIntersectUtilities.js';
 
 describe( 'hasGroupGaps', () => {
 
@@ -89,6 +90,68 @@ describe( 'hasGroupGaps', () => {
 		geometry.addGroup( 0, getVertexCount( geometry ) - 1, 0 );
 		const range = { start: 0, count: Infinity };
 		expect( hasGroupGaps( geometry, range ) ).toBe( true );
+
+	} );
+
+} );
+
+describe( 'intersectTri', () => {
+
+	it( 'should comply with three.js return values in a degenerate case', () => {
+
+		const ray = new Ray();
+		ray.origin.set( 0, 0, 1 );
+		ray.direction.set( 0, 0, - 1 );
+
+		const position = new BufferAttribute( new Float32Array( [
+			2, 0, 0,
+			0, 0, 0,
+			1, 1e-16, 0,
+		] ), 3 );
+
+		const normal = new BufferAttribute( new Float32Array( [
+			0, 0, 1,
+			0, 0, 1,
+			0, 0, 1,
+		] ), 3 );
+
+		const uv = new BufferAttribute( new Float32Array( [
+			1, 1,
+			1, 1,
+			1, 1,
+		] ), 2 );
+
+		const uv1 = new BufferAttribute( new Float32Array( [
+			1, 1,
+			1, 1,
+			1, 1,
+		] ), 2 );
+
+		const geo = new BufferGeometry();
+		geo.setAttribute( 'position', position );
+		geo.setAttribute( 'normal', normal );
+		geo.setAttribute( 'uv', uv );
+		geo.setAttribute( 'uv1', uv1 );
+
+		const intersection = intersectTri( geo, DoubleSide, ray, 0, undefined, 0, 10 );
+
+		expect( intersection !== undefined ).toBe( true );
+
+		if ( parseInt( REVISION ) >= 169 ) {
+
+			expect( intersection.barycoord.equals( new Vector3() ) ).toBe( true );
+			expect( intersection.uv.equals( new Vector3() ) ).toBe( true );
+			expect( intersection.uv1.equals( new Vector3() ) ).toBe( true );
+			expect( intersection.normal.equals( new Vector3() ) ).toBe( true );
+
+		} else {
+
+			expect( intersection.barycoord === undefined ).toBe( true );
+			expect( intersection.uv === null ).toBe( true );
+			expect( intersection.uv1 === null ).toBe( true );
+			expect( intersection.normal === null ).toBe( true );
+
+		}
 
 	} );
 

--- a/test/Utils.geometryUtils.test.js
+++ b/test/Utils.geometryUtils.test.js
@@ -1,4 +1,4 @@
-import { SphereGeometry, BoxGeometry, Ray, Vector3, Triangle, BufferGeometry, DoubleSide, REVISION, BufferAttribute } from 'three';
+import { SphereGeometry, BoxGeometry, Ray, Vector3, BufferGeometry, DoubleSide, REVISION, BufferAttribute } from 'three';
 import { getVertexCount, hasGroupGaps } from '../src/core/build/geometryUtils.js';
 import { intersectTri } from '../src/utils/ThreeRayIntersectUtilities.js';
 
@@ -106,7 +106,7 @@ describe( 'intersectTri', () => {
 		const position = new BufferAttribute( new Float32Array( [
 			2, 0, 0,
 			0, 0, 0,
-			1, 1e-16, 0,
+			1, 1e-20, 0,
 		] ), 3 );
 
 		const normal = new BufferAttribute( new Float32Array( [
@@ -135,7 +135,7 @@ describe( 'intersectTri', () => {
 
 		const intersection = intersectTri( geo, DoubleSide, ray, 0, undefined, 0, 10 );
 
-		expect( intersection !== undefined ).toBe( true );
+		expect( intersection !== null ).toBe( true );
 
 		if ( parseInt( REVISION ) >= 169 ) {
 

--- a/test/Utils.geometryUtils.test.js
+++ b/test/Utils.geometryUtils.test.js
@@ -1,4 +1,4 @@
-import { SphereGeometry, BoxGeometry, Ray, Vector3, BufferGeometry, DoubleSide, REVISION, BufferAttribute } from 'three';
+import { SphereGeometry, BoxGeometry, Ray, Vector3, BufferGeometry, DoubleSide, REVISION, BufferAttribute, Vector2 } from 'three';
 import { getVertexCount, hasGroupGaps } from '../src/core/build/geometryUtils.js';
 import { intersectTri } from '../src/utils/ThreeRayIntersectUtilities.js';
 
@@ -138,19 +138,27 @@ describe( 'intersectTri', () => {
 		expect( intersection !== null ).toBe( true );
 
 		const revision = parseInt( REVISION );
-		if ( revision >= 169 || 159 >= revision ) {
+		if ( revision >= 169 ) {
 
 			expect( intersection.barycoord.equals( new Vector3() ) ).toBe( true );
 			expect( intersection.uv.equals( new Vector3() ) ).toBe( true );
 			expect( intersection.uv1.equals( new Vector3() ) ).toBe( true );
 			expect( intersection.normal.equals( new Vector3() ) ).toBe( true );
 
-		} else {
+		} else if ( revision > 159 ) {
 
 			expect( intersection.barycoord === undefined ).toBe( true );
 			expect( intersection.uv === null ).toBe( true );
 			expect( intersection.uv1 === null ).toBe( true );
 			expect( intersection.normal === null ).toBe( true );
+
+		} else {
+
+			// Before r159 getBarycoord returned (-2, -1, -1) for collinear case...
+			expect( intersection.barycoord === undefined ).toBe( true );
+			expect( intersection.uv.equals( new Vector2( - 4, - 4 ) ) ).toBe( true );
+			expect( intersection.uv1.equals( new Vector2( - 4, - 4 ) ) ).toBe( true );
+			expect( intersection.normal.equals( new Vector3( 0, 0, 4 ) ) ).toBe( true );
 
 		}
 

--- a/test/Utils.geometryUtils.test.js
+++ b/test/Utils.geometryUtils.test.js
@@ -138,7 +138,7 @@ describe( 'intersectTri', () => {
 		expect( intersection !== null ).toBe( true );
 
 		const revision = parseInt( REVISION );
-		if ( revision >= 169 || 159 <= revision ) {
+		if ( revision >= 169 || 159 >= revision ) {
 
 			expect( intersection.barycoord.equals( new Vector3() ) ).toBe( true );
 			expect( intersection.uv.equals( new Vector3() ) ).toBe( true );

--- a/test/Utils.geometryUtils.test.js
+++ b/test/Utils.geometryUtils.test.js
@@ -106,7 +106,7 @@ describe( 'intersectTri', () => {
 		const position = new BufferAttribute( new Float32Array( [
 			2, 0, 0,
 			0, 0, 0,
-			1, 1e-20, 0,
+			1, 1e-40, 0,
 		] ), 3 );
 
 		const normal = new BufferAttribute( new Float32Array( [

--- a/test/Utils.geometryUtils.test.js
+++ b/test/Utils.geometryUtils.test.js
@@ -106,7 +106,7 @@ describe( 'intersectTri', () => {
 		const position = new BufferAttribute( new Float32Array( [
 			2, 0, 0,
 			0, 0, 0,
-			1, 1e-40, 0,
+			1, 1e-20, 0,
 		] ), 3 );
 
 		const normal = new BufferAttribute( new Float32Array( [
@@ -137,7 +137,8 @@ describe( 'intersectTri', () => {
 
 		expect( intersection !== null ).toBe( true );
 
-		if ( parseInt( REVISION ) >= 169 ) {
+		const revision = parseInt( REVISION );
+		if ( revision >= 169 || 159 <= revision ) {
 
 			expect( intersection.barycoord.equals( new Vector3() ) ).toBe( true );
 			expect( intersection.uv.equals( new Vector3() ) ).toBe( true );


### PR DESCRIPTION
I've tried to align return values with threejs. Intersecting a degenerate triangle with:
- three.js <= 159 - returns zero-ed attributes
- 159 < three.js < 169 - returns null attributes
- three.js >= 169 - returns zero-ed attributes

Also moved `Triangle.getBarycoord` inside the if statement as it was only needed with three.js >= 169. Or did I miss something?

There's also `getTriangleHitPointInfo` which does not suffer from NPE, but also always return zero-ed attributes already. I didn't feel it was necessary to be changed as it does not have a three.js analog (or I didn't find one)

Fixes #724 