### PR TITLE
Limit triangle bounds buffer to requested range

### DIFF
--- a/src/core/build/computeBoundsUtils.js
+++ b/src/core/build/computeBoundsUtils.js
@@ -80,18 +80,15 @@ export function computeTriangleBounds( geo, target = null, offset = null, count 
 	const triCount = getTriCount( geo );
 	const normalized = posAttr.normalized;
 	let triangleBounds;
-	if ( target === null ) {
+offset = offset || 0;
+count = count || triCount;
 
-		triangleBounds = new Float32Array( triCount * 6 );
+if (target) {
+    triangleBounds = target;
+} else {
+    triangleBounds = new Float32Array(count * 6); // only allocate for needed range
+}
 
-	} else {
-
-		triangleBounds = target;
-
-	}
-
-	offset = offset || 0;
-	count = count || triCount;
 
 	// used for non-normalized positions
 	const posArr = posAttr.array;


### PR DESCRIPTION
Title: Limit triangle bounds buffer to only the size needed (#774)

Description:
Currently, when generating a BVH for a sub-range of a mesh, the triangle bounds buffer is allocated for the full geometry size. This results in unnecessary memory usage for the unused portion of the buffer.

This PR updates the buffer allocation so that it only spans the required range, reducing memory usage. Note that this change introduces offsets when reading data in other parts of the code, which may have minor performance implications.

Related issues: #773

Impact:

Reduced memory footprint for BVH construction on sub-ranges.

Potential minor performance considerations due to offset handling.