### PR TITLE
WGSL: Avoid keyword as variable name

### DIFF
--- a/src/webgl/glsl/bvh_distance_functions.glsl.js
+++ b/src/webgl/glsl/bvh_distance_functions.glsl.js
@@ -136,16 +136,16 @@ float _bvhClosestPointToPoint(
 
 	// stack needs to be twice as long as the deepest tree we expect because
 	// we push both the left and right child onto the stack every traversal
-	int ptr = 0;
+	int pointer = 0;
 	uint stack[ BVH_STACK_DEPTH ];
 	stack[ 0 ] = 0u;
 
 	float closestDistanceSquared = maxDistance * maxDistance;
 	bool found = false;
-	while ( ptr > - 1 && ptr < BVH_STACK_DEPTH ) {
+	while ( pointer > - 1 && pointer < BVH_STACK_DEPTH ) {
 
-		uint currNodeIndex = stack[ ptr ];
-		ptr --;
+		uint currNodeIndex = stack[ pointer ];
+		pointer --;
 
 		// check if we intersect the current bounds
 		float boundsHitDistance = distanceSqToBVHNodeBoundsPoint( point, bvh_bvhBounds, currNodeIndex );
@@ -180,10 +180,10 @@ float _bvhClosestPointToPoint(
 			// set c2 in the stack so we traverse it later. We need to keep track of a pointer in
 			// the stack while we traverse. The second pointer added is the one that will be
 			// traversed first
-			ptr ++;
-			stack[ ptr ] = c2;
-			ptr ++;
-			stack[ ptr ] = c1;
+			pointer ++;
+			stack[ pointer ] = c2;
+			pointer ++;
+			stack[ pointer ] = c1;
 
 		}
 

--- a/src/webgl/glsl/bvh_ray_functions.glsl.js
+++ b/src/webgl/glsl/bvh_ray_functions.glsl.js
@@ -148,16 +148,16 @@ bool _bvhIntersectFirstHit(
 
 	// stack needs to be twice as long as the deepest tree we expect because
 	// we push both the left and right child onto the stack every traversal
-	int ptr = 0;
+	int pointer = 0;
 	uint stack[ BVH_STACK_DEPTH ];
 	stack[ 0 ] = 0u;
 
 	float triangleDistance = INFINITY;
 	bool found = false;
-	while ( ptr > - 1 && ptr < BVH_STACK_DEPTH ) {
+	while ( pointer > - 1 && pointer < BVH_STACK_DEPTH ) {
 
-		uint currNodeIndex = stack[ ptr ];
-		ptr --;
+		uint currNodeIndex = stack[ pointer ];
+		pointer --;
 
 		// check if we intersect the current bounds
 		float boundsHitDistance;
@@ -197,11 +197,11 @@ bool _bvhIntersectFirstHit(
 			// set c2 in the stack so we traverse it later. We need to keep track of a pointer in
 			// the stack while we traverse. The second pointer added is the one that will be
 			// traversed first
-			ptr ++;
-			stack[ ptr ] = c2;
+			pointer ++;
+			stack[ pointer ] = c2;
 
-			ptr ++;
-			stack[ ptr ] = c1;
+			pointer ++;
+			stack[ pointer ] = c1;
 
 		}
 

--- a/src/webgpu/bvh_ray_functions.wgsl.js
+++ b/src/webgpu/bvh_ray_functions.wgsl.js
@@ -97,7 +97,7 @@ export const bvhIntersectFirstHit = wgslFn( /* wgsl */ `
 		ray: Ray,
 	) -> IntersectionResult {
 
-		var ptr = 0;
+		var pointer = 0;
 		var stack: array<u32, BVH_STACK_DEPTH>;
 		stack[ 0 ] = 0u;
 
@@ -108,16 +108,16 @@ export const bvhIntersectFirstHit = wgslFn( /* wgsl */ `
 
 		loop {
 
-			if ( ptr < 0 || ptr >= i32( BVH_STACK_DEPTH ) ) {
+			if ( pointer < 0 || pointer >= i32( BVH_STACK_DEPTH ) ) {
 
 				break;
 
 			}
 
-			let currNodeIndex = stack[ ptr ];
+			let currNodeIndex = stack[ pointer ];
 			let node = bvh[ currNodeIndex ];
 
-			ptr = ptr - 1;
+			pointer = pointer - 1;
 
 			var boundsHitDistance: f32 = 0.0;
 
@@ -158,11 +158,11 @@ export const bvhIntersectFirstHit = wgslFn( /* wgsl */ `
 				let c1 = select( rightIndex, leftIndex, leftToRight );
 				let c2 = select( leftIndex, rightIndex, leftToRight );
 
-				ptr = ptr + 1;
-				stack[ ptr ] = c2;
+				pointer = pointer + 1;
+				stack[ pointer ] = c2;
 
-				ptr = ptr + 1;
-				stack[ ptr ] = c1;
+				pointer = pointer + 1;
+				stack[ pointer ] = c1;
 
 			}
 

--- a/src/webgpu/distance_functions.wgsl.js
+++ b/src/webgpu/distance_functions.wgsl.js
@@ -151,18 +151,18 @@ export const closestPointToPoint = wgslFn( /* wgsl */ `
 
 		// stack needs to be twice as long as the deepest tree we expect because
 		// we push both the left and right child onto the stack every traversal
-		var ptr = 0;
+		var pointer = 0;
 		var stack: array<u32, BVH_STACK_DEPTH>;
 		stack[ 0 ] = 0u;
 
 		var res: ClosestPointToPointResult;
 		res.distanceSq = maxDistance * maxDistance;
 
-		while ptr > - 1 && ptr < BVH_STACK_DEPTH {
+		while pointer > - 1 && pointer < BVH_STACK_DEPTH {
 
-			let currNodeIndex = stack[ ptr ];
+			let currNodeIndex = stack[ pointer ];
 			let node = bvh[ currNodeIndex ];
-			ptr = ptr - 1;
+			pointer = pointer - 1;
 
 			// check if we intersect the current bounds
 			let boundsDistance = distanceSqToBVHNodeBoundsPoint( point, bvh, currNodeIndex );
@@ -197,11 +197,11 @@ export const closestPointToPoint = wgslFn( /* wgsl */ `
 				let c1 = select( rightIndex, leftIndex, leftToRight );
 				let c2 = select( leftIndex, rightIndex, leftToRight );
 
-				ptr = ptr + 1;
-				stack[ ptr ] = c2;
+				pointer = pointer + 1;
+				stack[ pointer ] = c2;
 
-				ptr = ptr + 1;
-				stack[ ptr ] = c1;
+				pointer = pointer + 1;
+				stack[ pointer ] = c1;
 
 			}
 


### PR DESCRIPTION
Renames "ptr" to "pointer" to avoid conflict with "ptr" keyword in WGSL

cc @TheBlek fyi