### PR TITLE
Add missing node dependencies for bvhIntersectFirstHit

### DIFF
--- a/example/webgpu_gpuPathTracingSimple.js
+++ b/example/webgpu_gpuPathTracingSimple.js
@@ -12,7 +12,7 @@ import {
 
 // three-mesh-bvh
 import { MeshBVH, SAH } from 'three-mesh-bvh';
-import { ndcToCameraRay, bvhIntersectFirstHit } from 'three-mesh-bvh/webgpu';
+import { ndcToCameraRay, bvhIntersectFirstHit, getVertexAttribute } from 'three-mesh-bvh/webgpu';
 
 const params = {
 	enableRaytracing: true,
@@ -145,7 +145,7 @@ function init() {
 			}
 
 		}
-	`, [ ndcToCameraRay, bvhIntersectFirstHit ] );
+	`, [ ndcToCameraRay, bvhIntersectFirstHit, getVertexAttribute ] );
 
 	computeKernel = computeShader( computeShaderParams ).computeKernel( WORKGROUP_SIZE );
 

--- a/src/webgpu/bvh_ray_functions.wgsl.js
+++ b/src/webgpu/bvh_ray_functions.wgsl.js
@@ -1,5 +1,5 @@
 import { wgslFn } from 'three/tsl';
-import { bvhNodeStruct, intersectionResultStruct, intersectsBounds, rayStruct, constants, getVertexAttribute } from './common_functions.wgsl.js';
+import { bvhNodeStruct, intersectionResultStruct, intersectsBounds, rayStruct, constants } from './common_functions.wgsl.js';
 
 export const intersectsTriangle = wgslFn( /* wgsl */ `
 
@@ -47,7 +47,7 @@ export const intersectsTriangle = wgslFn( /* wgsl */ `
 
 	}
 
-`, [ rayStruct, intersectionResultStruct ] );
+`, [ rayStruct, intersectionResultStruct, constants ] );
 
 export const intersectTriangles = wgslFn( /* wgsl */ `
 
@@ -86,7 +86,7 @@ export const intersectTriangles = wgslFn( /* wgsl */ `
 
 	}
 
-`, [ intersectsTriangle, rayStruct, intersectionResultStruct ] );
+`, [ intersectsTriangle, rayStruct, intersectionResultStruct, constants ] );
 
 export const bvhIntersectFirstHit = wgslFn( /* wgsl */ `
 
@@ -172,4 +172,4 @@ export const bvhIntersectFirstHit = wgslFn( /* wgsl */ `
 
 	}
 
-`, [ intersectTriangles, intersectsBounds, rayStruct, bvhNodeStruct, intersectionResultStruct, constants, getVertexAttribute ] );
+`, [ intersectTriangles, intersectsBounds, rayStruct, bvhNodeStruct, intersectionResultStruct, constants ] );


### PR DESCRIPTION
Allows users to import bvhIntersectFirstHit node without errors. Right now it requires constants ~~and getVertexAttribute~~ nodes to be specified by the user