### PR TITLE
Bind lasso shape to canvas size

### DIFF
--- a/example/src/Selection.js
+++ b/example/src/Selection.js
@@ -29,16 +29,18 @@ class Selection {
 
 	/** Convert absolute screen coordinates `x` and `y` to relative coordinates in range [-1; 1]. */
 	static normalizePoint( element, x, y ) {
+
 		const rectangle = element?.getBoundingClientRect() ?? {
 			left: 0,
 			top: 0,
 			height: window.innerHeight,
 			width: window.innerWidth,
 		};
-		const correctedX = (x - rectangle.left) / rectangle.width;
-		const correctedY = (y - rectangle.top) / rectangle.height;
+		const correctedX = ( x - rectangle.left ) / rectangle.width;
+		const correctedY = ( y - rectangle.top ) / rectangle.height;
 
-		return [correctedX * 2 - 1, 1 - correctedY * 2];
+		return [ correctedX * 2 - 1, 1 - correctedY * 2 ];
+
 	}
 
 }


### PR DESCRIPTION
When the canvas does not fill the whole window the selection shape in the lasso example will be offset. To make the example code more reusable this pull request checks against the canvas size instead of the window size.