### PR TITLE
Construction: Only calculate triangle bounds for necessary range

### DIFF
--- a/src/core/build/buildTree.js
+++ b/src/core/build/buildTree.js
@@ -164,8 +164,9 @@ export function buildPackedTree( bvh, options ) {
 
 	const BufferConstructor = options.useSharedArrayBuffer ? SharedArrayBuffer : ArrayBuffer;
 
-	const triangleBounds = computeTriangleBounds( geometry );
-	const geometryRanges = options.indirect ? getFullGeometryRange( geometry, options.range ) : getRootIndexRanges( geometry, options.range );
+	const fullRange = getFullGeometryRange( geometry, options.range );
+	const triangleBounds = computeTriangleBounds( geometry, null, fullRange[ 0 ].offset, fullRange[ 0 ].count );
+	const geometryRanges = options.indirect ? fullRange : getRootIndexRanges( geometry, options.range );
 	bvh._roots = geometryRanges.map( range => {
 
 		const root = buildTree( bvh, triangleBounds, range.offset, range.count, options );

--- a/src/core/build/computeBoundsUtils.js
+++ b/src/core/build/computeBoundsUtils.js
@@ -83,16 +83,15 @@ export function computeTriangleBounds( geo, target = null, offset = null, count 
 	if ( target === null ) {
 
 		triangleBounds = new Float32Array( triCount * 6 );
-		offset = 0;
-		count = triCount;
 
 	} else {
 
 		triangleBounds = target;
-		offset = offset || 0;
-		count = count || triCount;
 
 	}
+
+	offset = offset || 0;
+	count = count || triCount;
 
 	// used for non-normalized positions
 	const posArr = posAttr.array;


### PR DESCRIPTION
Alternative to #766 
Fix #763 

Improves performance for BatchedMesh sub geometry bvh construction by only calculating the triangle bounds for the range used. This still creates a buffer large enough for the full range of geometry in the BatchedMesh for each construction but this can be improved at a later time.

cc @agargaro - what do you think?