### PR TITLE
Add a GPU BVH (bvh2) builder

### DIFF
--- a/example/webgpu_explodingMesh.html
+++ b/example/webgpu_explodingMesh.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+
+	<head>
+
+		<meta charset="UTF-8"/>
+		<link rel="shortcut icon" href="#">
+		<title>three-mesh-bvh - WebGPU Exploding Mesh</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+		<style type="text/css">
+			html, body {
+				padding: 0;
+				margin: 0;
+				overflow: hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0;
+				width: 100%;
+				color: #fff;
+				font-family: monospace;
+				text-align: center;
+				padding: 5px 0;
+				background: rgba(0,0,0,0.5);
+			}
+
+			#output {
+				position: absolute;
+				bottom: 10px;
+				left: 10px;
+				color: #fff;
+				font-family: monospace;
+				font-size: 13px;
+				background: rgba(0,0,0,0.7);
+				padding: 10px;
+				border-radius: 4px;
+				white-space: pre;
+			}
+		</style>
+
+	</head>
+
+	<body>
+
+		<div id="info">WebGPU Exploding Mesh - GPU BVH rebuilt every frame</div>
+		<div id="output">Initializing...</div>
+
+		<script type="module" src="./webgpu_explodingMesh.js"></script>
+
+	</body>
+
+</html>

--- a/example/webgpu_explodingMesh.js
+++ b/example/webgpu_explodingMesh.js
@@ -1,0 +1,1402 @@
+import * as THREE from 'three';
+import { WebGPURenderer, StorageBufferAttribute, StorageTexture, MeshBasicNodeMaterial } from 'three/webgpu';
+import Stats from 'three/addons/libs/stats.module.js';
+import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
+import {
+	attribute, uniform, wgslFn, varyingProperty,
+	textureStore, texture, colorSpaceToWorking,
+	storage, workgroupId, localId,
+	wgsl,
+} from 'three/tsl';
+
+// three-mesh-bvh
+import { GPUMeshBVH, SorterType } from 'three-mesh-bvh/src/gpu/index.js';
+import { ndcToCameraRay, bvh2IntersectFirstHit, getVertexAttribute } from 'three-mesh-bvh/webgpu';
+
+// ─── Parameters ───
+
+const BVH_UPDATE_MODES = {
+	REBUILD: 'Full BVH rebuild',
+	REFIT: 'BVH refit',
+};
+
+const params = {
+	pause: false,
+	bvhUpdateMode: BVH_UPDATE_MODES.REBUILD,
+	resolutionScale: 0.5,
+	smoothNormals: true,
+	floorY: - 1.5,
+	samples: 1,
+	explosionForce: 8,
+	gravity: 9.8,
+	bounce: 0.4,
+	chunkCount: 30,
+};
+
+// ─── Globals ───
+
+let renderer, camera, scene, gui, stats, clock, controls;
+let outputContainer;
+
+// GPU BVH
+let gpuBVH = null;
+let device = null;
+
+// Path tracing
+let fsQuad, fsMaterial, computeKernel, outputTex;
+let dispatchSize = [];
+const WORKGROUP_SIZE = [ 8, 8, 1 ];
+
+// Geometry
+let totalVertexCount = 0;
+let triCount = 0;
+let indexArray = null;
+let transformedPositions = null;
+let transformedNormals = null;
+
+// GPU transform buffers
+let gpuTransformKernel = null;
+let transformBuffers = null;
+
+// TSL storage buffers
+let geom_index, geom_position, geom_normals, geom_chunkIds, bvh2Nodes, rootIndexBuffer;
+let computeShaderParams = null;
+
+// Timing
+let avgBvhUpdateTime = 0;
+let avgTransformTime = 0;
+let frameCount = 0;
+let buildInProgress = false;
+let bvhBufferCapacity = 0;
+let bvhUpdateGeometry = null;
+
+// Voronoi chunks
+let chunkIds = null; // Uint32Array[totalVertexCount]
+let chunkCenters = []; // THREE.Vector3[]
+let chunkCount = 0;
+
+// Physics state
+let chunkOffsets = []; // THREE.Vector3[]
+let chunkVelocities = []; // THREE.Vector3[]
+let chunkRotations = []; // THREE.Quaternion[]
+let chunkAngularVelocities = []; // THREE.Vector3[]
+let exploded = false;
+let chunkMatricesArray = null; // Float32Array for GPU upload
+
+init();
+
+// ─── Create & Expand Geometry ───
+
+function createTorusKnotGeometry() {
+
+	const srcGeom = new THREE.TorusKnotGeometry( 1, 0.3, 400, 64 );
+
+	// Shift up so bottom sits on floor at y=0 (before expansion so both match)
+	srcGeom.computeBoundingBox();
+	const bottomY = srcGeom.boundingBox.min.y;
+	srcGeom.translate( 0, - bottomY, 0 );
+
+	const posAttr = srcGeom.attributes.position;
+	const normalAttr = srcGeom.attributes.normal;
+	const indexAttr = srcGeom.index;
+
+	const expandedCount = indexAttr.count;
+	const positions = new Float32Array( expandedCount * 3 );
+	const normals = new Float32Array( expandedCount * 3 );
+
+	for ( let i = 0; i < expandedCount; i ++ ) {
+
+		const idx = indexAttr.array[ i ];
+		positions[ i * 3 + 0 ] = posAttr.getX( idx );
+		positions[ i * 3 + 1 ] = posAttr.getY( idx );
+		positions[ i * 3 + 2 ] = posAttr.getZ( idx );
+		normals[ i * 3 + 0 ] = normalAttr.getX( idx );
+		normals[ i * 3 + 1 ] = normalAttr.getY( idx );
+		normals[ i * 3 + 2 ] = normalAttr.getZ( idx );
+
+	}
+
+	const geom = new THREE.BufferGeometry();
+	geom.setAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
+	geom.setAttribute( 'normal', new THREE.BufferAttribute( normals, 3 ) );
+
+	const indices = new Uint32Array( expandedCount );
+	for ( let i = 0; i < expandedCount; i ++ ) {
+
+		indices[ i ] = i;
+
+	}
+
+	geom.setIndex( new THREE.BufferAttribute( indices, 1 ) );
+
+	return { expanded: geom, original: srcGeom };
+
+}
+
+// ─── Voronoi Pre-Fracture ───
+
+function voronoiFracture( geometry, N ) {
+
+	const posAttr = geometry.attributes.position;
+	const vertexCount = posAttr.count;
+	const triCountLocal = vertexCount / 3;
+
+	// Pick N random triangle centroids as seed points
+	const seeds = [];
+	const usedTriangles = new Set();
+	for ( let i = 0; i < N; i ++ ) {
+
+		let triIdx;
+		do {
+
+			triIdx = Math.floor( Math.random() * triCountLocal );
+
+		} while ( usedTriangles.has( triIdx ) && usedTriangles.size < triCountLocal );
+
+		usedTriangles.add( triIdx );
+
+		const v0 = triIdx * 3;
+		const cx = ( posAttr.getX( v0 ) + posAttr.getX( v0 + 1 ) + posAttr.getX( v0 + 2 ) ) / 3;
+		const cy = ( posAttr.getY( v0 ) + posAttr.getY( v0 + 1 ) + posAttr.getY( v0 + 2 ) ) / 3;
+		const cz = ( posAttr.getZ( v0 ) + posAttr.getZ( v0 + 1 ) + posAttr.getZ( v0 + 2 ) ) / 3;
+		seeds.push( new THREE.Vector3( cx, cy, cz ) );
+
+	}
+
+	// Assign each triangle to nearest seed
+	const ids = new Uint32Array( vertexCount );
+	const centersAccum = [];
+	const centersCounts = [];
+	for ( let i = 0; i < N; i ++ ) {
+
+		centersAccum.push( new THREE.Vector3() );
+		centersCounts.push( 0 );
+
+	}
+
+	for ( let t = 0; t < triCountLocal; t ++ ) {
+
+		const v0 = t * 3;
+		const cx = ( posAttr.getX( v0 ) + posAttr.getX( v0 + 1 ) + posAttr.getX( v0 + 2 ) ) / 3;
+		const cy = ( posAttr.getY( v0 ) + posAttr.getY( v0 + 1 ) + posAttr.getY( v0 + 2 ) ) / 3;
+		const cz = ( posAttr.getZ( v0 ) + posAttr.getZ( v0 + 1 ) + posAttr.getZ( v0 + 2 ) ) / 3;
+
+		let bestDist = Infinity;
+		let bestId = 0;
+		for ( let s = 0; s < N; s ++ ) {
+
+			const dx = cx - seeds[ s ].x;
+			const dy = cy - seeds[ s ].y;
+			const dz = cz - seeds[ s ].z;
+			const d = dx * dx + dy * dy + dz * dz;
+			if ( d < bestDist ) {
+
+				bestDist = d;
+				bestId = s;
+
+			}
+
+		}
+
+		// All 3 vertices of this triangle get the same chunkId
+		ids[ v0 ] = bestId;
+		ids[ v0 + 1 ] = bestId;
+		ids[ v0 + 2 ] = bestId;
+
+		centersAccum[ bestId ].x += cx;
+		centersAccum[ bestId ].y += cy;
+		centersAccum[ bestId ].z += cz;
+		centersCounts[ bestId ] ++;
+
+	}
+
+	// Compute per-chunk center of mass
+	const centers = [];
+	for ( let i = 0; i < N; i ++ ) {
+
+		if ( centersCounts[ i ] > 0 ) {
+
+			centers.push( centersAccum[ i ].divideScalar( centersCounts[ i ] ) );
+
+		} else {
+
+			centers.push( seeds[ i ].clone() );
+
+		}
+
+	}
+
+	return { chunkIds: ids, chunkCenters: centers };
+
+}
+
+// ─── Solidify Chunks ───
+
+function solidifyChunks( expandedGeom, originalGeom, chunkIdsArr, chunkCentersArr, thickness ) {
+
+	const origPos = originalGeom.attributes.position;
+	const origNorm = originalGeom.attributes.normal;
+	const origIndex = originalGeom.index.array;
+	const origTriCount = origIndex.length / 3;
+
+	const expPos = expandedGeom.attributes.position;
+	const expNorm = expandedGeom.attributes.normal;
+	const expVertCount = expPos.count;
+	const expTriCount = expVertCount / 3;
+
+	// Build edge adjacency from original indexed geometry
+	const edgeMap = new Map();
+	for ( let t = 0; t < origTriCount; t ++ ) {
+
+		const i0 = origIndex[ t * 3 ];
+		const i1 = origIndex[ t * 3 + 1 ];
+		const i2 = origIndex[ t * 3 + 2 ];
+		const edges = [[ i0, i1 ], [ i1, i2 ], [ i2, i0 ]];
+		for ( const [ a, b ] of edges ) {
+
+			const key = Math.min( a, b ) + ',' + Math.max( a, b );
+			if ( ! edgeMap.has( key ) ) edgeMap.set( key, [] );
+			edgeMap.get( key ).push( t );
+
+		}
+
+	}
+
+	// Find boundary edges (where adjacent triangles belong to different chunks)
+	const boundaryEdges = [];
+	for ( const [ key, tris ] of edgeMap ) {
+
+		if ( tris.length !== 2 ) continue;
+		const c0 = chunkIdsArr[ tris[ 0 ] * 3 ];
+		const c1 = chunkIdsArr[ tris[ 1 ] * 3 ];
+		if ( c0 === c1 ) continue;
+
+		const parts = key.split( ',' );
+		boundaryEdges.push( {
+			v0: Number( parts[ 0 ] ),
+			v1: Number( parts[ 1 ] ),
+			chunk0: c0,
+			chunk1: c1
+		} );
+
+	}
+
+	// Count geometry: outer + inner faces + 4 wall tris per boundary edge
+	const wallTriTotal = boundaryEdges.length * 4;
+	const totalNewVerts = ( expTriCount * 2 + wallTriTotal ) * 3;
+
+	const newPositions = new Float32Array( totalNewVerts * 3 );
+	const newNormals = new Float32Array( totalNewVerts * 3 );
+	const newChunkIds = new Uint32Array( totalNewVerts );
+
+	let vOff = 0;
+
+	function addVertex( px, py, pz, nx, ny, nz, cid ) {
+
+		newPositions[ vOff * 3 ] = px;
+		newPositions[ vOff * 3 + 1 ] = py;
+		newPositions[ vOff * 3 + 2 ] = pz;
+		newNormals[ vOff * 3 ] = nx;
+		newNormals[ vOff * 3 + 1 ] = ny;
+		newNormals[ vOff * 3 + 2 ] = nz;
+		newChunkIds[ vOff ] = cid;
+		vOff ++;
+
+	}
+
+	// 1. Outer face (copy expanded geometry as-is)
+	for ( let i = 0; i < expVertCount; i ++ ) {
+
+		addVertex(
+			expPos.getX( i ), expPos.getY( i ), expPos.getZ( i ),
+			expNorm.getX( i ), expNorm.getY( i ), expNorm.getZ( i ),
+			chunkIdsArr[ i ]
+		);
+
+	}
+
+	// 2. Inner face (reversed winding, offset inward along normal)
+	for ( let t = 0; t < expTriCount; t ++ ) {
+
+		const v0 = t * 3;
+		const v1 = t * 3 + 1;
+		const v2 = t * 3 + 2;
+		const cid = chunkIdsArr[ v0 ];
+
+		// Reversed order: v0, v2, v1
+		for ( const vi of [ v0, v2, v1 ] ) {
+
+			addVertex(
+				expPos.getX( vi ) - expNorm.getX( vi ) * thickness,
+				expPos.getY( vi ) - expNorm.getY( vi ) * thickness,
+				expPos.getZ( vi ) - expNorm.getZ( vi ) * thickness,
+				- expNorm.getX( vi ),
+				- expNorm.getY( vi ),
+				- expNorm.getZ( vi ),
+				cid
+			);
+
+		}
+
+	}
+
+	// 3. Wall quads at boundary edges
+	for ( const edge of boundaryEdges ) {
+
+		const { v0, v1, chunk0, chunk1 } = edge;
+
+		// Outer and inner positions for the two edge vertices
+		const p0 = [ origPos.getX( v0 ), origPos.getY( v0 ), origPos.getZ( v0 ) ];
+		const n0 = [ origNorm.getX( v0 ), origNorm.getY( v0 ), origNorm.getZ( v0 ) ];
+		const p1 = [ origPos.getX( v1 ), origPos.getY( v1 ), origPos.getZ( v1 ) ];
+		const n1 = [ origNorm.getX( v1 ), origNorm.getY( v1 ), origNorm.getZ( v1 ) ];
+
+		const p0i = [ p0[ 0 ] - n0[ 0 ] * thickness, p0[ 1 ] - n0[ 1 ] * thickness, p0[ 2 ] - n0[ 2 ] * thickness ];
+		const p1i = [ p1[ 0 ] - n1[ 0 ] * thickness, p1[ 1 ] - n1[ 1 ] * thickness, p1[ 2 ] - n1[ 2 ] * thickness ];
+
+		// Compute wall normal from edge direction x thickness direction
+		const ex = p1[ 0 ] - p0[ 0 ], ey = p1[ 1 ] - p0[ 1 ], ez = p1[ 2 ] - p0[ 2 ];
+		const tx = ( n0[ 0 ] + n1[ 0 ] ) * 0.5;
+		const ty = ( n0[ 1 ] + n1[ 1 ] ) * 0.5;
+		const tz = ( n0[ 2 ] + n1[ 2 ] ) * 0.5;
+		let wnx = ey * tz - ez * ty;
+		let wny = ez * tx - ex * tz;
+		let wnz = ex * ty - ey * tx;
+		const wLen = Math.sqrt( wnx * wnx + wny * wny + wnz * wnz );
+		if ( wLen > 0.001 ) {
+
+			wnx /= wLen; wny /= wLen; wnz /= wLen;
+
+		}
+
+		// Ensure wall normal for chunk0 points toward chunk1
+		const c0 = chunkCentersArr[ chunk0 ];
+		const c1 = chunkCentersArr[ chunk1 ];
+		const dot = wnx * ( c1.x - c0.x ) + wny * ( c1.y - c0.y ) + wnz * ( c1.z - c0.z );
+		if ( dot < 0 ) {
+
+			wnx = - wnx; wny = - wny; wnz = - wnz;
+
+		}
+
+		// Wall for chunk0 (normal points outward from chunk0)
+		addVertex( p0[ 0 ], p0[ 1 ], p0[ 2 ], wnx, wny, wnz, chunk0 );
+		addVertex( p1[ 0 ], p1[ 1 ], p1[ 2 ], wnx, wny, wnz, chunk0 );
+		addVertex( p1i[ 0 ], p1i[ 1 ], p1i[ 2 ], wnx, wny, wnz, chunk0 );
+
+		addVertex( p0[ 0 ], p0[ 1 ], p0[ 2 ], wnx, wny, wnz, chunk0 );
+		addVertex( p1i[ 0 ], p1i[ 1 ], p1i[ 2 ], wnx, wny, wnz, chunk0 );
+		addVertex( p0i[ 0 ], p0i[ 1 ], p0i[ 2 ], wnx, wny, wnz, chunk0 );
+
+		// Wall for chunk1 (opposite normal, reversed winding)
+		addVertex( p1[ 0 ], p1[ 1 ], p1[ 2 ], - wnx, - wny, - wnz, chunk1 );
+		addVertex( p0[ 0 ], p0[ 1 ], p0[ 2 ], - wnx, - wny, - wnz, chunk1 );
+		addVertex( p0i[ 0 ], p0i[ 1 ], p0i[ 2 ], - wnx, - wny, - wnz, chunk1 );
+
+		addVertex( p1[ 0 ], p1[ 1 ], p1[ 2 ], - wnx, - wny, - wnz, chunk1 );
+		addVertex( p0i[ 0 ], p0i[ 1 ], p0i[ 2 ], - wnx, - wny, - wnz, chunk1 );
+		addVertex( p1i[ 0 ], p1i[ 1 ], p1i[ 2 ], - wnx, - wny, - wnz, chunk1 );
+
+	}
+
+	// Build final geometry
+	const finalPositions = newPositions.slice( 0, vOff * 3 );
+	const finalNormals = newNormals.slice( 0, vOff * 3 );
+	const finalChunkIds = newChunkIds.slice( 0, vOff );
+
+	const finalGeom = new THREE.BufferGeometry();
+	finalGeom.setAttribute( 'position', new THREE.BufferAttribute( finalPositions, 3 ) );
+	finalGeom.setAttribute( 'normal', new THREE.BufferAttribute( finalNormals, 3 ) );
+
+	const finalIndices = new Uint32Array( vOff );
+	for ( let i = 0; i < vOff; i ++ ) finalIndices[ i ] = i;
+	finalGeom.setIndex( new THREE.BufferAttribute( finalIndices, 1 ) );
+
+	return { geometry: finalGeom, chunkIds: finalChunkIds };
+
+}
+
+// ─── Physics ───
+
+function initPhysics( N ) {
+
+	chunkOffsets = [];
+	chunkVelocities = [];
+	chunkRotations = [];
+	chunkAngularVelocities = [];
+
+	for ( let i = 0; i < N; i ++ ) {
+
+		chunkOffsets.push( new THREE.Vector3() );
+		chunkVelocities.push( new THREE.Vector3() );
+		chunkRotations.push( new THREE.Quaternion() );
+		chunkAngularVelocities.push( new THREE.Vector3() );
+
+	}
+
+	exploded = false;
+
+}
+
+function triggerExplosion() {
+
+	const force = params.explosionForce;
+
+	// Compute mesh center (average of chunk centers)
+	const meshCenter = new THREE.Vector3();
+	for ( let i = 0; i < chunkCount; i ++ ) {
+
+		meshCenter.add( chunkCenters[ i ] );
+
+	}
+
+	meshCenter.divideScalar( chunkCount );
+
+	for ( let i = 0; i < chunkCount; i ++ ) {
+
+		const dir = new THREE.Vector3().subVectors( chunkCenters[ i ], meshCenter );
+		const dist = dir.length();
+		if ( dist > 0.001 ) dir.normalize();
+		else dir.set( Math.random() - 0.5, Math.random() - 0.5, Math.random() - 0.5 ).normalize();
+
+		// Outward velocity + upward bias + random perturbation
+		chunkVelocities[ i ].copy( dir ).multiplyScalar( force * ( 0.5 + Math.random() * 0.5 ) );
+		chunkVelocities[ i ].y += force * 0.4 * ( 0.5 + Math.random() * 0.5 );
+		chunkVelocities[ i ].x += ( Math.random() - 0.5 ) * force * 0.3;
+		chunkVelocities[ i ].z += ( Math.random() - 0.5 ) * force * 0.3;
+
+		// Random angular velocity
+		chunkAngularVelocities[ i ].set(
+			( Math.random() - 0.5 ) * 10,
+			( Math.random() - 0.5 ) * 10,
+			( Math.random() - 0.5 ) * 10
+		);
+
+	}
+
+	exploded = true;
+
+}
+
+function resetExplosion() {
+
+	for ( let i = 0; i < chunkCount; i ++ ) {
+
+		chunkOffsets[ i ].set( 0, 0, 0 );
+		chunkVelocities[ i ].set( 0, 0, 0 );
+		chunkRotations[ i ].identity();
+		chunkAngularVelocities[ i ].set( 0, 0, 0 );
+
+	}
+
+	exploded = false;
+
+}
+
+function updatePhysics( dt ) {
+
+	if ( ! exploded ) return;
+
+	const gravity = params.gravity;
+	const restitution = params.bounce;
+	const friction = 0.98;
+	const floorY = params.floorY;
+	const _q = new THREE.Quaternion();
+	const _axis = new THREE.Vector3();
+
+	for ( let i = 0; i < chunkCount; i ++ ) {
+
+		// Semi-implicit Euler
+		chunkVelocities[ i ].y -= gravity * dt;
+		chunkOffsets[ i ].addScaledVector( chunkVelocities[ i ], dt );
+
+		// Ground collision: check if chunk center + offset is below floor
+		const worldY = chunkCenters[ i ].y + chunkOffsets[ i ].y;
+		if ( worldY < floorY ) {
+
+			chunkOffsets[ i ].y = floorY - chunkCenters[ i ].y;
+			chunkVelocities[ i ].y = - chunkVelocities[ i ].y * restitution;
+			chunkVelocities[ i ].x *= friction;
+			chunkVelocities[ i ].z *= friction;
+			chunkAngularVelocities[ i ].multiplyScalar( 0.9 );
+
+		}
+
+		// Rotation via angular velocity
+		const angSpeed = chunkAngularVelocities[ i ].length();
+		if ( angSpeed > 0.001 ) {
+
+			_axis.copy( chunkAngularVelocities[ i ] ).normalize();
+			_q.setFromAxisAngle( _axis, angSpeed * dt );
+			chunkRotations[ i ].premultiply( _q );
+			chunkRotations[ i ].normalize();
+
+		}
+
+	}
+
+}
+
+function computeChunkMatrices() {
+
+	// Matrix per chunk: Translate(center + offset) * Rotate(rotation) * Translate(-center)
+	const _mat = new THREE.Matrix4();
+	const _rotMat = new THREE.Matrix4();
+	const _negCenter = new THREE.Matrix4();
+
+	for ( let i = 0; i < chunkCount; i ++ ) {
+
+		const center = chunkCenters[ i ];
+		const offset = chunkOffsets[ i ];
+		const rotation = chunkRotations[ i ];
+
+		_rotMat.makeRotationFromQuaternion( rotation );
+		_negCenter.makeTranslation( - center.x, - center.y, - center.z );
+
+		// T(center + offset) * R * T(-center)
+		_mat.makeTranslation(
+			center.x + offset.x,
+			center.y + offset.y,
+			center.z + offset.z
+		);
+		_mat.multiply( _rotMat );
+		_mat.multiply( _negCenter );
+
+		// Write to flat array (column-major, as GPU expects)
+		_mat.toArray( chunkMatricesArray, i * 16 );
+
+	}
+
+}
+
+// ─── Init ───
+
+async function init() {
+
+	outputContainer = document.getElementById( 'output' );
+	outputContainer.textContent = 'Initializing WebGPU...';
+
+	const adapter = await navigator.gpu.requestAdapter();
+	if ( ! adapter ) {
+
+		outputContainer.textContent = 'WebGPU not supported';
+		return;
+
+	}
+
+	const requiredFeatures = [];
+	if ( adapter.features.has( 'timestamp-query' ) ) {
+
+		requiredFeatures.push( 'timestamp-query' );
+
+	}
+
+	if ( adapter.features.has( 'subgroups' ) ) {
+
+		requiredFeatures.push( 'subgroups' );
+
+	}
+
+	device = await adapter.requestDevice( {
+		requiredFeatures,
+		requiredLimits: {
+			maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize,
+			maxStorageBuffersPerShaderStage: 10,
+		},
+	} );
+
+	// Renderer
+	renderer = new WebGPURenderer( {
+		canvas: document.createElement( 'canvas' ),
+		antialias: true,
+		forceWebGL: false,
+		device: device,
+	} );
+
+	if ( renderer.init ) {
+
+		await renderer.init();
+
+	}
+
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setClearColor( 0x111111 );
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.outputColorSpace = THREE.SRGBColorSpace;
+	document.body.appendChild( renderer.domElement );
+
+	// Scene
+	scene = new THREE.Scene();
+	const light = new THREE.DirectionalLight( 0xffffff, 3 );
+	light.position.set( 5, 5, 2.5 );
+	scene.add( light );
+	scene.add( new THREE.AmbientLight( 0xb0bec5, 2.4 ) );
+
+	// Camera
+	camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 100 );
+	camera.position.set( 0, 2.0, 4 );
+	camera.updateProjectionMatrix();
+
+	controls = new OrbitControls( camera, renderer.domElement );
+	controls.target.set( 0, 1.0, 0 );
+	controls.update();
+
+	clock = new THREE.Clock();
+
+	// Stats
+	stats = new Stats();
+	document.body.appendChild( stats.dom );
+
+	// GPU BVH builder
+	const sorterType = requiredFeatures.includes( 'subgroups' ) ? SorterType.ONESWEEP : SorterType.BUILTIN;
+	gpuBVH = new GPUMeshBVH( device, { sorterType } );
+
+	outputContainer.textContent = 'Creating geometry...';
+
+	const { expanded, original } = createTorusKnotGeometry();
+	await initializeWithGeometry( expanded, original );
+
+	window.addEventListener( 'resize', resize );
+
+}
+
+async function initializeWithGeometry( geometry, originalGeometry ) {
+
+	// Voronoi fracture on the surface geometry
+	chunkCount = params.chunkCount;
+	const fracture = voronoiFracture( geometry, chunkCount );
+
+	// Solidify: add inner faces + wall quads at chunk boundaries
+	const THICKNESS = 0.06;
+	const solidified = solidifyChunks(
+		geometry, originalGeometry,
+		fracture.chunkIds, fracture.chunkCenters,
+		THICKNESS
+	);
+
+	// Use solidified geometry from here on
+	const solidGeom = solidified.geometry;
+	chunkIds = solidified.chunkIds;
+	chunkCenters = fracture.chunkCenters;
+
+	const posAttr = solidGeom.attributes.position;
+	const normalAttr = solidGeom.attributes.normal;
+	totalVertexCount = posAttr.count;
+	triCount = totalVertexCount / 3;
+
+	console.log( `Total vertices: ${totalVertexCount}, triangles: ${triCount} (after solidify)` );
+
+	// Initialize physics
+	initPhysics( chunkCount );
+	chunkMatricesArray = new Float32Array( chunkCount * 16 );
+	// Set identity matrices initially
+	for ( let i = 0; i < chunkCount; i ++ ) {
+
+		new THREE.Matrix4().toArray( chunkMatricesArray, i * 16 );
+
+	}
+
+	// Prepare GPU buffers (vec4 layout for WGSL alignment)
+	const srcPositions4 = new Float32Array( totalVertexCount * 4 );
+	const srcNormals4 = new Float32Array( totalVertexCount * 4 );
+	for ( let i = 0; i < totalVertexCount; i ++ ) {
+
+		srcPositions4[ i * 4 + 0 ] = posAttr.getX( i );
+		srcPositions4[ i * 4 + 1 ] = posAttr.getY( i );
+		srcPositions4[ i * 4 + 2 ] = posAttr.getZ( i );
+		srcPositions4[ i * 4 + 3 ] = 1.0;
+
+		srcNormals4[ i * 4 + 0 ] = normalAttr.getX( i );
+		srcNormals4[ i * 4 + 1 ] = normalAttr.getY( i );
+		srcNormals4[ i * 4 + 2 ] = normalAttr.getZ( i );
+		srcNormals4[ i * 4 + 3 ] = 0.0;
+
+	}
+
+	const dstPositions4 = new Float32Array( totalVertexCount * 4 );
+	const dstNormals4 = new Float32Array( totalVertexCount * 4 );
+
+	transformBuffers = {
+		srcPositions: new StorageBufferAttribute( srcPositions4, 4 ),
+		srcNormals: new StorageBufferAttribute( srcNormals4, 4 ),
+		chunkIds: new StorageBufferAttribute( chunkIds, 1 ),
+		chunkMatrices: new StorageBufferAttribute( chunkMatricesArray, 16 ),
+		dstPositions: new StorageBufferAttribute( dstPositions4, 4 ),
+		dstNormals: new StorageBufferAttribute( dstNormals4, 4 ),
+	};
+
+	// Sequential index
+	indexArray = new Uint32Array( totalVertexCount );
+	for ( let i = 0; i < totalVertexCount; i ++ ) {
+
+		indexArray[ i ] = i;
+
+	}
+
+	// Setup GPU transform compute
+	await setupGPUTransform();
+
+	// Run initial transform (identity)
+	computeChunkMatrices();
+	transformBuffers.chunkMatrices.array.set( chunkMatricesArray );
+	transformBuffers.chunkMatrices.needsUpdate = true;
+	await runGPUTransform();
+
+	// Allocate CPU readback arrays
+	transformedPositions = new Float32Array( totalVertexCount * 3 );
+	transformedNormals = new Float32Array( totalVertexCount * 3 );
+
+	// Readback initial positions
+	await readbackTransformed();
+
+	// Build initial BVH
+	bvhUpdateGeometry = new THREE.BufferGeometry();
+	bvhUpdateGeometry.setAttribute( 'position', new THREE.BufferAttribute( transformedPositions, 3 ) );
+	bvhUpdateGeometry.setAttribute( 'normal', new THREE.BufferAttribute( transformedNormals, 3 ) );
+	bvhUpdateGeometry.setIndex( new THREE.BufferAttribute( indexArray, 1 ) );
+
+	outputContainer.textContent = `Warming up GPU BVH (${triCount} tris)...`;
+	await gpuBVH.build( bvhUpdateGeometry );
+
+	// Setup path tracing
+	await setupPathTracing();
+
+	// GUI
+	setupGUI();
+
+	// Start render loop
+	renderer.setAnimationLoop( render );
+
+}
+
+// ─── GPU Transform Compute ───
+
+async function setupGPUTransform() {
+
+	const TRANSFORM_WORKGROUP_SIZE = 256;
+
+	const transformShader = wgslFn( /* wgsl */`
+		fn compute(
+			srcPositions: ptr<storage, array<vec4f>, read>,
+			srcNormals: ptr<storage, array<vec4f>, read>,
+			chunkIds: ptr<storage, array<u32>, read>,
+			chunkMatrices: ptr<storage, array<mat4x4f>, read>,
+			vertexCount: u32,
+			dstPositions: ptr<storage, array<vec4f>, read_write>,
+			dstNormals: ptr<storage, array<vec4f>, read_write>,
+			workgroupId: vec3u,
+			localId: vec3u,
+		) -> void {
+			let globalId = workgroupId.x * 256u + localId.x;
+			if ( globalId >= vertexCount ) {
+				return;
+			}
+
+			let mat = chunkMatrices[chunkIds[globalId]];
+			let srcPos = srcPositions[globalId];
+			let srcNorm = srcNormals[globalId];
+
+			dstPositions[globalId] = mat * srcPos;
+			dstNormals[globalId] = vec4f( normalize( ( mat * vec4f( srcNorm.xyz, 0.0 ) ).xyz ), 0.0 );
+		}
+	` );
+
+	const transformParams = {
+		srcPositions: storage( transformBuffers.srcPositions, 'vec4f', totalVertexCount ).toReadOnly(),
+		srcNormals: storage( transformBuffers.srcNormals, 'vec4f', totalVertexCount ).toReadOnly(),
+		chunkIds: storage( transformBuffers.chunkIds, 'u32', totalVertexCount ).toReadOnly(),
+		chunkMatrices: storage( transformBuffers.chunkMatrices, 'mat4x4f', chunkCount ).toReadOnly(),
+		vertexCount: uniform( totalVertexCount ),
+		dstPositions: storage( transformBuffers.dstPositions, 'vec4f', totalVertexCount ),
+		dstNormals: storage( transformBuffers.dstNormals, 'vec4f', totalVertexCount ),
+		workgroupId: workgroupId,
+		localId: localId,
+	};
+
+	transformBuffers.params = transformParams;
+
+	gpuTransformKernel = transformShader( transformParams ).computeKernel( [ TRANSFORM_WORKGROUP_SIZE, 1, 1 ] );
+
+}
+
+async function runGPUTransform() {
+
+	const workgroupCount = Math.ceil( totalVertexCount / 256 );
+	renderer.compute( gpuTransformKernel, [ workgroupCount, 1, 1 ] );
+
+}
+
+async function readbackTransformed() {
+
+	const backend = renderer.backend;
+	const dstPosBuf = backend.get( transformBuffers.dstPositions );
+	const dstNormBuf = backend.get( transformBuffers.dstNormals );
+
+	if ( ! dstPosBuf || ! dstPosBuf.buffer || ! dstNormBuf || ! dstNormBuf.buffer ) {
+
+		console.warn( 'GPU transform buffers not ready' );
+		return;
+
+	}
+
+	const byteSize = totalVertexCount * 16;
+	const posReadBuffer = device.createBuffer( {
+		size: byteSize,
+		usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+	} );
+	const normReadBuffer = device.createBuffer( {
+		size: byteSize,
+		usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+	} );
+
+	const commandEncoder = device.createCommandEncoder();
+	commandEncoder.copyBufferToBuffer( dstPosBuf.buffer, 0, posReadBuffer, 0, byteSize );
+	commandEncoder.copyBufferToBuffer( dstNormBuf.buffer, 0, normReadBuffer, 0, byteSize );
+	device.queue.submit( [ commandEncoder.finish() ] );
+
+	await posReadBuffer.mapAsync( GPUMapMode.READ );
+	await normReadBuffer.mapAsync( GPUMapMode.READ );
+
+	const posData = new Float32Array( posReadBuffer.getMappedRange() );
+	const normData = new Float32Array( normReadBuffer.getMappedRange() );
+
+	for ( let i = 0; i < totalVertexCount; i ++ ) {
+
+		transformedPositions[ i * 3 + 0 ] = posData[ i * 4 + 0 ];
+		transformedPositions[ i * 3 + 1 ] = posData[ i * 4 + 1 ];
+		transformedPositions[ i * 3 + 2 ] = posData[ i * 4 + 2 ];
+		transformedNormals[ i * 3 + 0 ] = normData[ i * 4 + 0 ];
+		transformedNormals[ i * 3 + 1 ] = normData[ i * 4 + 1 ];
+		transformedNormals[ i * 3 + 2 ] = normData[ i * 4 + 2 ];
+
+	}
+
+	posReadBuffer.unmap();
+	normReadBuffer.unmap();
+	posReadBuffer.destroy();
+	normReadBuffer.destroy();
+
+}
+
+// ─── Path Tracing Setup ───
+
+async function setupPathTracing() {
+
+	geom_index = new StorageBufferAttribute( indexArray, 3 );
+	geom_position = new StorageBufferAttribute( transformedPositions, 3 );
+	geom_normals = new StorageBufferAttribute( transformedNormals, 3 );
+	geom_chunkIds = new StorageBufferAttribute( chunkIds, 1 );
+
+	bvhBufferCapacity = gpuBVH.maxNodeCount;
+	const bvh2Array = new Float32Array( bvhBufferCapacity * 8 );
+	bvh2Nodes = new StorageBufferAttribute( bvh2Array, 8 );
+
+	rootIndexBuffer = new StorageBufferAttribute( new Uint32Array( [ 0 ] ), 1 );
+
+	computeShaderParams = {
+		outputTex: textureStore( outputTex ),
+		smoothNormals: uniform( 1 ),
+		inverseProjectionMatrix: uniform( new THREE.Matrix4() ),
+		cameraToWorldMatrix: uniform( new THREE.Matrix4() ),
+		floorY: uniform( params.floorY ),
+		time: uniform( 0.0 ),
+		frameCount: uniform( 0 ),
+		samples: uniform( 1 ),
+		geom_index: storage( geom_index, 'uvec3', geom_index.count ).toReadOnly(),
+		geom_position: storage( geom_position, 'vec3', geom_position.count ).toReadOnly(),
+		geom_normals: storage( geom_normals, 'vec3', geom_normals.count ).toReadOnly(),
+		geom_chunkIds: storage( geom_chunkIds, 'u32', geom_chunkIds.count ).toReadOnly(),
+		bvh: storage( bvh2Nodes, 'BVH2Node', bvhBufferCapacity ).toReadOnly(),
+		rootIndexBuf: storage( rootIndexBuffer, 'u32', 1 ).toReadOnly(),
+		workgroupSize: uniform( new THREE.Vector3() ),
+		workgroupId: workgroupId,
+		localId: localId
+	};
+
+	const utils = wgsl( /* wgsl */ `
+		fn hash( seed: u32 ) -> u32 {
+			var s = seed;
+			s = s ^ ( s >> 16u );
+			s = s * 0x85ebca6bu;
+			s = s ^ ( s >> 13u );
+			s = s * 0xc2b2ae35u;
+			s = s ^ ( s >> 16u );
+			return s;
+		}
+
+		fn randomFloat( seed: ptr<function, u32> ) -> f32 {
+			*seed = hash( *seed );
+			return f32( *seed ) / f32( 0xffffffffu );
+		}
+
+		fn cosineSampleHemisphere( normal: vec3f, seed: ptr<function, u32> ) -> vec3f {
+			let r1 = randomFloat( seed );
+			let r2 = randomFloat( seed );
+			let phi = 2.0 * 3.14159265 * r1;
+			let cosTheta = sqrt( r2 );
+			let sinTheta = sqrt( 1.0 - r2 );
+
+			var tangent: vec3f;
+			if ( abs( normal.x ) > 0.9 ) {
+				tangent = normalize( cross( normal, vec3f( 0.0, 1.0, 0.0 ) ) );
+			} else {
+				tangent = normalize( cross( normal, vec3f( 1.0, 0.0, 0.0 ) ) );
+			}
+			let bitangent = cross( normal, tangent );
+
+			return normalize(
+				tangent * cos( phi ) * sinTheta +
+				bitangent * sin( phi ) * sinTheta +
+				normal * cosTheta
+			);
+		}
+
+		// Generate a vivid color from a chunk ID
+		fn chunkColor( id: u32 ) -> vec3f {
+			let h0 = hash( id * 7u + 13u );
+			let h1 = hash( h0 );
+			let h2 = hash( h1 );
+			// HSV-like: high saturation, high value
+			let hue = f32( h0 & 0xffffu ) / 65535.0;
+			let sat = 0.6 + f32( h1 & 0xffffu ) / 65535.0 * 0.4;
+			let val = 0.7 + f32( h2 & 0xffffu ) / 65535.0 * 0.3;
+			// HSV to RGB
+			let h = hue * 6.0;
+			let c = val * sat;
+			let x = c * ( 1.0 - abs( h % 2.0 - 1.0 ) );
+			let m = val - c;
+			var rgb = vec3f( m );
+			let hi = u32( floor( h ) ) % 6u;
+			if ( hi == 0u ) { rgb += vec3f( c, x, 0.0 ); }
+			else if ( hi == 1u ) { rgb += vec3f( x, c, 0.0 ); }
+			else if ( hi == 2u ) { rgb += vec3f( 0.0, c, x ); }
+			else if ( hi == 3u ) { rgb += vec3f( 0.0, x, c ); }
+			else if ( hi == 4u ) { rgb += vec3f( x, 0.0, c ); }
+			else { rgb += vec3f( c, 0.0, x ); }
+			return rgb;
+		}
+	` );
+
+	const computeShader = wgslFn( /* wgsl */`
+		fn compute(
+			outputTex: texture_storage_2d<rgba8unorm, write>,
+			smoothNormals: u32,
+			inverseProjectionMatrix: mat4x4f,
+			cameraToWorldMatrix: mat4x4f,
+			floorY: f32,
+			time: f32,
+			frameCount: u32,
+			samples: u32,
+			geom_position: ptr<storage, array<vec3f>, read>,
+			geom_index: ptr<storage, array<vec3u>, read>,
+			geom_normals: ptr<storage, array<vec3f>, read>,
+			geom_chunkIds: ptr<storage, array<u32>, read>,
+			bvh: ptr<storage, array<BVH2Node>, read>,
+			rootIndexBuf: ptr<storage, array<u32>, read>,
+			workgroupSize: vec3u,
+			workgroupId: vec3u,
+			localId: vec3u
+		) -> void {
+			let dimensions = textureDimensions( outputTex );
+			let indexUV = workgroupSize.xy * workgroupId.xy + localId.xy;
+			if ( indexUV.x >= dimensions.x || indexUV.y >= dimensions.y ) { return; }
+
+			let uv = vec2f( indexUV ) / vec2f( dimensions );
+			let ndc = uv * 2.0 - vec2f( 1.0 );
+			let rootIndex = rootIndexBuf[0];
+
+			var rngSeed = indexUV.x + indexUV.y * dimensions.x + frameCount * dimensions.x * dimensions.y;
+
+			// Lighting
+			let sunDir = normalize( vec3f( 0.5, 0.8, 0.3 ) );
+			let sunColor = vec3f( 1.4, 1.3, 1.1 );
+			let skyColor = vec3f( 0.4, 0.5, 0.7 );
+			let groundColor = vec3f( 0.2, 0.15, 0.1 );
+
+			var totalRadiance = vec3f( 0.0 );
+			let baseWorldRay = ndcToCameraRay( ndc, cameraToWorldMatrix * inverseProjectionMatrix );
+
+			for ( var sampleIdx = 0u; sampleIdx < samples; sampleIdx++ ) {
+				var throughput = vec3f( 1.0 );
+				var radiance = vec3f( 0.0 );
+				var worldRay = baseWorldRay;
+
+				let worldRayDirLen = length( worldRay.direction );
+				worldRay.direction = worldRay.direction / worldRayDirLen;
+
+				rngSeed = hash( rngSeed + sampleIdx * 12345u );
+
+				for ( var bounce = 0u; bounce < 4u; bounce++ ) {
+				var hitDist = 1e30f;
+				var hitNormal = vec3f( 0.0, 1.0, 0.0 );
+				var hitColor = vec3f( 0.5 );
+				var hitMetalness = 0.0;
+				var hitType = 0u; // 0=miss, 1=mesh, 2=floor
+
+				// === Test mesh (geometry already in world space) ===
+				let meshHit = bvh2IntersectFirstHit( geom_index, geom_position, bvh, worldRay, rootIndex );
+				if ( meshHit.didHit ) {
+					let meshDist = meshHit.dist;
+					if ( meshDist < hitDist && meshDist > 0.001 ) {
+						hitDist = meshDist;
+						var n = select(
+							meshHit.normal,
+							normalize( getVertexAttribute( meshHit.barycoord, meshHit.indices.xyz, geom_normals ) ),
+							smoothNormals > 0u
+						);
+						hitNormal = n;
+						// Per-chunk color from chunk ID of first vertex
+						let vertIdx = meshHit.indices.x;
+						let cid = geom_chunkIds[vertIdx];
+						hitColor = chunkColor( cid );
+						hitMetalness = 0.15;
+						hitType = 1u;
+					}
+				}
+
+				// === Test floor ===
+				if ( worldRay.direction.y < -0.0001 && worldRay.origin.y > floorY ) {
+					let floorDist = ( floorY - worldRay.origin.y ) / worldRay.direction.y;
+					if ( floorDist > 0.001 && floorDist < hitDist ) {
+						hitDist = floorDist;
+						hitNormal = vec3f( 0.0, 1.0, 0.0 );
+						let floorHitPoint = worldRay.origin + worldRay.direction * floorDist;
+						let cx = floor( floorHitPoint.x * 0.5 + 1000.0 );
+						let cz = floor( floorHitPoint.z * 0.5 + 1000.0 );
+						let checker = ( i32( cx ) + i32( cz ) ) % 2;
+						hitColor = select( vec3f( 0.3, 0.3, 0.32 ), vec3f( 0.5, 0.5, 0.52 ), checker == 1 );
+						hitType = 2u;
+					}
+				}
+
+				// === Process hit ===
+				if ( hitType == 0u ) {
+					let skyT = ( worldRay.direction.y + 1.0 ) * 0.5;
+					let envColor = mix( groundColor, skyColor, skyT );
+					let sunDot = max( 0.0, dot( worldRay.direction, sunDir ) );
+					let sun = sunColor * pow( sunDot, 128.0 ) * 2.0;
+					radiance += throughput * ( envColor + sun );
+					break;
+				}
+
+				let hitPoint = worldRay.origin + worldRay.direction * hitDist;
+
+				// Direct lighting with shadow ray (geometry is world-space)
+				var directLight = vec3f( 0.0 );
+				var shadowRay: Ray;
+				shadowRay.origin = hitPoint + hitNormal * 0.01;
+				shadowRay.direction = sunDir;
+				let shadowHit = bvh2IntersectFirstHit( geom_index, geom_position, bvh, shadowRay, rootIndex );
+
+				if ( !shadowHit.didHit ) {
+					let NdotL = max( 0.0, dot( hitNormal, sunDir ) );
+					directLight = sunColor * NdotL;
+				}
+
+				radiance += throughput * hitColor * directLight;
+
+				// Russian roulette after 2 bounces
+				if ( bounce > 1u ) {
+					let p = max( max( throughput.x, throughput.y ), throughput.z );
+					if ( randomFloat( &rngSeed ) > p ) {
+						break;
+					}
+					throughput /= p;
+				}
+
+				// Bounce
+				var bounceDir: vec3f;
+				if ( hitMetalness > 0.01 ) {
+					let reflectDir = reflect( worldRay.direction, hitNormal );
+					if ( randomFloat( &rngSeed ) < hitMetalness ) {
+						let roughness = 0.1;
+						let roughDir = cosineSampleHemisphere( reflectDir, &rngSeed );
+						bounceDir = normalize( mix( reflectDir, roughDir, roughness ) );
+						throughput *= hitColor;
+					} else {
+						bounceDir = cosineSampleHemisphere( hitNormal, &rngSeed );
+						throughput *= hitColor;
+					}
+				} else {
+					bounceDir = cosineSampleHemisphere( hitNormal, &rngSeed );
+					throughput *= hitColor;
+				}
+					worldRay.origin = hitPoint + hitNormal * 0.001;
+					worldRay.direction = bounceDir;
+				} // end bounce loop
+
+				totalRadiance += radiance;
+			} // end sample loop
+
+			var finalRadiance = totalRadiance / f32( samples );
+
+			// Tone mapping and gamma
+			finalRadiance = finalRadiance / ( finalRadiance + vec3f( 1.0 ) );
+			finalRadiance = pow( finalRadiance, vec3f( 1.0 / 2.2 ) );
+
+			textureStore( outputTex, indexUV, vec4f( finalRadiance, 1.0 ) );
+		}
+	`, [ ndcToCameraRay, bvh2IntersectFirstHit, getVertexAttribute, utils ] );
+
+	computeKernel = computeShader( computeShaderParams ).computeKernel( WORKGROUP_SIZE );
+
+	// Fullscreen quad for display
+	const vUv = varyingProperty( 'vec2', 'vUv' );
+	const vertexShader = wgslFn( /* wgsl */`
+		fn vertex( position: vec3f, uv: vec2f ) -> vec3f {
+			varyings.vUv = uv;
+			return position;
+		}
+	`, [ vUv ] );
+
+	fsMaterial = new MeshBasicNodeMaterial();
+	fsMaterial.positionNode = vertexShader( {
+		position: attribute( 'position' ),
+		uv: attribute( 'uv' )
+	} );
+	fsMaterial.colorNode = colorSpaceToWorking( texture( outputTex, vUv ), THREE.SRGBColorSpace );
+	fsQuad = new FullScreenQuad( fsMaterial );
+
+	resize();
+
+}
+
+// ─── GUI ───
+
+function setupGUI() {
+
+	gui = new GUI();
+
+	gui.add( { explode: triggerExplosion }, 'explode' ).name( 'Explode' );
+	gui.add( { reset: resetExplosion }, 'reset' ).name( 'Reset' );
+	gui.add( params, 'pause' );
+	gui.add( params, 'bvhUpdateMode', Object.values( BVH_UPDATE_MODES ) ).name( 'BVH update' );
+	gui.add( params, 'smoothNormals' );
+	gui.add( params, 'explosionForce', 2, 20, 0.5 ).name( 'explosion force' );
+	gui.add( params, 'gravity', 0, 20, 0.5 ).name( 'gravity' );
+	gui.add( params, 'bounce', 0, 1, 0.05 ).name( 'bounce' );
+	gui.add( params, 'samples', 1, 8, 1 ).name( 'samples per pixel' );
+	gui.add( params, 'resolutionScale', 0.1, 1, 0.1 ).onChange( resize );
+	gui.add( params, 'floorY', - 3, 0, 0.05 ).name( 'floor height' );
+
+}
+
+// ─── BVH Update ───
+
+async function updateBVH() {
+
+	if ( buildInProgress ) return;
+	buildInProgress = true;
+
+	try {
+
+		const useRefit = params.bvhUpdateMode === BVH_UPDATE_MODES.REFIT;
+
+		// GPU transform
+		const transformStart = performance.now();
+		computeChunkMatrices();
+		transformBuffers.chunkMatrices.array.set( chunkMatricesArray );
+		transformBuffers.chunkMatrices.needsUpdate = true;
+		await runGPUTransform();
+		const transformTime = performance.now() - transformStart;
+
+		// Readback transformed positions and normals
+		await readbackTransformed();
+
+		// Update ray tracer buffers
+		geom_position.array.set( transformedPositions );
+		geom_position.needsUpdate = true;
+		geom_normals.array.set( transformedNormals );
+		geom_normals.needsUpdate = true;
+
+		// Refit or rebuild BVH
+		const bvhStart = performance.now();
+		if ( useRefit ) {
+
+			await gpuBVH.refitAsync( { geometry: bvhUpdateGeometry, useFlatten: false } );
+
+		} else {
+
+			await gpuBVH.buildAsync( bvhUpdateGeometry, { useFlatten: false } );
+
+		}
+
+		const bvhUpdateTime = performance.now() - bvhStart;
+
+		// Update running averages
+		frameCount ++;
+		const alpha = Math.min( frameCount, 60 );
+		avgTransformTime += ( transformTime - avgTransformTime ) / alpha;
+		avgBvhUpdateTime += ( bvhUpdateTime - avgBvhUpdateTime ) / alpha;
+
+		// GPU->GPU copy BVH data
+		const maxNodeCount = gpuBVH.maxNodeCount;
+		const backend = renderer.backend;
+		const bvhDst = backend.get( bvh2Nodes );
+		const rootIndexDst = backend.get( rootIndexBuffer );
+
+		if ( bvhDst && bvhDst.buffer && rootIndexDst && rootIndexDst.buffer ) {
+
+			const byteLength = maxNodeCount * 32;
+			const commandEncoder = device.createCommandEncoder();
+			commandEncoder.copyBufferToBuffer( gpuBVH.bvh2Buffer, 0, bvhDst.buffer, 0, byteLength );
+			commandEncoder.copyBufferToBuffer( gpuBVH.clusterIdxBuffer, 0, rootIndexDst.buffer, 0, 4 );
+			device.queue.submit( [ commandEncoder.finish() ] );
+
+		} else {
+
+			console.info( 'BVH: Using CPU fallback' );
+			const bvh2Array = await readbackBVH( gpuBVH.bvh2Buffer, maxNodeCount );
+			bvh2Nodes.array.set( bvh2Array );
+			bvh2Nodes.needsUpdate = true;
+			const rootIdx = await readbackRootIndex( gpuBVH.clusterIdxBuffer );
+			rootIndexBuffer.array[ 0 ] = rootIdx;
+			rootIndexBuffer.needsUpdate = true;
+
+		}
+
+		// Update display
+		const bvhLabel = useRefit ? 'BVH refit' : 'BVH rebuild';
+		let output = `triangles: ${triCount}\n`;
+		output += `GPU transform: ${transformTime.toFixed( 2 )} ms (avg: ${avgTransformTime.toFixed( 2 )})\n`;
+		output += `${bvhLabel}: ${bvhUpdateTime.toFixed( 2 )} ms (avg: ${avgBvhUpdateTime.toFixed( 2 )})\n`;
+		output += `mode: ${params.bvhUpdateMode}`;
+		outputContainer.textContent = output;
+
+	} finally {
+
+		buildInProgress = false;
+
+	}
+
+}
+
+async function readbackBVH( bvhBuffer, nodeCount ) {
+
+	const byteLength = nodeCount * 32;
+	const readBuffer = device.createBuffer( {
+		size: byteLength,
+		usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+	} );
+
+	const commandEncoder = device.createCommandEncoder();
+	commandEncoder.copyBufferToBuffer( bvhBuffer, 0, readBuffer, 0, byteLength );
+	device.queue.submit( [ commandEncoder.finish() ] );
+
+	await readBuffer.mapAsync( GPUMapMode.READ );
+	const mapped = readBuffer.getMappedRange();
+	const copy = new Float32Array( mapped.slice( 0 ) );
+	readBuffer.unmap();
+	readBuffer.destroy();
+
+	return copy;
+
+}
+
+async function readbackRootIndex( clusterIdxBuffer ) {
+
+	const readBuffer = device.createBuffer( {
+		size: 4,
+		usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+	} );
+
+	const commandEncoder = device.createCommandEncoder();
+	commandEncoder.copyBufferToBuffer( clusterIdxBuffer, 0, readBuffer, 0, 4 );
+	device.queue.submit( [ commandEncoder.finish() ] );
+
+	await readBuffer.mapAsync( GPUMapMode.READ );
+	const mapped = readBuffer.getMappedRange();
+	const rootIndex = new Uint32Array( mapped )[ 0 ];
+	readBuffer.unmap();
+	readBuffer.destroy();
+
+	return rootIndex;
+
+}
+
+// ─── Resize ───
+
+function resize() {
+
+	const w = window.innerWidth;
+	const h = window.innerHeight;
+	const dpr = window.devicePixelRatio;
+	const scale = params.resolutionScale;
+
+	camera.aspect = w / h;
+	camera.updateProjectionMatrix();
+
+	renderer.setSize( w, h );
+	renderer.setPixelRatio( dpr );
+
+	if ( outputTex ) {
+
+		outputTex.dispose();
+
+	}
+
+	outputTex = new StorageTexture( w * dpr * scale, h * dpr * scale );
+	outputTex.format = THREE.RGBAFormat;
+	outputTex.type = THREE.UnsignedByteType;
+	outputTex.magFilter = THREE.LinearFilter;
+
+	if ( computeShaderParams ) {
+
+		computeShaderParams.outputTex = textureStore( outputTex );
+
+	}
+
+}
+
+// ─── Render ───
+
+async function render() {
+
+	stats.update();
+
+	const delta = Math.min( clock.getDelta(), 0.033 );
+
+	// Update physics
+	if ( ! params.pause && exploded ) {
+
+		updatePhysics( delta );
+
+	}
+
+	// Update BVH every frame
+	if ( ! params.pause && ! buildInProgress ) {
+
+		await updateBVH();
+
+	}
+
+	// Path trace
+	if ( computeKernel && outputTex ) {
+
+		dispatchSize = [
+			Math.ceil( outputTex.width / WORKGROUP_SIZE[ 0 ] ),
+			Math.ceil( outputTex.height / WORKGROUP_SIZE[ 1 ] ),
+		];
+
+		camera.updateMatrixWorld();
+
+		computeKernel.computeNode.parameters.outputTex.value = outputTex;
+		computeKernel.computeNode.parameters.smoothNormals.value = Number( params.smoothNormals );
+		computeKernel.computeNode.parameters.inverseProjectionMatrix.value = camera.projectionMatrixInverse;
+		computeKernel.computeNode.parameters.cameraToWorldMatrix.value.copy( camera.matrixWorld );
+		computeKernel.computeNode.parameters.floorY.value = params.floorY;
+		computeKernel.computeNode.parameters.time.value = clock.getElapsedTime();
+		computeKernel.computeNode.parameters.frameCount.value = frameCount;
+		computeKernel.computeNode.parameters.samples.value = params.samples;
+		computeKernel.computeNode.parameters.workgroupSize.value.fromArray( WORKGROUP_SIZE );
+
+		renderer.compute( computeKernel, dispatchSize );
+
+		fsMaterial.colorNode.colorNode.value = outputTex;
+		fsQuad.render( renderer );
+
+	}
+
+}

--- a/example/webgpu_gpuPathTracingSimple_gpuBuild.html
+++ b/example/webgpu_gpuPathTracingSimple_gpuBuild.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+
+	<head>
+
+		<meta charset="UTF-8"/>
+		<link rel="shortcut icon" href="#">
+		<title>three-mesh-bvh - GPU Path Tracing (GPU BVH Build)</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+		<style type="text/css">
+			html, body {
+				padding: 0;
+				margin: 0;
+				overflow: hidden;
+				font-family: monospace;
+			}
+
+			canvas {
+				width: 100%;
+				height: 100%;
+			}
+
+			#info {
+				position: absolute;
+				top: 0;
+				width: 100%;
+				color: #777;
+				font-family: monospace;
+				text-align: center;
+				padding: 5px 0;
+			}
+		</style>
+
+	</head>
+
+	<body>
+
+		<div id="info">Running BVH ray intersections with a WGSL compute shader.</div>
+
+		<script type="module" src="./webgpu_gpuPathTracingSimple_gpuBuild.js"></script>
+
+	</body>
+
+</html>

--- a/example/webgpu_gpuPathTracingSimple_gpuBuild.js
+++ b/example/webgpu_gpuPathTracingSimple_gpuBuild.js
@@ -1,0 +1,734 @@
+import * as THREE from 'three';
+import { WebGPURenderer, StorageBufferAttribute, StorageTexture, MeshBasicNodeMaterial } from 'three/webgpu';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import Stats from 'three/addons/libs/stats.module.js';
+import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+import {
+	attribute, uniform, wgslFn, varyingProperty,
+	textureStore, texture, colorSpaceToWorking,
+	storage, workgroupId, localId,
+} from 'three/tsl';
+
+// three-mesh-bvh
+import { MeshBVH, SAH } from 'three-mesh-bvh';
+import { GPUMeshBVH, SorterType } from 'three-mesh-bvh/src/gpu/index.js';
+import { ndcToCameraRay, bvh2IntersectFirstHit, getVertexAttribute } from 'three-mesh-bvh/webgpu';
+
+// Geometry types
+const GeometryType = {
+	SPHERE: 'sphere',
+	TORUS: 'torus',
+	INFERNO_BEAST: 'infernoBeast',
+	TREX: 'trex',
+};
+
+// Read sorter type from URL params (persists across refresh)
+function getSorterFromURL() {
+
+	const urlParams = new URLSearchParams( window.location.search );
+	const sorter = urlParams.get( 'sorter' );
+	if ( sorter === 'onesweep' ) return SorterType.ONESWEEP;
+	return SorterType.BUILTIN;
+
+}
+
+// Read geometry type from URL params
+function getGeometryFromURL() {
+
+	const urlParams = new URLSearchParams( window.location.search );
+	const geometry = urlParams.get( 'geometry' );
+	if ( geometry === 'sphere' ) return GeometryType.SPHERE;
+	if ( geometry === 'infernoBeast' ) return GeometryType.INFERNO_BEAST;
+	if ( geometry === 'trex' ) return GeometryType.TREX;
+	return GeometryType.TORUS; // default
+
+}
+
+const params = {
+	enableRaytracing: true,
+	animate: true,
+	resolutionScale: 0.1, // Low for BVH build testing (not traversal)
+	smoothNormals: true,
+	useBVH2: true, // true = BVH2 direct traversal (no flatten), false = flattened BVH
+	sorterType: getSorterFromURL(),
+	geometryType: getGeometryFromURL(),
+};
+
+// Geometry loading functions
+async function loadGeometry( type ) {
+
+	switch ( type ) {
+
+		case GeometryType.SPHERE:
+			return new THREE.SphereGeometry( 1, 128, 64 ); // ~16k tris
+
+		case GeometryType.INFERNO_BEAST:
+			return await loadInfernoBeast();
+
+		case GeometryType.TREX:
+			return await loadTRex();
+
+		case GeometryType.TORUS:
+		default:
+			return new THREE.TorusKnotGeometry( 1, 0.3, 1000, 150 ); // ~300k tris
+
+	}
+
+}
+
+async function loadInfernoBeast() {
+
+	const loader = new GLTFLoader();
+
+	return new Promise( ( resolve, reject ) => {
+
+		loader.load(
+			'/inferno-beast-from-space-from-jurafjvs-cc0-2.glb',
+			( gltf ) => {
+
+				// Merge all meshes from the model
+				const geometries = [];
+
+				gltf.scene.traverse( ( child ) => {
+
+					if ( child.isMesh && child.geometry ) {
+
+						const geom = child.geometry.clone();
+						child.updateWorldMatrix( true, false );
+						geom.applyMatrix4( child.matrixWorld );
+						geometries.push( geom );
+
+					}
+
+				} );
+
+				if ( geometries.length === 0 ) {
+
+					reject( new Error( 'No meshes found in GLB' ) );
+					return;
+
+				}
+
+				// Merge into single geometry
+				const merged = mergeGeometries( geometries );
+
+				// Scale and center
+				merged.computeBoundingBox();
+				const box = merged.boundingBox;
+				const center = box.getCenter( new THREE.Vector3() );
+				const size = box.getSize( new THREE.Vector3() );
+				const maxDim = Math.max( size.x, size.y, size.z );
+				const scale = 2.0 / maxDim;
+
+				const matrix = new THREE.Matrix4()
+					.makeScale( scale, scale, scale )
+					.multiply( new THREE.Matrix4().makeTranslation( - center.x, - center.y, - center.z ) );
+				merged.applyMatrix4( matrix );
+
+				resolve( merged );
+
+			},
+			undefined,
+			( error ) => reject( new Error( `Failed to load GLB: ${error.message}` ) )
+		);
+
+	} );
+
+}
+
+async function loadTRex() {
+
+	const loader = new GLTFLoader();
+
+	return new Promise( ( resolve, reject ) => {
+
+		loader.load(
+			'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/main/models/trex/scene.gltf',
+			( gltf ) => {
+
+				// Merge all meshes from the model
+				const geometries = [];
+
+				gltf.scene.traverse( ( child ) => {
+
+					if ( child.isMesh && child.geometry ) {
+
+						const geom = child.geometry.clone();
+						child.updateWorldMatrix( true, false );
+						geom.applyMatrix4( child.matrixWorld );
+						geometries.push( geom );
+
+					}
+
+				} );
+
+				if ( geometries.length === 0 ) {
+
+					reject( new Error( 'No meshes found in GLTF' ) );
+					return;
+
+				}
+
+				// Merge into single geometry
+				const merged = mergeGeometries( geometries );
+
+				// Scale and center
+				merged.computeBoundingBox();
+				const box = merged.boundingBox;
+				const center = box.getCenter( new THREE.Vector3() );
+				const size = box.getSize( new THREE.Vector3() );
+				const maxDim = Math.max( size.x, size.y, size.z );
+				const scale = 2.0 / maxDim;
+
+				const matrix = new THREE.Matrix4()
+					.makeScale( scale, scale, scale )
+					.multiply( new THREE.Matrix4().makeTranslation( - center.x, - center.y, - center.z ) );
+				merged.applyMatrix4( matrix );
+
+				resolve( merged );
+
+			},
+			undefined,
+			( error ) => reject( new Error( `Failed to load GLTF: ${error.message}` ) )
+		);
+
+	} );
+
+}
+
+function mergeGeometries( geometriesArray ) {
+
+	// Count total triangles
+	let totalTriangles = 0;
+	for ( const geom of geometriesArray ) {
+
+		if ( geom.index ) {
+
+			totalTriangles += geom.index.count / 3;
+
+		} else {
+
+			totalTriangles += geom.attributes.position.count / 3;
+
+		}
+
+	}
+
+	const positions = new Float32Array( totalTriangles * 9 );
+	let offset = 0;
+
+	for ( const geom of geometriesArray ) {
+
+		const posAttr = geom.attributes.position;
+		const indexAttr = geom.index;
+
+		if ( indexAttr ) {
+
+			for ( let i = 0; i < indexAttr.count; i ++ ) {
+
+				const idx = indexAttr.array[ i ];
+				positions[ offset ++ ] = posAttr.getX( idx );
+				positions[ offset ++ ] = posAttr.getY( idx );
+				positions[ offset ++ ] = posAttr.getZ( idx );
+
+			}
+
+		} else {
+
+			const arr = posAttr.array;
+			for ( let i = 0; i < arr.length; i ++ ) {
+
+				positions[ offset ++ ] = arr[ i ];
+
+			}
+
+		}
+
+	}
+
+	const merged = new THREE.BufferGeometry();
+	merged.setAttribute( 'position', new THREE.BufferAttribute( positions, 3 ) );
+	merged.computeVertexNormals();
+
+	// Generate index buffer (needed for BVH)
+	const indexCount = totalTriangles * 3;
+	const indices = new Uint32Array( indexCount );
+	for ( let i = 0; i < indexCount; i ++ ) {
+
+		indices[ i ] = i;
+
+	}
+
+	merged.setIndex( new THREE.BufferAttribute( indices, 1 ) );
+
+	return merged;
+
+}
+
+let renderer, camera, scene, gui, stats;
+let fsQuad, mesh, clock;
+let fsMaterial, computeKernelBVH2, computeKernelFlattened, outputTex;
+let dispatchSize = [];
+const WORKGROUP_SIZE = [ 8, 8, 1 ];
+
+init();
+
+async function init() {
+
+	// Request GPU adapter and device with required features and limits
+	const adapter = await navigator.gpu.requestAdapter();
+
+	// Build feature list based on adapter support
+	const requiredFeatures = [];
+	if ( adapter.features.has( 'timestamp-query' ) ) {
+
+		requiredFeatures.push( 'timestamp-query' );
+
+	}
+
+	if ( adapter.features.has( 'subgroups' ) ) {
+
+		requiredFeatures.push( 'subgroups' );
+
+	}
+
+	const device = await adapter.requestDevice( {
+		requiredFeatures,
+		requiredLimits: {
+			maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize,
+			maxStorageBuffersPerShaderStage: adapter.limits.maxStorageBuffersPerShaderStage,
+		},
+	} );
+
+	// renderer
+	renderer = new WebGPURenderer( {
+
+		canvas: document.createElement( 'canvas' ),
+		antialias: true,
+		forceWebGL: false,
+		device: device,
+
+	} );
+	if ( renderer.init ) {
+
+		await renderer.init();
+
+	}
+
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setClearColor( 0x09141a );
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.outputColorSpace = THREE.SRGBColorSpace;
+	document.body.appendChild( renderer.domElement );
+
+	// scene init
+	scene = new THREE.Scene();
+
+	// light init
+	const light = new THREE.DirectionalLight( 0xffffff, 1 );
+	light.position.set( 1, 1, 1 );
+	scene.add( light );
+	scene.add( new THREE.AmbientLight( 0xb0bec5, 0.5 ) );
+
+	// camera setup
+	camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.01, 100 );
+	camera.position.set( 0, 0, 4 );
+	camera.updateProjectionMatrix();
+
+	// stats setup
+	stats = new Stats();
+	document.body.appendChild( stats.dom );
+
+	// Load geometry based on URL param
+	console.log( `Loading geometry: ${params.geometryType}` );
+	const knotGeometry = await loadGeometry( params.geometryType );
+	mesh = new THREE.Mesh( knotGeometry, new THREE.MeshStandardMaterial() );
+	scene.add( mesh );
+
+	// Build CPU BVH for comparison
+	const cpuStart = performance.now();
+	const cpuBVH = new MeshBVH( knotGeometry.clone(), { maxLeafTris: 1, strategy: SAH } );
+	const cpuBuildTime = performance.now() - cpuStart;
+
+	// Build GPU BVH (without flatten - use BVH2 directly)
+	// Set debugTiming: true to see per-phase breakdown (adds ~1ms overhead from awaits)
+	// Set debugTiming: false (default) for production single-submission build
+	// Sorter options: 'builtin' (original), 'simple' (refactored), 'onesweep' (high-perf)
+	const gpuBVH = new GPUMeshBVH( device, { sorterType: params.sorterType } );
+	await gpuBVH.build( knotGeometry, { useFlatten: false, debugTiming: false } );
+	console.log( `Using sorter: ${gpuBVH.sorterType}` );
+
+	// Read back BVH2 format
+	const bvh2Array = await readbackBVH( device, gpuBVH.bvh2Buffer, gpuBVH.nodeCount );
+	const rootIndex = gpuBVH.rootIndex;
+	logBVHStats( knotGeometry, bvh2Array, gpuBVH, cpuBVH, cpuBuildTime, rootIndex );
+
+	// Note: Flattened BVH toggle disabled since we're not building it
+	// To re-enable comparison, change useFlatten to true above
+
+	// animation
+	clock = new THREE.Clock();
+
+	// TSL - shared geometry buffers
+	const geom_index = new StorageBufferAttribute( knotGeometry.index.array, 3 );
+	const geom_position = new StorageBufferAttribute( knotGeometry.attributes.position.array, 3 );
+	const geom_normals = new StorageBufferAttribute( knotGeometry.attributes.normal.array, 3 );
+
+	// BVH2 (direct, no flatten) compute kernel
+	const bvh2Nodes = new StorageBufferAttribute( bvh2Array, 8 );
+	const computeShaderParamsBVH2 = {
+		outputTex: textureStore( outputTex ),
+		smoothNormals: uniform( 1 ),
+		rootIndex: uniform( rootIndex ),
+		inverseProjectionMatrix: uniform( new THREE.Matrix4() ),
+		cameraToModelMatrix: uniform( new THREE.Matrix4() ),
+		geom_index: storage( geom_index, 'uvec3', geom_index.count ).toReadOnly(),
+		geom_position: storage( geom_position, 'vec3', geom_position.count ).toReadOnly(),
+		geom_normals: storage( geom_normals, 'vec3', geom_normals.count ).toReadOnly(),
+		bvh: storage( bvh2Nodes, 'BVH2Node', bvh2Nodes.count ).toReadOnly(),
+		workgroupSize: uniform( new THREE.Vector3() ),
+		workgroupId: workgroupId,
+		localId: localId
+	};
+
+	const computeShaderBVH2 = wgslFn( /* wgsl */`
+		fn compute(
+			outputTex: texture_storage_2d<rgba8unorm, write>,
+			smoothNormals: u32,
+			rootIndex: u32,
+			inverseProjectionMatrix: mat4x4f,
+			cameraToModelMatrix: mat4x4f,
+			geom_position: ptr<storage, array<vec3f>, read>,
+			geom_index: ptr<storage, array<vec3u>, read>,
+			geom_normals: ptr<storage, array<vec3f>, read>,
+			bvh: ptr<storage, array<BVH2Node>, read>,
+			workgroupSize: vec3u,
+			workgroupId: vec3u,
+			localId: vec3u,
+		) -> void {
+			let dimensions = textureDimensions( outputTex );
+			let indexUV = workgroupSize.xy * workgroupId.xy + localId.xy;
+			let uv = vec2f( indexUV ) / vec2f( dimensions );
+			let ndc = uv * 2.0 - vec2f( 1.0 );
+			var ray = ndcToCameraRay( ndc, cameraToModelMatrix * inverseProjectionMatrix );
+			let hitResult = bvh2IntersectFirstHit( geom_index, geom_position, bvh, ray, rootIndex );
+			if ( hitResult.didHit && hitResult.dist < 1.0 ) {
+				let normal = select(
+					hitResult.normal,
+					normalize( getVertexAttribute( hitResult.barycoord, hitResult.indices.xyz, geom_normals ) ),
+					smoothNormals > 0u,
+				);
+				textureStore( outputTex, indexUV, vec4f( normal, 1.0 ) );
+			} else {
+				let background = vec4f( 0.0366, 0.0813, 0.1057, 1.0 );
+				textureStore( outputTex, indexUV, background );
+			}
+		}
+	`, [ ndcToCameraRay, bvh2IntersectFirstHit, getVertexAttribute ] );
+
+	computeKernelBVH2 = computeShaderBVH2( computeShaderParamsBVH2 ).computeKernel( WORKGROUP_SIZE );
+
+	// Flattened BVH kernel not created (useFlatten: false)
+	// Toggle will only use BVH2
+	computeKernelFlattened = null;
+
+	// screen quad
+	const vUv = varyingProperty( 'vec2', 'vUv' );
+	const wgslVertexShader = wgslFn( /* wgsl */`
+		fn vertex( position: vec3f, uv: vec2f ) -> vec3f {
+			varyings.vUv = uv;
+			return position;
+		}
+	`, [ vUv ] );
+
+	fsMaterial = new MeshBasicNodeMaterial();
+	fsMaterial.positionNode = wgslVertexShader( {
+		position: attribute( 'position' ),
+		uv: attribute( 'uv' )
+	} );
+
+	fsMaterial.colorNode = colorSpaceToWorking( texture( outputTex, vUv ), THREE.SRGBColorSpace );
+	fsQuad = new FullScreenQuad( fsMaterial );
+
+	// controls
+	new OrbitControls( camera, renderer.domElement );
+
+	// gui
+	gui = new GUI();
+	gui.add( params, 'enableRaytracing' );
+	gui.add( params, 'animate' );
+	gui.add( params, 'smoothNormals' );
+	// gui.add( params, 'useBVH2' ).name( 'BVH2 (no flatten)' ); // Toggle disabled - using BVH2 only
+	gui.add( params, 'resolutionScale', 0.1, 1, 0.01 ).onChange( resize );
+	gui.add( params, 'sorterType', {
+		'Built-in': SorterType.BUILTIN,
+		'OneSweep': SorterType.ONESWEEP,
+	} ).name( 'Sorter' ).onChange( ( value ) => {
+
+		const url = new URL( window.location );
+		if ( value === SorterType.BUILTIN ) {
+
+			url.searchParams.delete( 'sorter' );
+
+		} else {
+
+			url.searchParams.set( 'sorter', value );
+
+		}
+
+		window.location.href = url.toString();
+
+	} );
+	gui.add( params, 'geometryType', {
+		'Sphere (16k)': GeometryType.SPHERE,
+		'Torus Knot (300k)': GeometryType.TORUS,
+		'Inferno Beast (900k)': GeometryType.INFERNO_BEAST,
+		'T-Rex (4k)': GeometryType.TREX,
+	} ).name( 'Geometry' ).onChange( ( value ) => {
+
+		const url = new URL( window.location );
+		if ( value === GeometryType.TORUS ) {
+
+			url.searchParams.delete( 'geometry' );
+
+		} else {
+
+			url.searchParams.set( 'geometry', value );
+
+		}
+
+		window.location.href = url.toString();
+
+	} );
+	gui.open();
+
+	// resize
+	window.addEventListener( 'resize', resize, false );
+	resize();
+
+	// start animation loop after everything is initialized
+	renderer.setAnimationLoop( render );
+
+}
+
+async function readbackBVH( device, bvhBuffer, nodeCount ) {
+
+	const byteLength = nodeCount * 32;
+	const readBuffer = device.createBuffer( {
+		size: byteLength,
+		usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+	} );
+
+	const commandEncoder = device.createCommandEncoder();
+	commandEncoder.copyBufferToBuffer( bvhBuffer, 0, readBuffer, 0, byteLength );
+	device.queue.submit( [ commandEncoder.finish() ] );
+
+	await readBuffer.mapAsync( GPUMapMode.READ );
+	const mapped = readBuffer.getMappedRange();
+	const copy = mapped.slice( 0 );
+	readBuffer.unmap();
+	readBuffer.destroy();
+
+	return new Float32Array( copy );
+
+}
+
+function logBVHStats( geometry, bvhArray, gpuBVH, cpuBVH, cpuBuildTime, rootIndex ) {
+
+	const primCount = Math.floor( geometry.index.count / 3 );
+	const gpuNodeCount = gpuBVH.nodeCount;
+	const gpuBuildTime = gpuBVH.buildTimeMs;
+
+	geometry.computeBoundingBox();
+	const bounds = geometry.boundingBox;
+
+	// BVH2 node layout: boundsMin (vec3f), leftChild (u32), boundsMax (vec3f), rightChild (u32)
+	// Each node is 8 floats = 32 bytes
+	const rootOffset = rootIndex * 8;
+	const rootMin = new THREE.Vector3( bvhArray[ rootOffset + 0 ], bvhArray[ rootOffset + 1 ], bvhArray[ rootOffset + 2 ] );
+	const rootMax = new THREE.Vector3( bvhArray[ rootOffset + 4 ], bvhArray[ rootOffset + 5 ], bvhArray[ rootOffset + 6 ] );
+
+	const okMin = rootMin.x <= bounds.min.x + 1e-3 && rootMin.y <= bounds.min.y + 1e-3 && rootMin.z <= bounds.min.z + 1e-3;
+	const okMax = rootMax.x >= bounds.max.x - 1e-3 && rootMax.y >= bounds.max.y - 1e-3 && rootMax.z >= bounds.max.z - 1e-3;
+	const boundsOk = okMin && okMax;
+
+	// Expected nodes for a binary tree: 2n - 1 internal + leaf nodes
+	const expectedNodes = 2 * primCount - 1;
+	const nodeCountOk = gpuNodeCount >= primCount && gpuNodeCount <= 2 * primCount;
+
+	// CPU BVH stats
+	const cpuNodeCount = cpuBVH._roots[ 0 ].byteLength / 32; // 32 bytes per node
+
+	const speedup = cpuBuildTime / gpuBuildTime;
+
+	const infoEl = document.getElementById( 'info' );
+	if ( infoEl ) {
+
+		infoEl.textContent = `${ primCount } tris | GPU: ${ gpuBuildTime.toFixed( 1 ) }ms | CPU: ${ cpuBuildTime.toFixed( 1 ) }ms | Speedup: ${ speedup.toFixed( 1 ) }x`;
+
+	}
+
+	console.log( '=== BVH Build Comparison ===' );
+	console.log( `Triangles: ${ primCount }` );
+	console.log( '' );
+	console.log( '--- GPU BVH2 (H-PLOC, no flatten) ---' );
+	console.log( `Nodes: ${ gpuNodeCount } (expected ~${ expectedNodes }, ok: ${ nodeCountOk })` );
+	console.log( `Root index: ${ rootIndex }` );
+	console.log( `Build time: ${ gpuBuildTime.toFixed( 2 ) }ms` );
+	console.log( `Throughput: ${ ( primCount / gpuBuildTime * 1000 / 1000 ).toFixed( 1 ) }k tris/sec` );
+
+	// CPU prep timing (geometry extraction, buffer allocation, upload)
+	const prep = gpuBVH.cpuPrepTimings;
+	if ( prep ) {
+
+		console.log( '' );
+		console.log( 'CPU prep breakdown:' );
+		console.log( `  Geometry extract: ${ prep.extract.toFixed( 2 ) }ms (${ ( prep.extract / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+		console.log( `  Buffer alloc:     ${ prep.alloc.toFixed( 2 ) }ms (${ ( prep.alloc / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+		console.log( `  Geometry upload:  ${ prep.upload.toFixed( 2 ) }ms (${ ( prep.upload / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+		if ( prep.pipeline > 0.01 ) {
+
+			console.log( `  Pipeline create:  ${ prep.pipeline.toFixed( 2 ) }ms (${ ( prep.pipeline / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+
+		}
+
+		if ( prep.sorterInit > 0.01 ) {
+
+			console.log( `  Sorter init:      ${ prep.sorterInit.toFixed( 2 ) }ms (${ ( prep.sorterInit / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+
+		}
+
+		console.log( `  CPU prep total:   ${ prep.total.toFixed( 2 ) }ms (${ ( prep.total / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+
+	}
+
+	// Pass breakdown (only available with debugTiming: true)
+	const t = gpuBVH.passTimings;
+	if ( t && t.setup !== undefined ) {
+
+		console.log( '' );
+		const timingMode = t.gpuTimestamps ? 'GPU timestamps' : 'multi-submit';
+		console.log( `GPU pass breakdown (${ timingMode }):` );
+		if ( t.setupBounds !== undefined ) {
+
+			console.log( `  Bounds+init:   ${ t.setupBounds.toFixed( 2 ) }ms (${ ( t.setupBounds / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+			console.log( `  Morton codes:  ${ t.setupMorton.toFixed( 2 ) }ms (${ ( t.setupMorton / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+
+		}
+
+		console.log( `  Setup total:   ${ t.setup.toFixed( 2 ) }ms (${ ( t.setup / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+		console.log( `  Radix sort:    ${ t.sort.toFixed( 2 ) }ms (${ ( t.sort / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+		console.log( `  H-PLOC (${ t.hplocIterations } iters): ${ t.hploc.toFixed( 2 ) }ms (${ ( t.hploc / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+		if ( t.flatten > 0 ) {
+
+			console.log( `  Flatten:       ${ t.flatten.toFixed( 2 ) }ms (${ ( t.flatten / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+
+		}
+
+		if ( t.readback > 0.01 ) {
+
+			console.log( `  Readback:      ${ t.readback.toFixed( 2 ) }ms (${ ( t.readback / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+
+		}
+
+		// Calculate GPU work total vs overhead
+		const gpuWork = t.setup + t.sort + t.hploc + ( t.flatten || 0 );
+		const overhead = gpuBuildTime - gpuWork - ( prep ? prep.total : 0 ) - ( t.readback || 0 );
+		if ( overhead > 0.5 ) {
+
+			console.log( `  Sync overhead: ~${ overhead.toFixed( 2 ) }ms (${ ( overhead / gpuBuildTime * 100 ).toFixed( 1 ) }%)` );
+
+		}
+
+	} else if ( t ) {
+
+		console.log( '' );
+		console.log( `Single-submission build (H-PLOC: ${ t.hplocIterations } iters)` );
+
+	}
+
+	console.log( '' );
+	console.log( '--- CPU BVH (SAH) ---' );
+	console.log( `Nodes: ${ cpuNodeCount.toFixed( 0 ) }` );
+	console.log( `Build time: ${ cpuBuildTime.toFixed( 2 ) }ms` );
+	console.log( `Throughput: ${ ( primCount / cpuBuildTime * 1000 / 1000 ).toFixed( 1 ) }k tris/sec` );
+	console.log( '' );
+	console.log( `>>> Speedup: ${ speedup.toFixed( 2 ) }x <<<` );
+	console.log( '' );
+	console.log( `Root bounds: min=${ rootMin.toArray().map( v => v.toFixed( 3 ) ) }, max=${ rootMax.toArray().map( v => v.toFixed( 3 ) ) }` );
+	console.log( `Geometry bounds: min=${ bounds.min.toArray().map( v => v.toFixed( 3 ) ) }, max=${ bounds.max.toArray().map( v => v.toFixed( 3 ) ) }` );
+	console.log( `Bounds check: ${ boundsOk ? 'PASS' : 'FAIL' }` );
+	console.log( '=============================' );
+
+}
+
+function resize() {
+
+	const w = window.innerWidth;
+	const h = window.innerHeight;
+	const dpr = window.devicePixelRatio;
+	const scale = params.resolutionScale;
+
+	camera.aspect = w / h;
+	camera.updateProjectionMatrix();
+
+	renderer.setSize( w, h );
+	renderer.setPixelRatio( dpr );
+
+	// reconstruct texture
+	if ( outputTex ) {
+
+		outputTex.dispose();
+
+	}
+
+	outputTex = new StorageTexture( w * dpr * scale, h * dpr * scale );
+	outputTex.format = THREE.RGBAFormat;
+	outputTex.type = THREE.UnsignedByteType;
+	outputTex.magFilter = THREE.LinearFilter;
+
+}
+
+function render() {
+
+	stats.update();
+
+	const delta = clock.getDelta();
+	if ( params.animate ) {
+
+		mesh.rotation.y += delta;
+
+	}
+
+	if ( params.enableRaytracing ) {
+
+		dispatchSize = [
+			Math.ceil( outputTex.width / WORKGROUP_SIZE[ 0 ] ),
+			Math.ceil( outputTex.height / WORKGROUP_SIZE[ 1 ] ),
+		];
+
+		camera.updateMatrixWorld();
+		mesh.updateMatrixWorld();
+
+		// Select kernel based on BVH mode (flattened may be null if not built)
+		const computeKernel = ( params.useBVH2 || ! computeKernelFlattened ) ? computeKernelBVH2 : computeKernelFlattened;
+
+		computeKernel.computeNode.parameters.outputTex.value = outputTex;
+		computeKernel.computeNode.parameters.smoothNormals.value = Number( params.smoothNormals );
+		computeKernel.computeNode.parameters.inverseProjectionMatrix.value = camera.projectionMatrixInverse;
+		computeKernel.computeNode.parameters.cameraToModelMatrix.value.copy( mesh.matrixWorld ).invert().multiply( camera.matrixWorld );
+		computeKernel.computeNode.parameters.workgroupSize.value.fromArray( WORKGROUP_SIZE );
+		renderer.compute( computeKernel, dispatchSize );
+
+		fsMaterial.colorNode.colorNode.value = outputTex;
+		fsQuad.render( renderer );
+
+	} else {
+
+		renderer.render( scene, camera );
+
+	}
+
+}

--- a/example/webgpu_skinnedMesh.html
+++ b/example/webgpu_skinnedMesh.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+
+	<head>
+
+		<meta charset="UTF-8"/>
+		<link rel="shortcut icon" href="#">
+		<title>three-mesh-bvh - WebGPU Skinned Mesh BVH Rebuild</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+
+		<style type="text/css">
+			html, body {
+				padding: 0;
+				margin: 0;
+				overflow: hidden;
+			}
+
+			#info {
+				position: absolute;
+				top: 0;
+				width: 100%;
+				color: #fff;
+				font-family: monospace;
+				text-align: center;
+				padding: 5px 0;
+				background: rgba(0,0,0,0.5);
+			}
+
+			#output {
+				position: absolute;
+				bottom: 10px;
+				left: 10px;
+				color: #fff;
+				font-family: monospace;
+				font-size: 13px;
+				background: rgba(0,0,0,0.7);
+				padding: 10px;
+				border-radius: 4px;
+				white-space: pre;
+			}
+		</style>
+
+	</head>
+
+	<body>
+
+		<div id="info">WebGPU Skinned Mesh - GPU BVH rebuilt every frame</div>
+		<div id="output">Initializing...</div>
+
+		<script type="module" src="./webgpu_skinnedMesh.js"></script>
+
+	</body>
+
+</html>

--- a/example/webgpu_skinnedMesh.js
+++ b/example/webgpu_skinnedMesh.js
@@ -1,0 +1,1548 @@
+import * as THREE from 'three';
+import { WebGPURenderer, StorageBufferAttribute, StorageTexture, MeshBasicNodeMaterial } from 'three/webgpu';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import Stats from 'three/addons/libs/stats.module.js';
+import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { FullScreenQuad } from 'three/addons/postprocessing/Pass.js';
+import {
+	attribute, uniform, wgslFn, varyingProperty,
+	textureStore, texture, colorSpaceToWorking,
+	storage, workgroupId, localId,
+	wgsl,
+} from 'three/tsl';
+
+// three-mesh-bvh
+import { GPUMeshBVH, SorterType } from 'three-mesh-bvh/src/gpu/index.js';
+import {
+	ndcToCameraRay,
+	intersectsTriangle,
+	intersectsBoundsBVH2,
+	bvh2NodeStruct,
+	intersectionResultStruct,
+	constants,
+} from 'three-mesh-bvh/webgpu';
+
+const params = {
+	pause: false,
+	rebuildEveryFrame: true,
+	useRefit: true,
+	useGpuTimestamps: false,
+	exposure: 1.0,
+	sunAzimuth: 35.0,
+	sunElevation: 32.0,
+	sunTemperature: 5600.0,
+	sunBrightness: 1.8,
+	resolutionScale: 0.5,
+	smoothNormals: true,
+	skeletonHelper: false,
+	floorY: 0.12,
+	walkSpeed: - 2.9,
+	maxBounces: 3,
+	samples: 1,
+};
+
+let renderer, camera, scene, helperScene, gui, stats, clock, controls;
+let mixer, animationAction, skinnedMeshes, skeletonHelper, model;
+let outputContainer;
+
+// GPU BVH
+let gpuBVH = null;
+let device = null;
+let hasTimestampQuery = false;
+
+// Path tracing
+let fsQuad, fsMaterial, computeKernel, presentKernel;
+let outputTex, radianceTex, guideTex, hitPosTex;
+let dispatchSize = [];
+let renderWidth = 1;
+let renderHeight = 1;
+const WORKGROUP_SIZE = [ 8, 8, 1 ];
+let presentShaderParams = null;
+
+// Geometry buffers (updated each frame)
+let indexArray = null;
+let triCount = 0;
+
+// GPU Skinning buffers and compute kernel
+let gpuSkinningKernel = null;
+let skinningBuffers = null; // { srcPositions, srcNormals, boneIndices, boneWeights, boneMatrices, dstPositions, dstNormals }
+let totalVertexCount = 0;
+let meshVertexOffsets = []; // Track where each mesh's vertices start in the merged buffer
+
+// GPU buffers for direct GPU→GPU pipeline (no CPU readback)
+let gpuIndexBuffer = null; // Static GPU index buffer for BVH builder
+let gpuPositionBuffer = null; // Skinning output GPU buffer (positions, vec4f)
+
+// TSL storage buffers (need to be recreated when BVH changes)
+let geom_index, geom_position, geom_normals, bvh2Nodes, rootIndexBuffer;
+let computeShaderParams = null;
+
+// Timing stats
+let avgEncodeTime = 0;
+let avgSkinTime = 0;
+let frameCount = 0;
+let buildInProgress = false;
+const sunDirectionVec = new THREE.Vector3();
+const sunColorVec = new THREE.Vector3();
+const sunTempColor = new THREE.Color();
+
+// BVH buffer capacity tracking (for GPU→GPU copy without readback)
+let bvhBufferCapacity = 0;
+
+function createStorageTexture( width, height, type ) {
+
+	const tex = new StorageTexture( width, height );
+	tex.format = THREE.RGBAFormat;
+	tex.type = type;
+	tex.magFilter = THREE.LinearFilter;
+	return tex;
+
+}
+
+function disposeTexturesWhenQueueIdle( textures ) {
+
+	const staleTextures = textures.filter( ( tex ) => tex !== undefined && tex !== null );
+	if ( staleTextures.length === 0 ) {
+
+		return;
+
+	}
+
+	const disposeNow = () => {
+
+		for ( const tex of staleTextures ) {
+
+			tex.dispose();
+
+		}
+
+	};
+
+	if ( device && device.queue && device.queue.onSubmittedWorkDone ) {
+
+		device.queue.onSubmittedWorkDone().then( disposeNow ).catch( disposeNow );
+
+	} else {
+
+		disposeNow();
+
+	}
+
+}
+
+function sunColorFromTemperature( kelvin, out = sunColorVec ) {
+
+	const t = THREE.MathUtils.clamp( kelvin, 1000.0, 40000.0 ) / 100.0;
+	let r = 255.0;
+	let g = 255.0;
+	let b = 255.0;
+
+	if ( t > 66.0 ) {
+
+		r = 329.698727446 * Math.pow( t - 60.0, - 0.1332047592 );
+		g = 288.1221695283 * Math.pow( t - 60.0, - 0.0755148492 );
+
+	} else {
+
+		g = 99.4708025861 * Math.log( Math.max( t, 1.0 ) ) - 161.1195681661;
+
+	}
+
+	if ( t < 66.0 ) {
+
+		if ( t <= 19.0 ) {
+
+			b = 0.0;
+
+		} else {
+
+			b = 138.5177312231 * Math.log( Math.max( t - 10.0, 1.0 ) ) - 305.0447927307;
+
+		}
+
+	}
+
+	sunTempColor.setRGB(
+		THREE.MathUtils.clamp( r, 0.0, 255.0 ) / 255.0,
+		THREE.MathUtils.clamp( g, 0.0, 255.0 ) / 255.0,
+		THREE.MathUtils.clamp( b, 0.0, 255.0 ) / 255.0,
+	).convertSRGBToLinear();
+	out.set( sunTempColor.r, sunTempColor.g, sunTempColor.b );
+	return out;
+
+}
+
+function sunDirectionFromAngles( azimuthDeg, elevationDeg, out = sunDirectionVec ) {
+
+	const azimuth = THREE.MathUtils.degToRad( azimuthDeg );
+	const elevation = THREE.MathUtils.degToRad( elevationDeg );
+	const cosEl = Math.cos( elevation );
+	out.set(
+		Math.sin( azimuth ) * cosEl,
+		Math.sin( elevation ),
+		Math.cos( azimuth ) * cosEl,
+	);
+	if ( out.lengthSq() < 1e-8 ) {
+
+		out.set( 0.0, 1.0, 0.0 );
+
+	} else {
+
+		out.normalize();
+
+	}
+
+	return out;
+
+}
+
+init();
+
+async function init() {
+
+	outputContainer = document.getElementById( 'output' );
+	outputContainer.textContent = 'Initializing WebGPU...';
+
+	// Request GPU adapter and device
+	const adapter = await navigator.gpu.requestAdapter();
+	if ( ! adapter ) {
+
+		outputContainer.textContent = 'WebGPU not supported';
+		return;
+
+	}
+
+	const requiredFeatures = [];
+	if ( adapter.features.has( 'timestamp-query' ) ) {
+
+		requiredFeatures.push( 'timestamp-query' );
+		hasTimestampQuery = true;
+
+	}
+
+	if ( adapter.features.has( 'subgroups' ) ) {
+
+		requiredFeatures.push( 'subgroups' );
+
+	}
+
+	device = await adapter.requestDevice( {
+		requiredFeatures,
+		requiredLimits: {
+			maxStorageBufferBindingSize: adapter.limits.maxStorageBufferBindingSize,
+			maxStorageBuffersPerShaderStage: 10,
+		},
+	} );
+
+	// Renderer
+	renderer = new WebGPURenderer( {
+		canvas: document.createElement( 'canvas' ),
+		antialias: true,
+		forceWebGL: false,
+		device: device,
+	} );
+
+	if ( renderer.init ) {
+
+		await renderer.init();
+
+	}
+
+	renderer.setPixelRatio( window.devicePixelRatio );
+	renderer.setClearColor( 0x111111 );
+	renderer.setSize( window.innerWidth, window.innerHeight );
+	renderer.outputColorSpace = THREE.SRGBColorSpace;
+	document.body.appendChild( renderer.domElement );
+
+	// Scene
+	scene = new THREE.Scene();
+	helperScene = new THREE.Scene();
+
+	const light = new THREE.DirectionalLight( 0xffffff, 3 );
+	light.position.set( 5, 5, 2.5 );
+	scene.add( light );
+	scene.add( new THREE.AmbientLight( 0xb0bec5, 2.4 ) );
+
+	// Camera
+	camera = new THREE.PerspectiveCamera( 75, window.innerWidth / window.innerHeight, 0.1, 100 );
+	camera.position.set( 6.5, 2.5, 6.5 );
+	camera.updateProjectionMatrix();
+
+	controls = new OrbitControls( camera, renderer.domElement );
+	clock = new THREE.Clock();
+
+	// Stats
+	stats = new Stats();
+	document.body.appendChild( stats.dom );
+
+	// GPU BVH builder
+	const sorterType = requiredFeatures.includes( 'subgroups' ) ? SorterType.ONESWEEP : SorterType.BUILTIN;
+	gpuBVH = new GPUMeshBVH( device, { sorterType } );
+
+	outputContainer.textContent = 'Loading model...';
+
+	// Load T-Rex model
+	new GLTFLoader().load(
+		'https://raw.githubusercontent.com/gkjohnson/3d-demo-data/main/models/trex/scene.gltf',
+		async ( gltf ) => {
+
+			model = gltf.scene;
+
+			// Collect all skinned meshes
+			skinnedMeshes = [];
+			console.log( '=== Meshes in T-Rex model ===' );
+			model.traverse( ( object ) => {
+
+				if ( object.isMesh ) {
+
+					const type = object.isSkinnedMesh ? 'SkinnedMesh' : 'Mesh';
+					const meshTriCount = object.geometry.index
+						? object.geometry.index.count / 3
+						: object.geometry.attributes.position.count / 3;
+					console.log( `  ${type}: "${object.name}" - ${meshTriCount} tris` );
+
+					if ( object.isSkinnedMesh ) {
+
+						object.frustumCulled = false;
+						skinnedMeshes.push( object );
+
+					}
+
+				}
+
+			} );
+			console.log( '=============================' );
+
+			if ( skinnedMeshes.length === 0 ) {
+
+				outputContainer.textContent = 'No skinned mesh found!';
+				return;
+
+			}
+
+			console.log( `Using ${skinnedMeshes.length} skinned meshes` );
+
+			model.updateMatrixWorld( true );
+			scene.add( model );
+
+			// Skeleton helper
+			skeletonHelper = new THREE.SkeletonHelper( model );
+			skeletonHelper.visible = params.skeletonHelper;
+			helperScene.add( skeletonHelper );
+			skeletonHelper.material.depthTest = false;
+
+			// Animation
+			mixer = new THREE.AnimationMixer( model );
+			animationAction = mixer.clipAction( gltf.animations[ 0 ] );
+			animationAction.play();
+
+			// Camera target
+			const box = new THREE.Box3().setFromObject( model );
+			box.getCenter( controls.target );
+			controls.target.z += 3;
+			controls.update();
+
+			// Initialize geometry arrays and build initial BVH
+			await initializeGeometry();
+
+			// Setup path tracing (needs BVH to be built first)
+			await setupPathTracing();
+
+			// GUI
+			setupGUI();
+
+			// Start render loop
+			renderer.setAnimationLoop( render );
+
+		}
+	);
+
+	window.addEventListener( 'resize', resize );
+
+}
+
+async function initializeGeometry() {
+
+	// Calculate total vertex count across all skinned meshes (expanded by index)
+	totalVertexCount = 0;
+	meshVertexOffsets = [];
+
+	for ( const mesh of skinnedMeshes ) {
+
+		meshVertexOffsets.push( totalVertexCount );
+		const geometry = mesh.geometry;
+		const indexAttr = geometry.index;
+		if ( indexAttr ) {
+
+			totalVertexCount += indexAttr.count;
+
+		} else {
+
+			totalVertexCount += geometry.attributes.position.count;
+
+		}
+
+	}
+
+	triCount = totalVertexCount / 3;
+	console.log( `Total vertices: ${totalVertexCount}, triangles: ${triCount}` );
+
+	// Allocate CPU arrays for collecting source data
+	// We use vec4 for positions/normals to match WGSL storage layout (16-byte stride)
+	const srcPositions = new Float32Array( totalVertexCount * 4 );
+	const srcNormals = new Float32Array( totalVertexCount * 4 );
+	const boneIndices = new Uint32Array( totalVertexCount * 4 );
+	const boneWeights = new Float32Array( totalVertexCount * 4 );
+
+	// Collect source data from all meshes (expanded by index)
+	let offset = 0;
+	for ( const mesh of skinnedMeshes ) {
+
+		const geometry = mesh.geometry;
+		const posAttr = geometry.attributes.position;
+		const normalAttr = geometry.attributes.normal;
+		const indexAttr = geometry.index;
+		const skinIndexAttr = geometry.attributes.skinIndex;
+		const skinWeightAttr = geometry.attributes.skinWeight;
+
+		const vertexCount = indexAttr ? indexAttr.count : posAttr.count;
+
+		for ( let i = 0; i < vertexCount; i ++ ) {
+
+			const srcIdx = indexAttr ? indexAttr.array[ i ] : i;
+
+			// Position (vec4, w=1 for position)
+			srcPositions[ offset * 4 + 0 ] = posAttr.getX( srcIdx );
+			srcPositions[ offset * 4 + 1 ] = posAttr.getY( srcIdx );
+			srcPositions[ offset * 4 + 2 ] = posAttr.getZ( srcIdx );
+			srcPositions[ offset * 4 + 3 ] = 1.0;
+
+			// Normal (vec4, w=0 for direction)
+			srcNormals[ offset * 4 + 0 ] = normalAttr.getX( srcIdx );
+			srcNormals[ offset * 4 + 1 ] = normalAttr.getY( srcIdx );
+			srcNormals[ offset * 4 + 2 ] = normalAttr.getZ( srcIdx );
+			srcNormals[ offset * 4 + 3 ] = 0.0;
+
+			// Bone indices (uvec4)
+			boneIndices[ offset * 4 + 0 ] = skinIndexAttr.getX( srcIdx );
+			boneIndices[ offset * 4 + 1 ] = skinIndexAttr.getY( srcIdx );
+			boneIndices[ offset * 4 + 2 ] = skinIndexAttr.getZ( srcIdx );
+			boneIndices[ offset * 4 + 3 ] = skinIndexAttr.getW( srcIdx );
+
+			// Bone weights (vec4)
+			boneWeights[ offset * 4 + 0 ] = skinWeightAttr.getX( srcIdx );
+			boneWeights[ offset * 4 + 1 ] = skinWeightAttr.getY( srcIdx );
+			boneWeights[ offset * 4 + 2 ] = skinWeightAttr.getZ( srcIdx );
+			boneWeights[ offset * 4 + 3 ] = skinWeightAttr.getW( srcIdx );
+
+			offset ++;
+
+		}
+
+	}
+
+	// Get bone count from first skeleton (all meshes share the same skeleton)
+	const skeleton = skinnedMeshes[ 0 ].skeleton;
+	const boneCount = skeleton.bones.length;
+	console.log( `Bone count: ${boneCount}` );
+
+	// Allocate bone matrices array (mat4x4 = 16 floats per bone)
+	const boneMatricesArray = new Float32Array( boneCount * 16 );
+
+	// Output arrays (vec4 layout for proper WGSL alignment)
+	const dstPositions = new Float32Array( totalVertexCount * 4 );
+	const dstNormals = new Float32Array( totalVertexCount * 4 );
+
+	// Create GPU storage buffers
+	skinningBuffers = {
+		srcPositions: new StorageBufferAttribute( srcPositions, 4 ),
+		srcNormals: new StorageBufferAttribute( srcNormals, 4 ),
+		boneIndices: new StorageBufferAttribute( boneIndices, 4 ),
+		boneWeights: new StorageBufferAttribute( boneWeights, 4 ),
+		boneMatrices: new StorageBufferAttribute( boneMatricesArray, 16 ),
+		dstPositions: new StorageBufferAttribute( dstPositions, 4 ),
+		dstNormals: new StorageBufferAttribute( dstNormals, 4 ),
+		boneCount: boneCount,
+	};
+
+	// Create sequential index for merged geometry
+	indexArray = new Uint32Array( totalVertexCount );
+	for ( let i = 0; i < totalVertexCount; i ++ ) {
+
+		indexArray[ i ] = i;
+
+	}
+
+	// Create GPU skinning compute shader
+	await setupGPUSkinning();
+
+	// Run initial GPU skinning
+	await runGPUSkinning();
+
+	// Create static GPU index buffer for BVH builder (STORAGE for BVH, COPY_DST for upload)
+	gpuIndexBuffer = device.createBuffer( {
+		size: indexArray.byteLength,
+		usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+	} );
+	device.queue.writeBuffer( gpuIndexBuffer, 0, indexArray );
+
+	// Get skinning output GPU buffers directly (vec4f layout, stride=4)
+	const backend = renderer.backend;
+	gpuPositionBuffer = backend.get( skinningBuffers.dstPositions ).buffer;
+
+	// Build initial BVH directly from GPU skinning output (no CPU readback!)
+	outputContainer.textContent = `Warming up GPU BVH (${triCount} tris)...`;
+	await gpuBVH.buildAsyncFromGPUBuffers( {
+		positionBuffer: gpuPositionBuffer,
+		indexBuffer: gpuIndexBuffer,
+		primCount: triCount,
+		positionStride: 4,
+	} );
+
+	outputContainer.textContent = 'Ready!';
+
+}
+
+async function setupGPUSkinning() {
+
+	const SKIN_WORKGROUP_SIZE = 256;
+
+	// GPU Skinning compute shader
+	// Each thread processes one vertex
+	const skinningShader = wgslFn( /* wgsl */`
+		fn compute(
+			srcPositions: ptr<storage, array<vec4f>, read>,
+			srcNormals: ptr<storage, array<vec4f>, read>,
+			boneIndices: ptr<storage, array<vec4u>, read>,
+			boneWeights: ptr<storage, array<vec4f>, read>,
+			boneMatrices: ptr<storage, array<mat4x4f>, read>,
+			bindMatrix: mat4x4f,
+			bindMatrixInverse: mat4x4f,
+			vertexCount: u32,
+			dstPositions: ptr<storage, array<vec4f>, read_write>,
+			dstNormals: ptr<storage, array<vec4f>, read_write>,
+			workgroupId: vec3u,
+			localId: vec3u,
+		) -> void {
+			let globalId = workgroupId.x * 256u + localId.x;
+			if ( globalId >= vertexCount ) {
+				return;
+			}
+
+			// Read source data
+			let srcPos = srcPositions[globalId];
+			let srcNorm = srcNormals[globalId];
+			let indices = boneIndices[globalId];
+			let weights = boneWeights[globalId];
+
+			// Transform source position/normal by bind matrix
+			let boundPos = bindMatrix * srcPos;
+			let boundNorm = bindMatrix * vec4f(srcNorm.xyz, 0.0);
+
+			// Apply weighted bone transforms
+			var skinnedPos = vec4f(0.0, 0.0, 0.0, 0.0);
+			var skinnedNorm = vec4f(0.0, 0.0, 0.0, 0.0);
+
+			// Bone 0
+			if ( weights.x > 0.0 ) {
+				let boneMat = boneMatrices[indices.x];
+				skinnedPos += weights.x * (boneMat * boundPos);
+				skinnedNorm += weights.x * (boneMat * boundNorm);
+			}
+
+			// Bone 1
+			if ( weights.y > 0.0 ) {
+				let boneMat = boneMatrices[indices.y];
+				skinnedPos += weights.y * (boneMat * boundPos);
+				skinnedNorm += weights.y * (boneMat * boundNorm);
+			}
+
+			// Bone 2
+			if ( weights.z > 0.0 ) {
+				let boneMat = boneMatrices[indices.z];
+				skinnedPos += weights.z * (boneMat * boundPos);
+				skinnedNorm += weights.z * (boneMat * boundNorm);
+			}
+
+			// Bone 3
+			if ( weights.w > 0.0 ) {
+				let boneMat = boneMatrices[indices.w];
+				skinnedPos += weights.w * (boneMat * boundPos);
+				skinnedNorm += weights.w * (boneMat * boundNorm);
+			}
+
+			// Apply bind matrix inverse
+			skinnedPos = bindMatrixInverse * skinnedPos;
+			skinnedNorm = bindMatrixInverse * skinnedNorm;
+
+			// Normalize the normal
+			let finalNorm = normalize(skinnedNorm.xyz);
+
+			// Write output
+			dstPositions[globalId] = vec4f(skinnedPos.xyz, 1.0);
+			dstNormals[globalId] = vec4f(finalNorm, 0.0);
+		}
+	` );
+
+	// Create compute kernel params
+	const skinningParams = {
+		srcPositions: storage( skinningBuffers.srcPositions, 'vec4f', totalVertexCount ).toReadOnly(),
+		srcNormals: storage( skinningBuffers.srcNormals, 'vec4f', totalVertexCount ).toReadOnly(),
+		boneIndices: storage( skinningBuffers.boneIndices, 'vec4<u32>', totalVertexCount ).toReadOnly(),
+		boneWeights: storage( skinningBuffers.boneWeights, 'vec4f', totalVertexCount ).toReadOnly(),
+		boneMatrices: storage( skinningBuffers.boneMatrices, 'mat4x4f', skinningBuffers.boneCount ).toReadOnly(),
+		bindMatrix: uniform( new THREE.Matrix4() ),
+		bindMatrixInverse: uniform( new THREE.Matrix4() ),
+		vertexCount: uniform( totalVertexCount ),
+		dstPositions: storage( skinningBuffers.dstPositions, 'vec4f', totalVertexCount ),
+		dstNormals: storage( skinningBuffers.dstNormals, 'vec4f', totalVertexCount ),
+		workgroupId: workgroupId,
+		localId: localId,
+	};
+
+	skinningBuffers.params = skinningParams;
+
+	gpuSkinningKernel = skinningShader( skinningParams ).computeKernel( [ SKIN_WORKGROUP_SIZE, 1, 1 ] );
+
+}
+
+async function runGPUSkinning() {
+
+	// Update skeleton and bone matrices
+	const mesh = skinnedMeshes[ 0 ];
+	const skeleton = mesh.skeleton;
+	skeleton.update();
+
+	// Upload bone matrices to GPU
+	skinningBuffers.boneMatrices.array.set( skeleton.boneMatrices );
+	skinningBuffers.boneMatrices.needsUpdate = true;
+
+	// Set bind matrices (use first mesh - they typically share the same skeleton)
+	skinningBuffers.params.bindMatrix.value.copy( mesh.bindMatrix );
+	skinningBuffers.params.bindMatrixInverse.value.copy( mesh.bindMatrixInverse );
+
+	// Dispatch compute shader
+	const workgroupCount = Math.ceil( totalVertexCount / 256 );
+	renderer.compute( gpuSkinningKernel, [ workgroupCount, 1, 1 ] );
+
+}
+
+async function setupPathTracing() {
+
+	// Create initial storage buffers
+	// Index stays as uvec3 (used by BVH traversal)
+	geom_index = new StorageBufferAttribute( indexArray, 3 );
+
+	// Positions and normals: use skinning output directly (vec4f layout → array<f32>, stride 4)
+	// Use the skinning output StorageBufferAttributes directly - they point to the GPU buffers
+	geom_position = skinningBuffers.dstPositions;
+	geom_normals = skinningBuffers.dstNormals;
+
+	// Create BVH storage buffer with capacity for growth (avoid reallocations)
+	// Use maxNodeCount (2 * primCount) for capacity since we won't know exact count
+	bvhBufferCapacity = gpuBVH.maxNodeCount;
+	const bvh2Array = new Float32Array( bvhBufferCapacity * 8 ); // 8 floats per node
+	bvh2Nodes = new StorageBufferAttribute( bvh2Array, 8 );
+
+	// Root index buffer - read on GPU to avoid CPU readback
+	// clusterIdx[0] contains the root index after build
+	rootIndexBuffer = new StorageBufferAttribute( new Uint32Array( [ 0 ] ), 1 );
+
+	// Ensure render targets exist with the current viewport size before kernel creation.
+	resize();
+
+	computeShaderParams = {
+		outputTex: textureStore( radianceTex ),
+		guideTex: textureStore( guideTex ),
+		hitPosTex: textureStore( hitPosTex ),
+		smoothNormals: uniform( 1 ),
+		inverseProjectionMatrix: uniform( new THREE.Matrix4() ),
+		cameraToWorldMatrix: uniform( new THREE.Matrix4() ),
+		worldToModelMatrix: uniform( new THREE.Matrix4() ),
+		modelToWorldMatrix: uniform( new THREE.Matrix4() ),
+		floorY: uniform( 0.12 ),
+		time: uniform( 0.0 ),
+		walkSpeed: uniform( params.walkSpeed ),
+		sunDirection: uniform( new THREE.Vector3( 0.0, 1.0, 0.0 ) ),
+		sunColor: uniform( new THREE.Vector3( 1.0, 1.0, 1.0 ) ),
+		frameCount: uniform( 0 ),
+		samples: uniform( 1 ),
+		geom_index: storage( geom_index, 'uvec3', geom_index.count ).toReadOnly(),
+		geom_position: storage( geom_position, 'f32', totalVertexCount * 4 ).toReadOnly(),
+		geom_normals: storage( geom_normals, 'f32', totalVertexCount * 4 ).toReadOnly(),
+		bvh: storage( bvh2Nodes, 'BVH2Node', bvhBufferCapacity ).toReadOnly(),
+		rootIndexBuf: storage( rootIndexBuffer, 'u32', 1 ).toReadOnly(),
+		workgroupSize: uniform( new THREE.Vector3() ),
+		workgroupId: workgroupId,
+		localId: localId
+	};
+
+	const utils = wgsl( /* wgsl */ `
+		fn hash( seed: u32 ) -> u32 {
+			// Simple hash for random numbers
+
+			var s = seed;
+			s = s ^ ( s >> 16u );
+			s = s * 0x85ebca6bu;
+			s = s ^ ( s >> 13u );
+			s = s * 0xc2b2ae35u;
+			s = s ^ ( s >> 16u );
+			return s;
+		}
+
+		fn randomFloat( seed: ptr<function, u32> ) -> f32 {
+			*seed = hash( *seed );
+			return f32( *seed ) / f32( 0xffffffffu );
+		}
+
+		// Cosine-weighted hemisphere sampling for diffuse
+		fn cosineSampleHemisphere( normal: vec3f, seed: ptr<function, u32> ) -> vec3f {
+			let r1 = randomFloat( seed );
+			let r2 = randomFloat( seed );
+			let phi = 2.0 * 3.14159265 * r1;
+			let cosTheta = sqrt( r2 );
+			let sinTheta = sqrt( 1.0 - r2 );
+
+			// Create orthonormal basis
+			var tangent: vec3f;
+			if ( abs( normal.x ) > 0.9 ) {
+				tangent = normalize( cross( normal, vec3f( 0.0, 1.0, 0.0 ) ) );
+			} else {
+				tangent = normalize( cross( normal, vec3f( 1.0, 0.0, 0.0 ) ) );
+			}
+			let bitangent = cross( normal, tangent );
+
+			return normalize(
+				tangent * cos( phi ) * sinTheta +
+				bitangent * sin( phi ) * sinTheta +
+				normal * cosTheta
+			);
+		}
+
+		// Box intersection (axis-aligned, in world space)
+		fn intersectBox( rayOrigin: vec3f, rayDir: vec3f, boxMin: vec3f, boxMax: vec3f ) -> f32 {
+			let invDir = 1.0 / rayDir;
+			let t1 = ( boxMin - rayOrigin ) * invDir;
+			let t2 = ( boxMax - rayOrigin ) * invDir;
+			let tMin = min( t1, t2 );
+			let tMax = max( t1, t2 );
+			let tEnter = max( max( tMin.x, tMin.y ), tMin.z );
+			let tExit = min( min( tMax.x, tMax.y ), tMax.z );
+			if ( tEnter > tExit || tExit < 0.0 ) {
+				return -1.0;
+			}
+			return select( tExit, tEnter, tEnter > 0.0 );
+		}
+
+		fn getBoxNormal( hitPoint: vec3f, boxMin: vec3f, boxMax: vec3f ) -> vec3f {
+			let center = ( boxMin + boxMax ) * 0.5;
+			let halfSize = ( boxMax - boxMin ) * 0.5;
+			let local = hitPoint - center;
+			let d = abs( local ) - halfSize;
+			let maxAxis = max( max( d.x, d.y ), d.z );
+			if ( abs( d.x - maxAxis ) < 0.001 ) {
+				return vec3f( sign( local.x ), 0.0, 0.0 );
+			} else if ( abs( d.y - maxAxis ) < 0.001 ) {
+				return vec3f( 0.0, sign( local.y ), 0.0 );
+			}
+			return vec3f( 0.0, 0.0, sign( local.z ) );
+		}
+
+		// Use fract-based wrapping to handle negative moveOffset properly
+		fn wrapZ( base: f32, offset: f32, period: f32, range: f32 ) -> f32 {
+			return base + ( ( offset % period ) + period ) % period - range;
+		}
+
+		// Load vertex position from f32 array with stride 4 (vec4f layout)
+		fn loadVertexPosition( positions: ptr<storage, array<f32>, read>, idx: u32 ) -> vec3f {
+			let base = idx * 4u;
+			return vec3f( positions[base], positions[base + 1u], positions[base + 2u] );
+		}
+
+		// Get interpolated vertex attribute from f32 array with stride 4
+		fn getVertexAttributeF32( barycoord: vec3f, indices: vec3u, data: ptr<storage, array<f32>, read> ) -> vec3f {
+			let b0 = indices.x * 4u;
+			let b1 = indices.y * 4u;
+			let b2 = indices.z * 4u;
+			let v0 = vec3f( data[b0], data[b0 + 1u], data[b0 + 2u] );
+			let v1 = vec3f( data[b1], data[b1 + 1u], data[b1 + 2u] );
+			let v2 = vec3f( data[b2], data[b2 + 1u], data[b2 + 2u] );
+			return v0 * barycoord.x + v1 * barycoord.y + v2 * barycoord.z;
+		}
+
+		// BVH2 traversal with stride-4 position loading (array<f32> instead of array<vec3f>)
+		fn bvh2IntersectFirstHitF32(
+			bvh_index: ptr<storage, array<vec3u>, read>,
+			bvh_position: ptr<storage, array<f32>, read>,
+			bvh: ptr<storage, array<BVH2Node>, read>,
+			ray: Ray,
+			rootIndex: u32,
+		) -> IntersectionResult {
+
+			const INVALID_IDX = 0xFFFFFFFFu;
+
+			var pointer = 0;
+			var stack: array<u32, BVH_STACK_DEPTH>;
+			stack[ 0 ] = rootIndex;
+
+			var bestHit: IntersectionResult;
+			bestHit.didHit = false;
+			bestHit.dist = INFINITY;
+
+			loop {
+				if ( pointer < 0 || pointer >= i32( BVH_STACK_DEPTH ) ) {
+					break;
+				}
+
+				let currNodeIndex = stack[ pointer ];
+				let node = bvh[ currNodeIndex ];
+				pointer = pointer - 1;
+
+				var boundsHitDistance: f32 = 0.0;
+				if ( ! intersectsBoundsBVH2( ray, node.boundsMin, node.boundsMax, &boundsHitDistance ) || boundsHitDistance > bestHit.dist ) {
+					continue;
+				}
+
+				let isLeaf = node.leftChild == INVALID_IDX;
+
+				if ( isLeaf ) {
+					let triIndex = node.rightChild;
+					let indices = bvh_index[ triIndex ];
+					let a = loadVertexPosition( bvh_position, indices.x );
+					let b = loadVertexPosition( bvh_position, indices.y );
+					let c = loadVertexPosition( bvh_position, indices.z );
+
+					var triResult = intersectsTriangle( ray, a, b, c );
+					if ( triResult.didHit && triResult.dist < bestHit.dist ) {
+						bestHit = triResult;
+						bestHit.indices = vec4u( indices.xyz, triIndex );
+					}
+				} else {
+					let leftIndex = node.leftChild;
+					let rightIndex = node.rightChild;
+
+					let extent = node.boundsMax - node.boundsMin;
+					var splitAxis = 0u;
+					if ( extent.y > extent.x && extent.y > extent.z ) {
+						splitAxis = 1u;
+					} else if ( extent.z > extent.x ) {
+						splitAxis = 2u;
+					}
+
+					let leftToRight = ray.direction[ splitAxis ] >= 0.0;
+					let c1 = select( rightIndex, leftIndex, leftToRight );
+					let c2 = select( leftIndex, rightIndex, leftToRight );
+
+					pointer = pointer + 1;
+					stack[ pointer ] = c2;
+					pointer = pointer + 1;
+					stack[ pointer ] = c1;
+				}
+			}
+
+			return bestHit;
+		}
+
+	` );
+
+	const computeShader = wgslFn( /* wgsl */`
+			fn compute(
+				outputTex: texture_storage_2d<rgba16float, write>,
+				guideTex: texture_storage_2d<rgba16float, write>,
+				hitPosTex: texture_storage_2d<rgba16float, write>,
+				smoothNormals: u32,
+				inverseProjectionMatrix: mat4x4f,
+			cameraToWorldMatrix: mat4x4f,
+			worldToModelMatrix: mat4x4f,
+				modelToWorldMatrix: mat4x4f,
+				floorY: f32,
+				time: f32,
+				walkSpeed: f32,
+				sunDirection: vec3f,
+				sunColor: vec3f,
+				frameCount: u32,
+				samples: u32,
+			geom_position: ptr<storage, array<f32>, read>,
+			geom_index: ptr<storage, array<vec3u>, read>,
+			geom_normals: ptr<storage, array<f32>, read>,
+			bvh: ptr<storage, array<BVH2Node>, read>,
+			rootIndexBuf: ptr<storage, array<u32>, read>,
+			workgroupSize: vec3u,
+			workgroupId: vec3u,
+			localId: vec3u
+		) -> void {
+			let dimensions = textureDimensions( outputTex );
+			let indexUV = workgroupSize.xy * workgroupId.xy + localId.xy;
+			if ( indexUV.x >= dimensions.x || indexUV.y >= dimensions.y ) { return; }
+
+			let uv = vec2f( indexUV ) / vec2f( dimensions );
+			let ndc = uv * 2.0 - vec2f( 1.0 );
+			let rootIndex = rootIndexBuf[0];
+
+			// Initialize RNG with pixel position and frame
+			var rngSeed = indexUV.x + indexUV.y * dimensions.x + frameCount * dimensions.x * dimensions.y;
+
+			// Create world-space ray
+			var worldRay = ndcToCameraRay( ndc, cameraToWorldMatrix * inverseProjectionMatrix );
+			let cameraToModelMatrix = worldToModelMatrix * cameraToWorldMatrix;
+
+				// Lighting
+				let sunDir = normalizeSafe( sunDirection, vec3f( 0.0, 1.0, 0.0 ) );
+
+			// Moving offset for floor and boxes
+			let moveOffset = time * walkSpeed;
+
+
+			// Define colorful boxes with varied materials
+			// Format: position, size, color, metalness (0=diffuse, 1=mirror)
+
+			// Ground-level boxes (left side)
+			let z0 = wrapZ( 0.0, moveOffset, 30.0, 15.0 );
+			let box0Min = vec3f( -6.0, floorY, z0 - 1.5 );
+			let box0Max = vec3f( -4.0, floorY + 2.5, z0 + 1.5 );
+			let box0Color = vec3f( 0.9, 0.15, 0.15 ); // Red
+			let box0Metal = 0.1;
+
+			let z1 = wrapZ( 8.0, moveOffset, 25.0, 12.0 );
+			let box1Min = vec3f( -7.0, floorY, z1 - 1.0 );
+			let box1Max = vec3f( -5.0, floorY + 1.8, z1 + 1.0 );
+			let box1Color = vec3f( 0.15, 0.8, 0.2 ); // Green
+			let box1Metal = 0.2;
+
+			let z2 = wrapZ( -6.0, moveOffset, 35.0, 20.0 );
+			let box2Min = vec3f( -8.0, floorY, z2 - 1.2 );
+			let box2Max = vec3f( -5.5, floorY + 3.5, z2 + 1.2 );
+			let box2Color = vec3f( 0.2, 0.3, 0.9 ); // Blue
+			let box2Metal = 0.6; // More reflective
+
+			// Ground-level boxes (right side)
+			let z3 = wrapZ( 3.0, moveOffset, 28.0, 14.0 );
+			let box3Min = vec3f( 4.0, floorY, z3 - 1.0 );
+			let box3Max = vec3f( 6.0, floorY + 2.0, z3 + 1.0 );
+			let box3Color = vec3f( 0.95, 0.8, 0.1 ); // Yellow
+			let box3Metal = 0.15;
+
+			let z4 = wrapZ( -4.0, moveOffset, 32.0, 18.0 );
+			let box4Min = vec3f( 5.5, floorY, z4 - 1.5 );
+			let box4Max = vec3f( 8.0, floorY + 3.0, z4 + 1.5 );
+			let box4Color = vec3f( 0.8, 0.2, 0.75 ); // Purple
+			let box4Metal = 0.4;
+
+			let z5 = wrapZ( 10.0, moveOffset, 26.0, 13.0 );
+			let box5Min = vec3f( 4.5, floorY, z5 - 0.8 );
+			let box5Max = vec3f( 6.0, floorY + 1.5, z5 + 0.8 );
+			let box5Color = vec3f( 0.1, 0.85, 0.85 ); // Cyan
+			let box5Metal = 0.25;
+
+			// Floating boxes (varied heights)
+			let z6 = wrapZ( 2.0, moveOffset, 24.0, 12.0 );
+			let box6Min = vec3f( -5.0, floorY + 2.5, z6 - 0.6 );
+			let box6Max = vec3f( -3.5, floorY + 4.0, z6 + 0.6 );
+			let box6Color = vec3f( 1.0, 0.5, 0.0 ); // Orange
+			let box6Metal = 0.8; // Highly reflective
+
+			let z7 = wrapZ( -3.0, moveOffset, 22.0, 11.0 );
+			let box7Min = vec3f( 3.0, floorY + 1.8, z7 - 0.7 );
+			let box7Max = vec3f( 4.5, floorY + 3.2, z7 + 0.7 );
+			let box7Color = vec3f( 0.95, 0.95, 0.95 ); // White/silver
+			let box7Metal = 0.95; // Almost mirror
+
+			let z8 = wrapZ( 6.0, moveOffset, 20.0, 10.0 );
+			let box8Min = vec3f( -3.0, floorY + 3.0, z8 - 0.5 );
+			let box8Max = vec3f( -1.5, floorY + 4.5, z8 + 0.5 );
+			let box8Color = vec3f( 0.3, 0.9, 0.5 ); // Mint
+			let box8Metal = 0.5;
+
+			let z9 = wrapZ( -8.0, moveOffset, 27.0, 15.0 );
+			let box9Min = vec3f( 2.0, floorY + 4.0, z9 - 0.8 );
+			let box9Max = vec3f( 4.0, floorY + 6.0, z9 + 0.8 );
+			let box9Color = vec3f( 0.9, 0.3, 0.4 ); // Coral
+			let box9Metal = 0.05; // Very matte
+
+				// Multi-sample path tracing
+				var totalRadiance = vec3f( 0.0 );
+				let baseWorldRay = ndcToCameraRay( ndc, cameraToWorldMatrix * inverseProjectionMatrix );
+				var firstHitNormal = vec3f( 0.0, 0.0, 0.0 );
+				var firstHitDepth = 0.0;
+				var firstHitPosition = vec3f( 0.0 );
+				var firstHitValid = false;
+
+			for ( var sampleIdx = 0u; sampleIdx < samples; sampleIdx++ ) {
+				// Reset for each sample
+				var throughput = vec3f( 1.0 );
+				var radiance = vec3f( 0.0 );
+				var worldRay = baseWorldRay;
+
+				// Normalize world ray direction for consistent distance comparisons
+				let worldRayDirLen = length( worldRay.direction );
+				worldRay.direction = worldRay.direction / worldRayDirLen;
+
+				// Update RNG seed for this sample
+				rngSeed = hash( rngSeed + sampleIdx * 12345u );
+
+				for ( var bounce = 0u; bounce < 4u; bounce++ ) {
+				var hitDist = 1e30f;  // World-space distance (not parametric t)
+				var hitNormal = vec3f( 0.0, 1.0, 0.0 );
+				var hitColor = vec3f( 0.5 );
+				var hitMetalness = 0.0;  // Material property for boxes
+				var hitType = 0u; // 0=miss, 1=dino, 2=floor, 3=box
+
+				// === Test dinosaur (BVH in model space) ===
+				var modelRay: Ray;
+				modelRay.origin = ( worldToModelMatrix * vec4f( worldRay.origin, 1.0 ) ).xyz;
+				modelRay.direction = ( worldToModelMatrix * vec4f( worldRay.direction, 0.0 ) ).xyz;
+				// Compute scale factor between model and world space
+				let modelDirLen = length( modelRay.direction );
+				modelRay.direction = modelRay.direction / modelDirLen;
+
+				let dinoHit = bvh2IntersectFirstHitF32( geom_index, geom_position, bvh, modelRay, rootIndex );
+				if ( dinoHit.didHit ) {
+					// Convert model-space distance to world-space distance
+					let dinoWorldDist = dinoHit.dist / modelDirLen;
+					if ( dinoWorldDist < hitDist && dinoWorldDist > 0.001 ) {
+						hitDist = dinoWorldDist;
+						var n = select(
+							dinoHit.normal,
+							normalize( getVertexAttributeF32( dinoHit.barycoord, dinoHit.indices.xyz, geom_normals ) ),
+							smoothNormals > 0u
+						);
+						hitNormal = normalize( ( modelToWorldMatrix * vec4f( n, 0.0 ) ).xyz );
+						hitColor = vec3f( 0.85, 0.85, 0.85 ); // White albedo
+						hitMetalness = 0.25; // Slightly reflective
+						hitType = 1u;
+					}
+				}
+
+				// === Test floor (world space, normalized ray means t = distance) ===
+				if ( worldRay.direction.y < -0.0001 && worldRay.origin.y > floorY ) {
+					let floorDist = ( floorY - worldRay.origin.y ) / worldRay.direction.y;
+					if ( floorDist > 0.001 && floorDist < hitDist ) {
+						hitDist = floorDist;
+						hitNormal = vec3f( 0.0, 1.0, 0.0 );
+						let floorHitPoint = worldRay.origin + worldRay.direction * floorDist;
+						// Moving checkerboard - use fract to handle negative coords properly
+						let cx = floor( floorHitPoint.x * 0.3 + 1000.0 );  // Offset to avoid negative
+						let cz = floor( ( floorHitPoint.z - moveOffset ) * 0.3 + 1000.0 );
+						let checker = ( i32( cx ) + i32( cz ) ) % 2;
+						hitColor = select( vec3f( 0.3, 0.3, 0.32 ), vec3f( 0.5, 0.5, 0.52 ), checker == 1 );
+						hitType = 2u;
+					}
+				}
+
+				// === Test boxes (unrolled, world space) ===
+				var boxDist: f32;
+				var boxHitPoint: vec3f;
+
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box0Min, box0Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box0Min, box0Max ); hitColor = box0Color; hitMetalness = box0Metal; hitType = 3u;
+				}
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box1Min, box1Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box1Min, box1Max ); hitColor = box1Color; hitMetalness = box1Metal; hitType = 3u;
+				}
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box2Min, box2Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box2Min, box2Max ); hitColor = box2Color; hitMetalness = box2Metal; hitType = 3u;
+				}
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box3Min, box3Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box3Min, box3Max ); hitColor = box3Color; hitMetalness = box3Metal; hitType = 3u;
+				}
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box4Min, box4Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box4Min, box4Max ); hitColor = box4Color; hitMetalness = box4Metal; hitType = 3u;
+				}
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box5Min, box5Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box5Min, box5Max ); hitColor = box5Color; hitMetalness = box5Metal; hitType = 3u;
+				}
+				// Floating boxes
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box6Min, box6Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box6Min, box6Max ); hitColor = box6Color; hitMetalness = box6Metal; hitType = 3u;
+				}
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box7Min, box7Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box7Min, box7Max ); hitColor = box7Color; hitMetalness = box7Metal; hitType = 3u;
+				}
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box8Min, box8Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box8Min, box8Max ); hitColor = box8Color; hitMetalness = box8Metal; hitType = 3u;
+				}
+				boxDist = intersectBox( worldRay.origin, worldRay.direction, box9Min, box9Max );
+				if ( boxDist > 0.001 && boxDist < hitDist ) {
+					hitDist = boxDist; boxHitPoint = worldRay.origin + worldRay.direction * boxDist;
+					hitNormal = getBoxNormal( boxHitPoint, box9Min, box9Max ); hitColor = box9Color; hitMetalness = box9Metal; hitType = 3u;
+				}
+
+					// === Process hit ===
+					if ( sampleIdx == 0u && bounce == 0u ) {
+						if ( hitType != 0u ) {
+
+							let hitPoint0 = worldRay.origin + worldRay.direction * hitDist;
+							firstHitNormal = normalize( hitNormal );
+							firstHitDepth = hitDist;
+							firstHitPosition = hitPoint0;
+							firstHitValid = true;
+						} else {
+
+							firstHitNormal = vec3f( 0.0, 0.0, 0.0 );
+							firstHitDepth = 0.0;
+							firstHitPosition = vec3f( 0.0 );
+							firstHitValid = false;
+						}
+					}
+
+					if ( hitType == 0u ) {
+						radiance += throughput * skyRadiance( worldRay.direction, sunDir, sunColor );
+						break;
+					}
+
+				let hitPoint = worldRay.origin + worldRay.direction * hitDist;
+
+				// Direct lighting with shadow ray
+				var directLight = vec3f( 0.0 );
+				var shadowRay: Ray;
+				shadowRay.origin = ( worldToModelMatrix * vec4f( hitPoint + hitNormal * 0.01, 1.0 ) ).xyz;
+				shadowRay.direction = normalize( ( worldToModelMatrix * vec4f( sunDir, 0.0 ) ).xyz );
+				let shadowHit = bvh2IntersectFirstHitF32( geom_index, geom_position, bvh, shadowRay, rootIndex );
+
+				var inShadow = shadowHit.didHit;
+
+				// Also check shadow against boxes (unrolled)
+				let shadowOrigin = hitPoint + hitNormal * 0.01;
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box0Min, box0Max ) > 0.0 ) { inShadow = true; }
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box1Min, box1Max ) > 0.0 ) { inShadow = true; }
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box2Min, box2Max ) > 0.0 ) { inShadow = true; }
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box3Min, box3Max ) > 0.0 ) { inShadow = true; }
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box4Min, box4Max ) > 0.0 ) { inShadow = true; }
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box5Min, box5Max ) > 0.0 ) { inShadow = true; }
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box6Min, box6Max ) > 0.0 ) { inShadow = true; }
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box7Min, box7Max ) > 0.0 ) { inShadow = true; }
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box8Min, box8Max ) > 0.0 ) { inShadow = true; }
+				if ( !inShadow && intersectBox( shadowOrigin, sunDir, box9Min, box9Max ) > 0.0 ) { inShadow = true; }
+
+				if ( !inShadow ) {
+					let NdotL = max( 0.0, dot( hitNormal, sunDir ) );
+					directLight = sunColor * NdotL;
+				}
+
+				// Add direct lighting contribution
+				radiance += throughput * hitColor * directLight;
+
+				// Russian roulette after 2 bounces
+				if ( bounce > 1u ) {
+					let p = max( max( throughput.x, throughput.y ), throughput.z );
+					if ( randomFloat( &rngSeed ) > p ) {
+						break;
+					}
+					throughput /= p;
+				}
+
+				// Bounce - objects with metalness get reflections
+				var bounceDir: vec3f;
+				if ( hitMetalness > 0.01 ) {
+					// Metallic surface: blend reflection and diffuse
+					let reflectDir = reflect( worldRay.direction, hitNormal );
+					let diffuseDir = cosineSampleHemisphere( hitNormal, &rngSeed );
+					// Probabilistic selection based on metalness
+					if ( randomFloat( &rngSeed ) < hitMetalness ) {
+						// Specular reflection (roughness based on inverse metalness)
+						let roughness = 0.1 * ( 1.0 - hitMetalness * 0.5 );
+						let roughDir = cosineSampleHemisphere( reflectDir, &rngSeed );
+						bounceDir = normalize( mix( reflectDir, roughDir, roughness ) );
+						// Metallic reflection tints with surface color
+						throughput *= mix( vec3f( 1.0 ), hitColor, hitMetalness );
+					} else {
+						// Diffuse
+						bounceDir = diffuseDir;
+						throughput *= hitColor;
+					}
+				} else {
+					// Floor and matte surfaces: pure diffuse
+					bounceDir = cosineSampleHemisphere( hitNormal, &rngSeed );
+					throughput *= hitColor;
+				}
+					worldRay.origin = hitPoint + hitNormal * 0.001;
+					worldRay.direction = bounceDir;
+				} // end bounce loop
+
+				totalRadiance += radiance;
+			} // end sample loop
+
+				// Average samples
+				var finalRadiance = totalRadiance / f32( samples );
+
+				textureStore( outputTex, indexUV, vec4f( finalRadiance, 1.0 ) );
+				textureStore( guideTex, indexUV, vec4f( firstHitNormal, firstHitDepth ) );
+				let hitMask = select( 0.0, 1.0, firstHitValid );
+				textureStore( hitPosTex, indexUV, vec4f( firstHitPosition, hitMask ) );
+			}
+			fn normalizeSafe( v: vec3f, fallbackDir: vec3f ) -> vec3f {
+				let lenSq = dot( v, v );
+				if ( lenSq <= 1e-8 ) {
+					return fallbackDir;
+				}
+				return v * inverseSqrt( lenSq );
+			}
+
+			fn vmfPdf( direction: vec3f, mu: vec3f, kappaInput: f32 ) -> f32 {
+				let kappa = clamp( kappaInput, 1e-3, 3000.0 );
+				let alignment = clamp( dot( mu, direction ), -1.0, 1.0 );
+				let norm = kappa / ( 6.28318530718 * max( 1.0 - exp( -2.0 * kappa ), 1e-6 ) );
+				return max( norm * exp( kappa * ( alignment - 1.0 ) ), 0.0 );
+			}
+
+			fn skyRadiance( dir: vec3f, sunDirection: vec3f, sunColor: vec3f ) -> vec3f {
+				let skyDir = normalize( dir );
+				let skyT = clamp( 0.5 * ( skyDir.y + 1.0 ), 0.0, 1.0 );
+				let baseSky = mix( vec3f( 0.02, 0.03, 0.05 ), vec3f( 0.12, 0.17, 0.26 ), skyT );
+				let sunDirSafe = normalizeSafe( sunDirection, vec3f( 0.0, 1.0, 0.0 ) );
+				let sunDot = 0.5 * ( 1.0 + dot( sunDirSafe, skyDir ) );
+				let broadLobe = 0.5 * pow( max( sunDot, 0.0 ), 4.0 );
+				let sharpLobe = 5.0 * vmfPdf( skyDir, sunDirSafe, 3000.0 );
+				return baseSky + max( sunColor, vec3f( 0.0 ) ) * ( broadLobe + sharpLobe );
+			}
+
+
+		`, [ ndcToCameraRay, intersectsTriangle, intersectsBoundsBVH2, bvh2NodeStruct, intersectionResultStruct, constants, utils ] );
+
+	computeKernel = computeShader( computeShaderParams ).computeKernel( WORKGROUP_SIZE );
+
+	const presentShader = wgslFn( /* wgsl */`
+		fn present(
+			inputTex: texture_2d<f32>,
+			outputTex: texture_storage_2d<rgba8unorm, write>,
+			exposure: f32,
+			workgroupSize: vec3u,
+			workgroupId: vec3u,
+			localId: vec3u
+		) -> void {
+			let dimensions = textureDimensions( outputTex );
+			let indexUV = workgroupSize.xy * workgroupId.xy + localId.xy;
+			if ( indexUV.x >= dimensions.x || indexUV.y >= dimensions.y ) { return; }
+
+			var color = textureLoad( inputTex, vec2i( indexUV ), 0 ).rgb * exposure;
+			color = color / ( color + vec3f( 1.0 ) ); // Reinhard tone map
+			color = pow( color, vec3f( 1.0 / 2.2 ) ); // Gamma
+			textureStore( outputTex, indexUV, vec4f( color, 1.0 ) );
+		}
+	` );
+
+	presentShaderParams = {
+		inputTex: texture( radianceTex ),
+		outputTex: textureStore( outputTex ),
+		exposure: uniform( params.exposure ),
+		workgroupSize: uniform( new THREE.Vector3() ),
+		workgroupId: workgroupId,
+		localId: localId
+	};
+
+	presentKernel = presentShader( presentShaderParams ).computeKernel( WORKGROUP_SIZE );
+
+	// Fullscreen quad for display
+	const vUv = varyingProperty( 'vec2', 'vUv' );
+	const vertexShader = wgslFn( /* wgsl */`
+		fn vertex( position: vec3f, uv: vec2f ) -> vec3f {
+			varyings.vUv = uv;
+			return position;
+		}
+	`, [ vUv ] );
+
+	fsMaterial = new MeshBasicNodeMaterial();
+	fsMaterial.positionNode = vertexShader( {
+		position: attribute( 'position' ),
+		uv: attribute( 'uv' )
+	} );
+	fsMaterial.colorNode = colorSpaceToWorking( texture( outputTex, vUv ), THREE.SRGBColorSpace );
+	fsQuad = new FullScreenQuad( fsMaterial );
+
+}
+
+function setupGUI() {
+
+	gui = new GUI();
+	gui.add( params, 'pause' ).onChange( ( v ) => {
+
+		if ( animationAction ) animationAction.paused = v;
+
+	} );
+	gui.add( params, 'rebuildEveryFrame' );
+	gui.add( params, 'useRefit' ).name( 'use refit' );
+	if ( hasTimestampQuery ) {
+
+		gui.add( params, 'useGpuTimestamps' ).name( 'gpu timestamps' );
+
+	}
+
+	gui.add( params, 'smoothNormals' );
+	gui.add( params, 'floorY', - 1, 1, 0.05 ).name( 'floor height' );
+	gui.add( params, 'walkSpeed', - 5, 5, 0.1 ).name( 'walk speed' );
+	gui.add( params, 'samples', 1, 8, 1 ).name( 'samples per pixel' );
+	const sunFolder = gui.addFolder( 'sun' );
+	sunFolder.add( params, 'sunAzimuth', - 180.0, 180.0, 1.0 ).name( 'azimuth' );
+	sunFolder.add( params, 'sunElevation', - 5.0, 89.0, 1.0 ).name( 'elevation' );
+	sunFolder.add( params, 'sunTemperature', 1500.0, 12000.0, 50.0 ).name( 'temperature (K)' );
+	sunFolder.add( params, 'sunBrightness', 0.0, 12.0, 0.1 ).name( 'brightness' );
+	gui.add( params, 'exposure', 0.6, 2.0, 0.05 );
+	gui.add( params, 'skeletonHelper' ).onChange( ( v ) => {
+
+		if ( skeletonHelper ) skeletonHelper.visible = v;
+
+	} );
+	gui.add( params, 'resolutionScale', 0.1, 1, 0.1 ).onChange( resize );
+
+}
+
+async function rebuildBVH() {
+
+	// Prevent concurrent builds
+	if ( buildInProgress ) return;
+	buildInProgress = true;
+
+	try {
+
+		// GPU Skinning - much faster than CPU!
+		const skinStart = performance.now();
+		await runGPUSkinning();
+		const skinTime = performance.now() - skinStart;
+
+		// Update BVH directly from GPU skinning output (no CPU readback!)
+		const buildStart = performance.now();
+		const useGpuTimestamps = hasTimestampQuery && params.useGpuTimestamps;
+		let refitGpuLeaves = null;
+		let refitGpuInternal = null;
+		let refitGpuTotal = null;
+		let rebuildGpuSetup = null;
+		let rebuildGpuSort = null;
+		let rebuildGpuHploc = null;
+		if ( params.useRefit ) {
+
+			if ( useGpuTimestamps ) {
+
+				await gpuBVH.refit( { debugTiming: true } );
+				const passTimings = gpuBVH.passTimings;
+				refitGpuLeaves = passTimings.refitLeaves ?? null;
+				refitGpuInternal = passTimings.refitInternal ?? null;
+				refitGpuTotal = passTimings.refitGpuTotal ?? null;
+
+			} else {
+
+				await gpuBVH.refitAsync();
+
+			}
+
+		} else {
+
+			if ( useGpuTimestamps ) {
+
+				await gpuBVH.buildAsyncFromGPUBuffers( {
+					positionBuffer: gpuPositionBuffer,
+					indexBuffer: gpuIndexBuffer,
+					primCount: triCount,
+					positionStride: 4,
+					debugTiming: true,
+				} );
+				const passTimings = gpuBVH.passTimings;
+				rebuildGpuSetup = passTimings.setup ?? null;
+				rebuildGpuSort = passTimings.sort ?? null;
+				rebuildGpuHploc = passTimings.hploc ?? null;
+
+			} else {
+
+				await gpuBVH.buildAsyncFromGPUBuffers( {
+					positionBuffer: gpuPositionBuffer,
+					indexBuffer: gpuIndexBuffer,
+					primCount: triCount,
+					positionStride: 4,
+				} );
+
+			}
+
+		}
+
+		const encodeTime = performance.now() - buildStart;
+
+		// Update running averages
+		frameCount ++;
+		const alpha = Math.min( frameCount, 60 );
+		avgSkinTime += ( skinTime - avgSkinTime ) / alpha;
+		avgEncodeTime += ( encodeTime - avgEncodeTime ) / alpha;
+
+		// GPU→GPU copy BVH data (no CPU readback stall!)
+		// Use maxNodeCount as upper bound since exact nodeCount isn't known without CPU readback
+		const maxNodeCount = gpuBVH.maxNodeCount;
+		const backend = renderer.backend;
+
+		// GPU→GPU copy (fast path - no CPU roundtrip)
+		const bvhDst = backend.get( bvh2Nodes );
+		const rootIndexDst = backend.get( rootIndexBuffer );
+		if ( bvhDst && bvhDst.buffer && rootIndexDst && rootIndexDst.buffer ) {
+
+			const byteLength = maxNodeCount * 32; // 8 floats * 4 bytes
+			const commandEncoder = device.createCommandEncoder();
+			commandEncoder.copyBufferToBuffer( gpuBVH.bvh2Buffer, 0, bvhDst.buffer, 0, byteLength );
+			// Copy root index from clusterIdx[0] (4 bytes)
+			commandEncoder.copyBufferToBuffer( gpuBVH.clusterIdxBuffer, 0, rootIndexDst.buffer, 0, 4 );
+			device.queue.submit( [ commandEncoder.finish() ] );
+			// No await needed - queue ordering guarantees copy completes before ray trace
+
+		}
+
+		// Update display
+		let output = `triangles: ${triCount}\n`;
+		output += `GPU skinning: ${skinTime.toFixed( 2 )} ms (avg: ${avgSkinTime.toFixed( 2 )})\n`;
+		output += `${params.useRefit ? 'BVH refit' : 'BVH encode'}: ${encodeTime.toFixed( 2 )} ms (avg: ${avgEncodeTime.toFixed( 2 )})\n`;
+		output += `sun: az ${params.sunAzimuth.toFixed( 0 )}°, el ${params.sunElevation.toFixed( 0 )}°, ${params.sunTemperature.toFixed( 0 )}K, b ${params.sunBrightness.toFixed( 1 )}\n`;
+		output += `exposure: ${params.exposure.toFixed( 2 )}\n`;
+		if ( refitGpuTotal !== null && refitGpuLeaves !== null && refitGpuInternal !== null ) {
+
+			output += `refit GPU timestamps: total ${refitGpuTotal.toFixed( 2 )} ms (leaves ${refitGpuLeaves.toFixed( 2 )}, internal ${refitGpuInternal.toFixed( 2 )})\n`;
+
+		}
+
+		if ( rebuildGpuSetup !== null && rebuildGpuSort !== null && rebuildGpuHploc !== null ) {
+
+			const rebuildGpuTotal = rebuildGpuSetup + rebuildGpuSort + rebuildGpuHploc;
+			output += `rebuild GPU timestamps: total ${rebuildGpuTotal.toFixed( 2 )} ms (setup ${rebuildGpuSetup.toFixed( 2 )}, sort ${rebuildGpuSort.toFixed( 2 )}, hploc ${rebuildGpuHploc.toFixed( 2 )})\n`;
+
+		}
+
+		const modePrefix = useGpuTimestamps ? 'timed (timestamp readback)' : 'zero CPU readback';
+		output += `mode: fully GPU (${modePrefix}, ${params.useRefit ? 'refit' : 'rebuild'})`;
+
+		outputContainer.textContent = output;
+
+	} finally {
+
+		buildInProgress = false;
+
+	}
+
+}
+
+function resize() {
+
+	const w = window.innerWidth;
+	const h = window.innerHeight;
+	const dpr = window.devicePixelRatio;
+	const scale = params.resolutionScale;
+	renderWidth = Math.max( 1, Math.floor( w * dpr * scale ) );
+	renderHeight = Math.max( 1, Math.floor( h * dpr * scale ) );
+
+	camera.aspect = w / h;
+	camera.updateProjectionMatrix();
+
+	renderer.setSize( w, h );
+	renderer.setPixelRatio( dpr );
+
+	const staleTextures = [ outputTex, radianceTex, guideTex, hitPosTex ];
+
+	outputTex = createStorageTexture( renderWidth, renderHeight, THREE.UnsignedByteType );
+	radianceTex = createStorageTexture( renderWidth, renderHeight, THREE.HalfFloatType );
+	guideTex = createStorageTexture( renderWidth, renderHeight, THREE.HalfFloatType );
+	hitPosTex = createStorageTexture( renderWidth, renderHeight, THREE.HalfFloatType );
+
+	disposeTexturesWhenQueueIdle( staleTextures );
+
+	frameCount = 0;
+
+}
+
+async function render() {
+
+	stats.update();
+
+	const delta = Math.min( clock.getDelta(), 0.033 );
+
+	if ( mixer ) {
+
+		mixer.update( delta );
+
+	}
+
+	if ( skeletonHelper ) {
+
+		skeletonHelper.visible = params.skeletonHelper;
+
+	}
+
+	// Update skeleton matrices before skinning
+	scene.updateMatrixWorld( true );
+
+	// Rebuild BVH every frame if enabled (awaited to ensure consistent data)
+	if ( params.rebuildEveryFrame && ! params.pause && skinnedMeshes && skinnedMeshes.length > 0 && ! buildInProgress ) {
+
+		await rebuildBVH();
+
+	}
+
+	// Path trace
+	if ( computeKernel && presentKernel && outputTex && radianceTex && guideTex && hitPosTex && model ) {
+
+		dispatchSize = [
+			Math.ceil( renderWidth / WORKGROUP_SIZE[ 0 ] ),
+			Math.ceil( renderHeight / WORKGROUP_SIZE[ 1 ] ),
+		];
+
+		camera.updateMatrixWorld();
+		model.updateMatrixWorld();
+
+		// Set up transform matrices for world-space floor + model-space BVH intersection
+		const modelMatrix = skinnedMeshes[ 0 ].matrixWorld;
+		const modelMatrixInverse = modelMatrix.clone().invert();
+		const sunDirWorld = sunDirectionFromAngles( params.sunAzimuth, params.sunElevation, sunDirectionVec );
+		const sunLightColor = sunColorFromTemperature( params.sunTemperature, sunColorVec ).multiplyScalar( Math.max( params.sunBrightness, 0.0 ) );
+
+		computeKernel.computeNode.parameters.outputTex.value = radianceTex;
+		computeKernel.computeNode.parameters.guideTex.value = guideTex;
+		computeKernel.computeNode.parameters.hitPosTex.value = hitPosTex;
+		computeKernel.computeNode.parameters.smoothNormals.value = Number( params.smoothNormals );
+		computeKernel.computeNode.parameters.inverseProjectionMatrix.value = camera.projectionMatrixInverse;
+		computeKernel.computeNode.parameters.cameraToWorldMatrix.value.copy( camera.matrixWorld );
+		computeKernel.computeNode.parameters.worldToModelMatrix.value.copy( modelMatrixInverse );
+		computeKernel.computeNode.parameters.modelToWorldMatrix.value.copy( modelMatrix );
+		computeKernel.computeNode.parameters.floorY.value = params.floorY;
+		computeKernel.computeNode.parameters.time.value = clock.getElapsedTime();
+		computeKernel.computeNode.parameters.walkSpeed.value = params.walkSpeed;
+		computeKernel.computeNode.parameters.sunDirection.value.copy( sunDirWorld );
+		computeKernel.computeNode.parameters.sunColor.value.copy( sunLightColor );
+		computeKernel.computeNode.parameters.frameCount.value = frameCount;
+		computeKernel.computeNode.parameters.samples.value = params.samples;
+		computeKernel.computeNode.parameters.workgroupSize.value.fromArray( WORKGROUP_SIZE );
+
+		renderer.compute( computeKernel, dispatchSize );
+		presentKernel.computeNode.parameters.inputTex.value = radianceTex;
+		presentKernel.computeNode.parameters.outputTex.value = outputTex;
+		presentKernel.computeNode.parameters.exposure.value = params.exposure;
+		presentKernel.computeNode.parameters.workgroupSize.value.fromArray( WORKGROUP_SIZE );
+		renderer.compute( presentKernel, dispatchSize );
+
+		fsMaterial.colorNode.colorNode.value = outputTex;
+		fsQuad.render( renderer );
+
+		if ( skeletonHelper && params.skeletonHelper ) {
+
+			// The main image is path traced via compute + fullscreen quad, so helper lines
+			// need an explicit raster overlay pass.
+			const previousAutoClear = renderer.autoClear;
+			renderer.autoClear = false;
+			renderer.render( helperScene, camera );
+			renderer.autoClear = previousAutoClear;
+
+		}
+
+	}
+
+}

--- a/src/gpu/GPUMeshBVH.js
+++ b/src/gpu/GPUMeshBVH.js
@@ -1,0 +1,3953 @@
+import { setupShaders } from './shaders/setup.wgsl.js';
+import { radixSortShaders } from './shaders/radix_sort.wgsl.js';
+import {
+	hplocShader,
+	hplocShaderWave32,
+	hplocShaderWave64,
+	hplocShaderWave32Indirect,
+	hplocShaderWave64Indirect,
+	hplocShaderIndirect,
+	hplocUpdateDispatchShaderWave32,
+	hplocUpdateDispatchShaderWave64,
+	hplocInitActiveListShader,
+	hplocInitIndirectCountersShader,
+} from './shaders/hploc.wgsl.js';
+import { flattenShader } from './shaders/flatten.wgsl.js';
+import { refitBuildParentsShader, refitBVHLeavesShader, getRefitBVHInternalShader } from './shaders/refit.wgsl.js';
+import { OneSweepSorter } from './sorting/OneSweepSorter.js';
+
+// Subgroup detection shader
+const subgroupDetectShader = /* wgsl */ `
+enable subgroups;
+
+@group(0) @binding(0)
+var<storage, read_write> outSize : array<u32, 1>;
+
+@compute @workgroup_size(1)
+fn main(@builtin(subgroup_size) subgroupSize : u32) {
+    outSize[0] = subgroupSize;
+}
+`;
+
+/**
+ * Available sorter types
+ */
+export const SorterType = {
+	BUILTIN: 'builtin', // Original inline implementation
+	ONESWEEP: 'onesweep', // High-performance OneSweep
+};
+
+// H-PLOC indirect iteration cap: ceil(log2(N) * factor)
+// Reduced from 3 to 2 to cut tail no-op indirect iterations.
+const HPLOC_MAX_ITERATION_FACTOR = 2;
+// Refit propagation may require deeper wave count than H-PLOC merge iterations.
+const REFIT_MAX_ITERATION_FACTOR = 4;
+
+/**
+ * GPU-based BVH builder using H-PLOC algorithm.
+ * Builds BVH entirely on the GPU using WebGPU compute shaders.
+ */
+export class GPUMeshBVH {
+
+	constructor( device, options = {} ) {
+
+		this.device = device;
+
+		// Sorter configuration: prefer OneSweep when subgroups available (much faster)
+		const hasSubgroups = device.features && device.features.has( 'subgroups' );
+		if ( options.sorterType === SorterType.BUILTIN || options.sorterType === SorterType.ONESWEEP ) {
+
+			this._sorterType = options.sorterType;
+
+		} else if ( options.sorterType !== undefined ) {
+
+			// Unknown sorter types (including removed SIMPLE) fall back to builtin.
+			this._sorterType = SorterType.BUILTIN;
+			if ( options.verbose === true ) {
+
+				console.warn( `GPUMeshBVH: Unsupported sorterType "${options.sorterType}", falling back to "${SorterType.BUILTIN}"` );
+
+			}
+
+		} else if ( hasSubgroups ) {
+
+			this._sorterType = SorterType.ONESWEEP;
+
+		} else {
+
+			this._sorterType = SorterType.BUILTIN;
+
+		}
+
+		this._sorter = null;
+
+		// Pipeline cache
+		this._pipelines = null;
+
+		// Build state buffers (reusable)
+		this._buildBuffers = null;
+
+		// Output buffers
+		this._bvhBuffer = null;
+		this._positionBuffer = null;
+		this._indexBuffer = null;
+
+		// Stats
+		this._nodeCount = 0;
+		this._primCount = 0;
+		this._buildTimeMs = 0;
+		this._passTimings = null;
+		this._rootIndex = 0;
+
+		// Timestamp query support (for accurate timing without multi-submit overhead)
+		this._hasTimestampQuery = device.features.has( 'timestamp-query' );
+		this._timestampBuffers = null;
+
+		// Subgroups support - enables 1-subgroup-per-workgroup design for H-PLOC
+		// This eliminates wasted workgroupBarrier() synchronization overhead
+		this._hasSubgroups = device.features && device.features.has( 'subgroups' );
+		this._subgroupSize = 0; // Detected at runtime (32 for Apple/NVIDIA, 64 for AMD)
+		this._hplocShaderVariant = 'fallback'; // 'wave32', 'wave64', or 'fallback'
+		// Default to 64 (fallback workgroup size), updated after subgroup detection
+		this._hplocWorkgroupSize = 64;
+
+		// Verbose logging (disabled by default for performance)
+		this._verbose = options.verbose === true;
+
+		// Position stride (floats per vertex: 3 for vec3, 4 for vec4)
+		this._positionStride = 3;
+
+		// External buffer tracking (don't destroy buffers we don't own)
+		this._externalPositionBuffer = false;
+		this._externalIndexBuffer = false;
+
+		// Refit parent map validity (topology-dependent).
+		this._refitParentsDirty = true;
+		this._refitBindGroups = null;
+		this._refitBindGroupsCacheKey = null;
+
+	}
+
+	get sorterType() {
+
+		return this._sorterType;
+
+	}
+
+	get bvhBuffer() {
+
+		return this._bvhBuffer;
+
+	}
+
+	get positionBuffer() {
+
+		return this._positionBuffer;
+
+	}
+
+	get indexBuffer() {
+
+		return this._indexBuffer;
+
+	}
+
+	get nodeCount() {
+
+		return this._nodeCount;
+
+	}
+
+	get buildTimeMs() {
+
+		return this._buildTimeMs;
+
+	}
+
+	get passTimings() {
+
+		return this._passTimings;
+
+	}
+
+	get cpuPrepTimings() {
+
+		return this._cpuPrepTimings;
+
+	}
+
+	get rootIndex() {
+
+		return this._rootIndex;
+
+	}
+
+	// Returns the raw BVH2 buffer (H-PLOC format with absolute child indices)
+	get bvh2Buffer() {
+
+		return this._buildBuffers ? this._buildBuffers.bvh2Nodes : null;
+
+	}
+
+	/**
+	 * Returns the clusterIdx buffer - after build, clusterIdx[0] contains the root index.
+	 * Use this for GPU-side root index access to avoid CPU readback stalls.
+	 */
+	get clusterIdxBuffer() {
+
+		return this._buildBuffers ? this._buildBuffers.clusterIdx : null;
+
+	}
+
+	/**
+	 * Returns the maximum possible node count for the last build (2 * primCount).
+	 * Use this to size destination buffers when avoiding CPU readback.
+	 */
+	get maxNodeCount() {
+
+		return this._primCount ? 2 * this._primCount : 0;
+
+	}
+
+	// Returns the sorter instance for debugging (may be null if using builtin sort)
+	get sorter() {
+
+		return this._sorter;
+
+	}
+
+	/**
+	 * Build BVH from Three.js BufferGeometry
+	 * @param {BufferGeometry} geometry
+	 * @param {Object} options
+	 * @param {boolean} options.useFlatten - If true, run flatten pass for traditional traversal format (default: false)
+	 * @param {boolean} options.debugTiming - If true, add per-phase timing (uses GPU timestamps if available)
+	 * @returns {Promise<void>}
+	 */
+	async build( geometry, options = {} ) {
+
+		const { useFlatten = false, debugTiming = false } = options;
+
+		const startTime = performance.now();
+
+		// Extract geometry data
+		const t0 = performance.now();
+		const { positions, indices, primCount } = this._extractGeometryData( geometry );
+		const extractTime = performance.now() - t0;
+
+		this._primCount = primCount;
+
+		// Allocate buffers (includes readback buffer)
+		const t1 = performance.now();
+		this._allocateBuffers( primCount );
+		const allocTime = performance.now() - t1;
+
+		// Upload geometry to GPU
+		// Note: No await needed here - WebGPU guarantees ordering between writeBuffer and command submission
+		const t2 = performance.now();
+		this._uploadGeometry( positions, indices );
+		const uploadTime = performance.now() - t2;
+
+		// Create pipelines if needed (requires subgroup detection first)
+		const t3 = performance.now();
+		if ( ! this._pipelines ) {
+
+			// Detect subgroup size for optimal H-PLOC variant selection
+			if ( this._hasSubgroups && this._subgroupSize === 0 ) {
+
+				await this._detectSubgroupSize();
+
+			}
+
+			this._pipelines = this._createPipelines();
+
+		}
+
+		const pipelineTime = performance.now() - t3;
+
+		// Initialize external sorter if configured, or grow if needed
+		const t4 = performance.now();
+		if ( this._sorterType === SorterType.BUILTIN ) {
+
+			// Dispose any stale external sorter when using builtin
+			// This prevents _recordRadixSortPass from accidentally using an old sorter
+			if ( this._sorter ) {
+
+				this._sorter.dispose();
+				this._sorter = null;
+
+			}
+
+		} else {
+
+			if ( ! this._sorter ) {
+
+				await this._initSorter( primCount );
+
+			} else if ( this._sorter.maxKeys !== undefined && primCount > this._sorter.maxKeys ) {
+
+				// Sorter exists but buffers are too small - reinit to grow
+				await this._sorter.init( primCount );
+
+			}
+
+		}
+
+		const sorterInitTime = performance.now() - t4;
+
+		// Store CPU prep timings for debug mode
+		this._cpuPrepTimings = {
+			extract: extractTime,
+			alloc: allocTime,
+			upload: uploadTime,
+			pipeline: pipelineTime,
+			sorterInit: sorterInitTime,
+			total: extractTime + allocTime + uploadTime + pipelineTime + sorterInitTime,
+		};
+
+		// Build path selection:
+		// - debugTiming + timestamps: single-submit with GPU timestamp queries (most accurate)
+		// - debugTiming + no timestamps: multi-submit with CPU timing (adds sync overhead)
+		// - no debugTiming: single-submit (fastest, no timing breakdown)
+		if ( debugTiming ) {
+
+			if ( this._hasTimestampQuery ) {
+
+				if ( this._verbose ) console.info( 'GPUMeshBVH: Using DEBUG build path (single-submit with timestamps)' );
+				await this._buildSingleSubmitWithTimestamps( primCount, useFlatten );
+
+			} else {
+
+				if ( this._verbose ) console.info( 'GPUMeshBVH: Using DEBUG build path (multi-submit, no timestamps)' );
+				await this._buildWithTiming( primCount, useFlatten );
+
+			}
+
+		} else {
+
+			if ( this._verbose ) console.info( 'GPUMeshBVH: Using FAST build path (single-submit, no timing)' );
+			await this._buildSingleSubmit( primCount, useFlatten );
+
+		}
+
+		this._buildTimeMs = performance.now() - startTime;
+		this._refitParentsDirty = true;
+
+	}
+
+	/**
+	 * Refit existing BVH topology after primitive positions change.
+	 * Keeps child links fixed and updates only node bounds.
+	 *
+	 * @param {Object} options
+	 * @param {?BufferGeometry} options.geometry - Optional geometry to upload before refit
+	 * @param {boolean} options.useFlatten - If true, rerun flatten pass after refit (default: false)
+	 * @param {boolean} options.debugTiming - If true and timestamp-query is available, record GPU split timings for refit passes
+	 * @returns {Promise<void>}
+	 */
+	async refit( options = {} ) {
+
+		return this._refitInternal( options, true );
+
+	}
+
+	/**
+	 * Asynchronous refit variant.
+	 * Submits GPU work without waiting for completion.
+	 *
+	 * @param {Object} options
+	 * @param {?BufferGeometry} options.geometry - Optional geometry to upload before refit
+	 * @param {boolean} options.useFlatten - If true, rerun flatten pass after refit (default: false)
+	 * @param {boolean} options.debugTiming - Ignored in async mode unless completion is awaited externally
+	 * @returns {Promise<void>} Resolves after submission
+	 */
+	async refitAsync( options = {} ) {
+
+		return this._refitInternal( options, false );
+
+	}
+
+	async _refitInternal( options = {}, waitForCompletion = true ) {
+
+		const { geometry = null, useFlatten = false, debugTiming = false } = options;
+		if ( ! this._buildBuffers || ! this._pipelines || ! this._primCount ) {
+
+			throw new Error( 'GPUMeshBVH.refit: No existing BVH. Build first.' );
+
+		}
+
+		const startTime = performance.now();
+		let extractTime = 0;
+		let uploadTime = 0;
+
+		if ( geometry ) {
+
+			const tExtract = performance.now();
+			const { positions, indices, primCount } = this._extractGeometryData( geometry );
+			extractTime = performance.now() - tExtract;
+			if ( primCount !== this._primCount ) {
+
+				throw new Error( `GPUMeshBVH.refit: primCount changed (${this._primCount} -> ${primCount}). Rebuild required.` );
+
+			}
+
+			const tUpload = performance.now();
+			this._uploadGeometry( positions, indices, false );
+			uploadTime = performance.now() - tUpload;
+
+		}
+
+		if ( ! this._positionBuffer || ! this._indexBuffer ) {
+
+			throw new Error( 'GPUMeshBVH.refit: Missing geometry buffers.' );
+
+		}
+
+		let parentBuildTime = 0;
+		if ( this._refitParentsDirty ) {
+
+			const tParents = performance.now();
+			await this._buildRefitParentMap( waitForCompletion );
+			parentBuildTime = performance.now() - tParents;
+
+		}
+
+		const tRefit = performance.now();
+		const refitInfo = await this._runRefitPass( useFlatten, waitForCompletion, debugTiming );
+		const refitTime = performance.now() - tRefit;
+
+		this._cpuPrepTimings = {
+			extract: extractTime,
+			alloc: 0,
+			upload: uploadTime,
+			pipeline: 0,
+			sorterInit: 0,
+			total: extractTime + uploadTime,
+		};
+
+		const passTimings = {
+			refit: refitTime,
+			refitBuildParents: parentBuildTime,
+			refitIterations: refitInfo.maxIterations,
+		};
+		if ( refitInfo.gpuTimestamps ) {
+
+			passTimings.gpuTimestamps = true;
+			passTimings.refitLeaves = refitInfo.refitLeaves;
+			passTimings.refitInternal = refitInfo.refitInternal;
+			passTimings.refitGpuTotal = refitInfo.refitGpuTotal;
+
+		}
+
+		this._passTimings = passTimings;
+
+		this._buildTimeMs = performance.now() - startTime;
+
+	}
+
+	/**
+	 * Build BVH without CPU readback - fully asynchronous GPU operation.
+	 * Use this for per-frame rebuilds where you want to avoid CPU stalls.
+	 *
+	 * After calling this:
+	 * - bvh2Buffer contains the BVH (use maxNodeCount for buffer sizing)
+	 * - clusterIdxBuffer[0] contains the root index (read in shader)
+	 * - nodeCount and rootIndex getters will NOT be updated (use GPU-side values)
+	 *
+	 * @param {BufferGeometry} geometry
+	 * @param {Object} options
+	 * @param {boolean} options.useFlatten - If true, run flatten pass (default: false)
+	 * @returns {Promise<void>} - Resolves when GPU work is submitted (not completed)
+	 */
+	async buildAsync( geometry, options = {} ) {
+
+		const { useFlatten = false } = options;
+
+		// Extract geometry data
+		const { positions, indices, primCount } = this._extractGeometryData( geometry );
+		this._primCount = primCount;
+
+		// Allocate buffers if needed (reuses existing if capacity sufficient)
+		this._allocateBuffers( primCount );
+
+		// Upload geometry to GPU
+		this._uploadGeometry( positions, indices );
+
+		// Create pipelines if needed
+		if ( ! this._pipelines ) {
+
+			if ( this._hasSubgroups && this._subgroupSize === 0 ) {
+
+				await this._detectSubgroupSize();
+
+			}
+
+			this._pipelines = this._createPipelines();
+
+		}
+
+		// Initialize sorter if needed
+		if ( this._sorterType !== SorterType.BUILTIN ) {
+
+			if ( ! this._sorter ) {
+
+				await this._initSorter( primCount );
+
+			} else if ( this._sorter.maxKeys !== undefined && primCount > this._sorter.maxKeys ) {
+
+				await this._sorter.init( primCount );
+
+			}
+
+		}
+
+		// Build without readback
+		this._buildSingleSubmitNoReadback( primCount, useFlatten );
+
+	}
+
+	/**
+	 * Build BVH from pre-existing GPU buffers.
+	 * Default path avoids CPU readback; debug timing mode adds synchronization for measurements.
+	 * Accepts raw GPU buffers with configurable position stride, eliminating
+	 * GPU→CPU→GPU round-trips for use cases like GPU skinning.
+	 *
+	 * @param {Object} options
+	 * @param {GPUBuffer} options.positionBuffer - GPU buffer with position data as array<f32>
+	 * @param {GPUBuffer} options.indexBuffer - GPU buffer with index data as array<u32>
+	 * @param {number} options.primCount - Number of triangles
+	 * @param {number} options.positionStride - Floats per vertex (3 for vec3, 4 for vec4). Default: 3
+	 * @param {boolean} options.useFlatten - If true, run flatten pass. Default: false
+	 * @param {boolean} options.debugTiming - If true, collect per-phase timings (uses timestamp-query when available)
+	 * @returns {Promise<void>}
+	 */
+	async buildAsyncFromGPUBuffers( options ) {
+
+		const startTime = performance.now();
+
+		const {
+			positionBuffer,
+			indexBuffer,
+			primCount,
+			positionStride = 3,
+			useFlatten = false,
+			debugTiming = false,
+		} = options;
+
+		this._primCount = primCount;
+		this._positionStride = positionStride;
+
+		// Invalidate setup bind groups if position/index buffer identity changes
+		if ( this._positionBuffer !== positionBuffer || this._indexBuffer !== indexBuffer ) {
+
+			this._setupBindGroups = null;
+			this._refitBindGroups = null;
+			this._refitBindGroupsCacheKey = null;
+
+		}
+
+		// Swap in external buffers (destroy old owned buffers if any)
+		if ( this._positionBuffer && ! this._externalPositionBuffer ) {
+
+			this._positionBuffer.destroy();
+
+		}
+
+		this._positionBuffer = positionBuffer;
+		this._externalPositionBuffer = true;
+
+		if ( this._indexBuffer && ! this._externalIndexBuffer ) {
+
+			this._indexBuffer.destroy();
+
+		}
+
+		this._indexBuffer = indexBuffer;
+		this._externalIndexBuffer = true;
+
+		// Allocate build buffers if needed
+		this._allocateBuffers( primCount );
+
+		// Initialize build state (scene bounds, node counter)
+		this._initBuildState();
+
+		// Create pipelines if needed
+		if ( ! this._pipelines ) {
+
+			if ( this._hasSubgroups && this._subgroupSize === 0 ) {
+
+				await this._detectSubgroupSize();
+
+			}
+
+			this._pipelines = this._createPipelines();
+
+		}
+
+		// Initialize sorter if needed
+		if ( this._sorterType !== SorterType.BUILTIN ) {
+
+			if ( ! this._sorter ) {
+
+				await this._initSorter( primCount );
+
+			} else if ( this._sorter.maxKeys !== undefined && primCount > this._sorter.maxKeys ) {
+
+				await this._sorter.init( primCount );
+
+			}
+
+		}
+
+		if ( debugTiming ) {
+
+			if ( this._hasTimestampQuery ) {
+
+				if ( this._verbose ) console.info( 'GPUMeshBVH: Using DEBUG GPU-buffer build path (single-submit with timestamps)' );
+				await this._buildSingleSubmitWithTimestamps( primCount, useFlatten );
+
+			} else {
+
+				if ( this._verbose ) console.info( 'GPUMeshBVH: Using DEBUG GPU-buffer build path (multi-submit, no timestamps)' );
+				await this._buildWithTiming( primCount, useFlatten );
+
+			}
+
+		} else {
+
+			// Fast path: build without waiting and without readback.
+			this._buildSingleSubmitNoReadback( primCount, useFlatten );
+
+		}
+
+		this._buildTimeMs = performance.now() - startTime;
+		this._refitParentsDirty = true;
+
+	}
+
+	/**
+	 * Single-submission build without CPU readback.
+	 * After this returns, bvh2Buffer has the BVH and clusterIdx[0] has the root index.
+	 * No await needed - WebGPU queue ordering guarantees completion before subsequent commands.
+	 */
+	_buildSingleSubmitNoReadback( primCount, useFlatten ) {
+
+		const device = this.device;
+		const workgroupSize = 256;
+		const workgroupCount = Math.ceil( primCount / workgroupSize );
+
+		// Pre-allocate uniform data
+		const ALIGN = 256;
+		const uniformCount = 1 + 1 + 4 + 1 + 1;
+		const uniformData = new ArrayBuffer( uniformCount * ALIGN );
+
+		let offset = 0;
+		const offsets = {};
+
+		offsets.setup = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, workgroupCount, this._positionStride, 0 ] );
+		offset += ALIGN;
+
+		offsets.morton = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, workgroupCount, 0, 0 ] );
+		offset += ALIGN;
+
+		offsets.sort = [];
+		const sortWorkgroupCount = Math.ceil( primCount / 256 );
+		for ( let i = 0; i < 4; i ++ ) {
+
+			offsets.sort.push( offset );
+			new Uint32Array( uniformData, offset, 4 ).set( [ primCount, i * 8, sortWorkgroupCount, 0 ] );
+			offset += ALIGN;
+
+		}
+
+		offsets.hploc = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, 0, 0, 0 ] );
+		offset += ALIGN;
+
+		const useIndirectDispatch = this._hplocShaderVariant === 'wave32' || this._hplocShaderVariant === 'wave64';
+		const initialWorkgroupCount = useIndirectDispatch ? Math.ceil( primCount / this._hplocWorkgroupSize ) : 0;
+		offsets.initCounters = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, initialWorkgroupCount, 0, 0 ] );
+		offset += ALIGN;
+
+		device.queue.writeBuffer( this._buildBuffers.uniforms, 0, uniformData );
+
+		// Record all passes
+		const commandEncoder = device.createCommandEncoder();
+
+		this._recordSetupPass( commandEncoder, primCount, offsets );
+		this._recordRadixSortPass( commandEncoder, primCount, offsets );
+		this._runHPLOCPassSync( commandEncoder, primCount, offsets );
+
+		if ( useFlatten ) {
+
+			this._runFlattenPass( commandEncoder, primCount );
+
+		}
+
+		// Submit without waiting - no readback needed
+		device.queue.submit( [ commandEncoder.finish() ] );
+		// Queue ordering guarantees this completes before any subsequent commands
+		this._refitParentsDirty = true;
+
+	}
+
+	/**
+	 * DEBUG: Run the H-PLOC indirect dispatch debug version.
+	 * Call this after build() to diagnose indirect dispatch issues.
+	 * Logs detailed state information to console.
+	 */
+	async debugIndirectDispatch() {
+
+		if ( this._hplocShaderVariant !== 'wave32' && this._hplocShaderVariant !== 'wave64' ) {
+
+			console.warn( 'debugIndirectDispatch: only available for wave32/wave64 variants' );
+			return;
+
+		}
+
+		const primCount = this._primCount;
+		const workgroupSize = 256;
+		const workgroupCount = Math.ceil( primCount / workgroupSize );
+
+		// Setup uniforms
+		const ALIGN = 256;
+		const uniformData = new ArrayBuffer( 2 * ALIGN );
+		new Uint32Array( uniformData, 0, 4 ).set( [ primCount, workgroupCount, this._positionStride, 0 ] );
+		new Uint32Array( uniformData, ALIGN, 4 ).set( [ primCount, 0, 0, 0 ] );
+		this.device.queue.writeBuffer( this._buildBuffers.uniforms, 0, uniformData );
+
+		// Re-initialize buffers for H-PLOC
+		// Reset parentIdx to INVALID
+		const initParent = new Uint32Array( primCount );
+		initParent.fill( 0xFFFFFFFF );
+		this.device.queue.writeBuffer( this._buildBuffers.parentIdx, 0, initParent );
+
+		// Re-initialize clusterIdx to [0, 1, 2, ..., primCount-1]
+		// This is crucial - after the previous build, clusterIdx contains INVALID_IDX for merged clusters
+		const initCluster = new Uint32Array( primCount );
+		for ( let i = 0; i < primCount; i ++ ) {
+
+			initCluster[ i ] = i;
+
+		}
+
+		this.device.queue.writeBuffer( this._buildBuffers.clusterIdx, 0, initCluster );
+
+		// Re-initialize state (left=i, right=i, split=i, active=1)
+		const initState = new Uint32Array( primCount * 4 );
+		for ( let i = 0; i < primCount; i ++ ) {
+
+			initState[ i * 4 + 0 ] = i;
+			initState[ i * 4 + 1 ] = i;
+			initState[ i * 4 + 2 ] = i;
+			initState[ i * 4 + 3 ] = 1;
+
+		}
+
+		this.device.queue.writeBuffer( this._buildBuffers.hplocState, 0, initState );
+
+		// Reset node counter
+		this.device.queue.writeBuffer( this._buildBuffers.nodeCounter, 0, new Uint32Array( [ primCount ] ) );
+
+		console.log( '=== DEBUG: Running H-PLOC Indirect Dispatch ===' );
+		await this._debugRunHPLOCPassIndirect( primCount, ALIGN );
+		console.log( '=== DEBUG: Done ===' );
+		this._refitParentsDirty = true;
+
+	}
+
+	/**
+	 * Trace indirect H-PLOC active list decay per iteration.
+	 * This replays only the H-PLOC phase using existing morton codes / leaf bounds
+	 * from the most recent build and returns active primitive counts per iteration.
+	 *
+	 * NOTE: This method mutates H-PLOC build-state buffers (cluster/state/parent/counters).
+	 * Call this only for profiling/analysis, not between dependent traversal operations.
+	 */
+	async traceIndirectActiveCounts() {
+
+		if ( ! this._buildBuffers || ! this._pipelines || ! this._primCount ) {
+
+			throw new Error( 'traceIndirectActiveCounts requires a completed build with primCount > 0.' );
+
+		}
+
+		const device = this.device;
+		const primCount = this._primCount;
+		const workgroupSize = this._hplocWorkgroupSize;
+		const initialWorkgroupCount = Math.ceil( primCount / workgroupSize );
+		const maxIterations = this._getHPLOCMaxIterations( primCount );
+
+		// H-PLOC shader only needs primCount at binding(0) uniforms.
+		device.queue.writeBuffer( this._buildBuffers.uniforms, 0, new Uint32Array( [ primCount, 0, 0, 0 ] ) );
+
+		// Re-initialize per-primitive state for a clean H-PLOC replay.
+		const initParent = new Uint32Array( primCount );
+		initParent.fill( 0xFFFFFFFF );
+		device.queue.writeBuffer( this._buildBuffers.parentIdx, 0, initParent );
+
+		const initCluster = new Uint32Array( primCount );
+		const initState = new Uint32Array( primCount * 4 );
+		for ( let i = 0; i < primCount; i ++ ) {
+
+			initCluster[ i ] = i;
+			initState[ i * 4 + 0 ] = i;
+			initState[ i * 4 + 1 ] = i;
+			initState[ i * 4 + 2 ] = i;
+			initState[ i * 4 + 3 ] = 1;
+
+		}
+
+		device.queue.writeBuffer( this._buildBuffers.clusterIdx, 0, initCluster );
+		device.queue.writeBuffer( this._buildBuffers.hplocState, 0, initState );
+		device.queue.writeBuffer( this._buildBuffers.nodeCounter, 0, new Uint32Array( [ primCount ] ) );
+
+		// activeList0 is mutated during normal indirect execution; reinitialize to identity.
+		{
+
+			const workgroupCount = Math.ceil( primCount / 256 );
+			const enc = device.createCommandEncoder();
+			const passEncoder = enc.beginComputePass();
+			const bindGroup = device.createBindGroup( {
+				layout: this._pipelines.initActiveList.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: 0, size: 16 } },
+					{ binding: 1, resource: { buffer: this._buildBuffers.activeList0 } },
+				],
+			} );
+			passEncoder.setPipeline( this._pipelines.initActiveList );
+			passEncoder.setBindGroup( 0, bindGroup );
+			passEncoder.dispatchWorkgroups( workgroupCount );
+			passEncoder.end();
+			device.queue.submit( [ enc.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+
+		}
+
+		// Initialize ping-pong counters and indirect dispatch args.
+		device.queue.writeBuffer( this._buildBuffers.activeCount0, 0, new Uint32Array( [ primCount ] ) );
+		device.queue.writeBuffer( this._buildBuffers.activeCount1, 0, new Uint32Array( [ 0 ] ) );
+		device.queue.writeBuffer( this._buildBuffers.indirectDispatch, 0, new Uint32Array( [ initialWorkgroupCount, 1, 1 ] ) );
+
+		const countReadback = device.createBuffer( {
+			size: 8, // activeCount0 + activeCount1
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+
+		const readCounts = async () => {
+
+			const enc = device.createCommandEncoder();
+			enc.copyBufferToBuffer( this._buildBuffers.activeCount0, 0, countReadback, 0, 4 );
+			enc.copyBufferToBuffer( this._buildBuffers.activeCount1, 0, countReadback, 4, 4 );
+			device.queue.submit( [ enc.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+			await countReadback.mapAsync( GPUMapMode.READ );
+			const data = new Uint32Array( countReadback.getMappedRange() );
+			const count0 = data[ 0 ];
+			const count1 = data[ 1 ];
+			countReadback.unmap();
+			return [ count0, count1 ];
+
+		};
+
+		const createIndirectBindGroup = ( listIn, listOut, countIn, countOut ) => {
+
+			return device.createBindGroup( {
+				layout: this._pipelines.hplocIndirect.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: 0, size: 16 } },
+					{ binding: 1, resource: { buffer: this._buildBuffers.mortonCodes } },
+					{ binding: 2, resource: { buffer: this._buildBuffers.clusterIdx } },
+					{ binding: 3, resource: { buffer: this._buildBuffers.parentIdx } },
+					{ binding: 4, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+					{ binding: 5, resource: { buffer: this._buildBuffers.nodeCounter } },
+					{ binding: 6, resource: { buffer: this._buildBuffers.hplocState } },
+					{ binding: 7, resource: { buffer: listIn } },
+					{ binding: 8, resource: { buffer: listOut } },
+					{ binding: 9, resource: { buffer: countOut } },
+					{ binding: 10, resource: { buffer: countIn } },
+				],
+			} );
+
+		};
+
+		const createUpdateDispatchBindGroup = ( countIn, countOut ) => {
+
+			return device.createBindGroup( {
+				layout: this._pipelines.updateDispatch.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: countIn } },
+					{ binding: 1, resource: { buffer: this._buildBuffers.indirectDispatch } },
+					{ binding: 2, resource: { buffer: countOut } },
+				],
+			} );
+
+		};
+
+		const hplocBG_0to1 = createIndirectBindGroup(
+			this._buildBuffers.activeList0, this._buildBuffers.activeList1,
+			this._buildBuffers.activeCount0, this._buildBuffers.activeCount1
+		);
+		const hplocBG_1to0 = createIndirectBindGroup(
+			this._buildBuffers.activeList1, this._buildBuffers.activeList0,
+			this._buildBuffers.activeCount1, this._buildBuffers.activeCount0
+		);
+		const updateBG_1to0 = createUpdateDispatchBindGroup(
+			this._buildBuffers.activeCount1, this._buildBuffers.activeCount0
+		);
+		const updateBG_0to1 = createUpdateDispatchBindGroup(
+			this._buildBuffers.activeCount0, this._buildBuffers.activeCount1
+		);
+
+		const activeCounts = [ primCount ];
+		const dispatchWorkgroups = [ initialWorkgroupCount ];
+
+		// Iteration 0 uses direct dispatch from activeList0 -> activeList1.
+		{
+
+			const enc = device.createCommandEncoder();
+			const passEncoder = enc.beginComputePass();
+			passEncoder.setPipeline( this._pipelines.hplocIndirect );
+			passEncoder.setBindGroup( 0, hplocBG_0to1 );
+			passEncoder.dispatchWorkgroups( initialWorkgroupCount );
+			passEncoder.end();
+			device.queue.submit( [ enc.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+
+		}
+
+		let counts = await readCounts();
+		let nextInputCount = counts[ 1 ]; // Iteration 1 reads activeCount1.
+
+		for ( let iter = 1; iter < maxIterations && nextInputCount > 0; iter ++ ) {
+
+			activeCounts.push( nextInputCount );
+			dispatchWorkgroups.push( Math.ceil( nextInputCount / workgroupSize ) );
+
+			const useList1AsInput = ( iter % 2 === 1 );
+
+			const enc = device.createCommandEncoder();
+			const passEncoder = enc.beginComputePass();
+			passEncoder.setPipeline( this._pipelines.updateDispatch );
+			passEncoder.setBindGroup( 0, useList1AsInput ? updateBG_1to0 : updateBG_0to1 );
+			passEncoder.dispatchWorkgroups( 1 );
+			passEncoder.setPipeline( this._pipelines.hplocIndirect );
+			passEncoder.setBindGroup( 0, useList1AsInput ? hplocBG_1to0 : hplocBG_0to1 );
+			passEncoder.dispatchWorkgroupsIndirect( this._buildBuffers.indirectDispatch, 0 );
+			passEncoder.end();
+			device.queue.submit( [ enc.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+
+			counts = await readCounts();
+			nextInputCount = useList1AsInput ? counts[ 0 ] : counts[ 1 ];
+
+		}
+
+		countReadback.destroy();
+		this._refitParentsDirty = true;
+
+		const estimatedAppendAtomicsOld = activeCounts.reduce( ( sum, v ) => sum + v, 0 );
+		const estimatedAppendAtomicsNew = dispatchWorkgroups.reduce( ( sum, v ) => sum + v, 0 );
+		const estimatedReductionFactor = estimatedAppendAtomicsNew > 0
+			? estimatedAppendAtomicsOld / estimatedAppendAtomicsNew
+			: 0;
+		const estimatedReductionPct = estimatedAppendAtomicsOld > 0
+			? ( 1 - estimatedAppendAtomicsNew / estimatedAppendAtomicsOld ) * 100
+			: 0;
+
+		return {
+			workgroupSize,
+			maxIterations,
+			nonZeroIterations: activeCounts.length,
+			activeCounts,
+			dispatchWorkgroups,
+			estimatedAppendAtomicsOld,
+			estimatedAppendAtomicsNew,
+			estimatedReductionFactor,
+			estimatedReductionPct,
+		};
+
+	}
+
+	/**
+	 * Trace refit active-list propagation with per-wave readback.
+	 * Useful for diagnosing whether refit cost is dominated by leaves or internal waves.
+	 *
+	 * NOTE: Like traceIndirectActiveCounts(), this is a profiling helper and introduces
+	 * substantial synchronization overhead due to per-iteration readbacks.
+	 */
+	async traceRefitActiveCounts( options = {} ) {
+
+		const { useFlatten = false } = options;
+		if ( ! this._buildBuffers || ! this._pipelines || ! this._primCount ) {
+
+			throw new Error( 'traceRefitActiveCounts requires a completed build with primCount > 0.' );
+
+		}
+
+		if ( this._refitParentsDirty ) {
+
+			await this._buildRefitParentMap( true );
+
+		}
+
+		const device = this.device;
+		const primCount = this._primCount;
+		const workgroupSize = 256;
+		const leafWorkgroupCount = Math.ceil( primCount / workgroupSize );
+		const maxIterations = this._getRefitMaxIterations( primCount );
+
+		// Refit uniforms: primCount + position stride.
+		device.queue.writeBuffer( this._buildBuffers.uniforms, 0, new Uint32Array( [ primCount, this._positionStride, 0, 0 ] ) );
+
+		const maxNodesUsed = Math.max( 1, 2 * primCount );
+		{
+
+			const clearEncoder = device.createCommandEncoder();
+			clearEncoder.clearBuffer( this._buildBuffers.refitVisitCount, 0, maxNodesUsed * 4 );
+			clearEncoder.clearBuffer( this._buildBuffers.activeCount0 );
+			clearEncoder.clearBuffer( this._buildBuffers.activeCount1 );
+			device.queue.submit( [ clearEncoder.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+
+		}
+
+		const bg = this._getOrCreateRefitBindGroups();
+
+		const countReadback = device.createBuffer( {
+			size: 8, // activeCount0 + activeCount1
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+
+		const readCounts = async () => {
+
+			const readEncoder = device.createCommandEncoder();
+			readEncoder.copyBufferToBuffer( this._buildBuffers.activeCount0, 0, countReadback, 0, 4 );
+			readEncoder.copyBufferToBuffer( this._buildBuffers.activeCount1, 0, countReadback, 4, 4 );
+			device.queue.submit( [ readEncoder.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+			await countReadback.mapAsync( GPUMapMode.READ );
+			const data = new Uint32Array( countReadback.getMappedRange() );
+			const result = [ data[ 0 ], data[ 1 ] ];
+			countReadback.unmap();
+			return result;
+
+		};
+
+		// Pass 1: leaves update and initial parent enqueue.
+		const tLeaves = performance.now();
+		{
+
+			const leafEncoder = device.createCommandEncoder();
+			const passEncoder = leafEncoder.beginComputePass();
+			passEncoder.setPipeline( this._pipelines.refitLeaves );
+			passEncoder.setBindGroup( 0, bg.leaves );
+			passEncoder.dispatchWorkgroups( leafWorkgroupCount );
+			passEncoder.end();
+			device.queue.submit( [ leafEncoder.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+
+		}
+
+		const leavesTimeMs = performance.now() - tLeaves;
+
+		let counts = await readCounts();
+		let inputCount = counts[ 0 ]; // Leaves always seed activeCount0.
+
+		const activeCounts = [];
+		const dispatchWorkgroups = [];
+		const waveTimesMs = [];
+
+		for ( let iter = 0; iter < maxIterations && inputCount > 0; iter ++ ) {
+
+			activeCounts.push( inputCount );
+			dispatchWorkgroups.push( Math.ceil( inputCount / workgroupSize ) );
+
+			const use0to1 = ( iter % 2 === 0 );
+			const tWave = performance.now();
+
+			const waveEncoder = device.createCommandEncoder();
+			const passEncoder = waveEncoder.beginComputePass();
+			passEncoder.setPipeline( this._pipelines.updateDispatch );
+			passEncoder.setBindGroup( 0, use0to1 ? bg.update_0to1 : bg.update_1to0 );
+			passEncoder.dispatchWorkgroups( 1 );
+			passEncoder.setPipeline( this._pipelines.refitInternal );
+			passEncoder.setBindGroup( 0, use0to1 ? bg.internal_0to1 : bg.internal_1to0 );
+			passEncoder.dispatchWorkgroupsIndirect( this._buildBuffers.indirectDispatch, 0 );
+			passEncoder.end();
+			device.queue.submit( [ waveEncoder.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+
+			waveTimesMs.push( performance.now() - tWave );
+
+			counts = await readCounts();
+			inputCount = use0to1 ? counts[ 1 ] : counts[ 0 ];
+
+		}
+
+		if ( useFlatten ) {
+
+			const flattenEncoder = device.createCommandEncoder();
+			this._runFlattenPass( flattenEncoder, primCount );
+			device.queue.submit( [ flattenEncoder.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+
+		}
+
+		countReadback.destroy();
+
+		const totalWaveTimeMs = waveTimesMs.reduce( ( sum, v ) => sum + v, 0 );
+		const estimatedInternalNodeVisits = activeCounts.reduce( ( sum, v ) => sum + v, 0 );
+		const totalInternalWorkgroups = dispatchWorkgroups.reduce( ( sum, v ) => sum + v, 0 );
+
+		return {
+			workgroupSize,
+			leafWorkgroupCount,
+			maxIterations,
+			nonZeroIterations: activeCounts.length,
+			activeCounts,
+			dispatchWorkgroups,
+			waveTimesMs,
+			leavesTimeMs,
+			totalWaveTimeMs,
+			updateDispatchCalls: waveTimesMs.length,
+			estimatedInternalNodeVisits,
+			totalInternalWorkgroups,
+		};
+
+	}
+
+	/**
+	 * Single-submission build - all passes recorded to one command encoder
+	 * This is the optimized path with minimal CPU/driver overhead
+	 */
+	async _buildSingleSubmit( primCount, useFlatten ) {
+
+		const device = this.device;
+		const workgroupSize = 256;
+		const workgroupCount = Math.ceil( primCount / workgroupSize );
+
+		// Pre-allocate uniform data (256-byte aligned offsets for WebGPU)
+		// Layout: [setup, morton, sort0, sort1, sort2, sort3, hploc, initCounters]
+		// Atomic scene bounds eliminates reduction passes
+		const ALIGN = 256;
+		const uniformCount = 1 + 1 + 4 + 1 + 1; // setup + morton + 4 sort + hploc + initCounters
+		const uniformData = new ArrayBuffer( uniformCount * ALIGN );
+
+		let offset = 0;
+		const offsets = {};
+
+		// Setup uniforms
+		offsets.setup = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, workgroupCount, this._positionStride, 0 ] );
+		offset += ALIGN;
+
+		// Morton uniforms (same as setup)
+		offsets.morton = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, workgroupCount, 0, 0 ] );
+		offset += ALIGN;
+
+		// Radix sort uniforms (4 passes with different bit offsets)
+		offsets.sort = [];
+		const sortWorkgroupCount = Math.ceil( primCount / 256 );
+		for ( let i = 0; i < 4; i ++ ) {
+
+			offsets.sort.push( offset );
+			new Uint32Array( uniformData, offset, 4 ).set( [ primCount, i * 8, sortWorkgroupCount, 0 ] );
+			offset += ALIGN;
+
+		}
+
+		// H-PLOC uniforms
+		offsets.hploc = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, 0, 0, 0 ] );
+		offset += ALIGN;
+
+		// InitCounters uniforms (for GPU-based counter initialization in indirect dispatch)
+		const useIndirectDispatch = this._hplocShaderVariant === 'wave32' || this._hplocShaderVariant === 'wave64';
+		const initialWorkgroupCount = useIndirectDispatch ? Math.ceil( primCount / this._hplocWorkgroupSize ) : 0;
+		offsets.initCounters = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, initialWorkgroupCount, 0, 0 ] );
+		offset += ALIGN;
+
+		// Upload all uniforms at once
+		device.queue.writeBuffer( this._buildBuffers.uniforms, 0, uniformData );
+
+		// Record all passes to single command encoder
+		const commandEncoder = device.createCommandEncoder();
+
+		// === SETUP PHASE ===
+		this._recordSetupPass( commandEncoder, primCount, offsets );
+
+		// === RADIX SORT PHASE ===
+		this._recordRadixSortPass( commandEncoder, primCount, offsets );
+
+		// === H-PLOC PHASE ===
+		const hplocIterations = this._runHPLOCPassSync( commandEncoder, primCount, offsets );
+
+		// === FLATTEN PHASE (optional) ===
+		if ( useFlatten ) {
+
+			this._runFlattenPass( commandEncoder, primCount );
+
+		}
+
+		// === READBACK ===
+		commandEncoder.copyBufferToBuffer(
+			this._buildBuffers.nodeCounter, 0,
+			this._buildBuffers.readback, 0, 4
+		);
+		commandEncoder.copyBufferToBuffer(
+			this._buildBuffers.clusterIdx, 0,
+			this._buildBuffers.readback, 4, 4
+		);
+
+		// Single submit!
+		device.queue.submit( [ commandEncoder.finish() ] );
+		await device.queue.onSubmittedWorkDone();
+
+		// Read results
+		await this._buildBuffers.readback.mapAsync( GPUMapMode.READ );
+		const data = new Uint32Array( this._buildBuffers.readback.getMappedRange() );
+		this._nodeCount = Math.min( data[ 0 ], 2 * primCount );
+		this._rootIndex = data[ 1 ];
+		this._buildBuffers.readback.unmap();
+
+		this._passTimings = { hplocIterations };
+
+	}
+
+	/**
+	 * Single-submission build with GPU timestamp queries for accurate per-phase timing
+	 * No multi-submit overhead - timestamps are resolved after all work completes
+	 */
+	async _buildSingleSubmitWithTimestamps( primCount, useFlatten ) {
+
+		const device = this.device;
+		const workgroupSize = 256;
+		const workgroupCount = Math.ceil( primCount / workgroupSize );
+
+		// Pre-allocate uniform data (same as _buildSingleSubmit)
+		const ALIGN = 256;
+		const uniformCount = 1 + 1 + 4 + 1 + 1; // setup + morton + 4 sort + hploc + initCounters
+		const uniformData = new ArrayBuffer( uniformCount * ALIGN );
+
+		let offset = 0;
+		const offsets = {};
+
+		offsets.setup = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, workgroupCount, this._positionStride, 0 ] );
+		offset += ALIGN;
+
+		offsets.morton = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, workgroupCount, 0, 0 ] );
+		offset += ALIGN;
+
+		offsets.sort = [];
+		const sortWorkgroupCount = Math.ceil( primCount / 256 );
+		for ( let i = 0; i < 4; i ++ ) {
+
+			offsets.sort.push( offset );
+			new Uint32Array( uniformData, offset, 4 ).set( [ primCount, i * 8, sortWorkgroupCount, 0 ] );
+			offset += ALIGN;
+
+		}
+
+		offsets.hploc = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, 0, 0, 0 ] );
+		offset += ALIGN;
+
+		const initialWorkgroupCount = Math.ceil( primCount / this._hplocWorkgroupSize );
+
+		// Add uniforms for initIndirectCounters shader
+		offsets.initCounters = offset;
+		new Uint32Array( uniformData, offset, 4 ).set( [ primCount, initialWorkgroupCount, 0, 0 ] );
+		offset += ALIGN;
+
+		device.queue.writeBuffer( this._buildBuffers.uniforms, 0, uniformData );
+		// Note: No await needed - WebGPU guarantees ordering between writeBuffer and command submission
+
+		const ts = this._timestampBuffers;
+
+		// Push error scopes BEFORE creating command encoder to catch encoding errors
+		// (validation errors during encoding would otherwise escape)
+		device.pushErrorScope( 'validation' );
+		device.pushErrorScope( 'out-of-memory' );
+
+		const commandEncoder = device.createCommandEncoder();
+
+		// Timestamp indices - each (querySet, queryIndex) pair can only be used ONCE per command buffer
+		// Layout: [0]=setup start, [1]=setup end, [2]=sort start (builtin only), [3]=sort end (builtin only),
+		//         [4]=hploc start, [5]=hploc end
+		let tsIdx = 0;
+
+		// === SETUP PHASE (with timestamps) ===
+		// Pass 1: Bounds + init (start timestamp)
+		{
+
+			const passEncoder = commandEncoder.beginComputePass( {
+				timestampWrites: {
+					querySet: ts.querySet,
+					beginningOfPassWriteIndex: tsIdx ++,
+				},
+			} );
+			const bindGroup = device.createBindGroup( {
+				layout: this._pipelines.setupBounds.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: offsets.setup, size: 16 } },
+					{ binding: 1, resource: { buffer: this._positionBuffer } },
+					{ binding: 2, resource: { buffer: this._indexBuffer } },
+					{ binding: 3, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+					{ binding: 4, resource: { buffer: this._buildBuffers.clusterIdx } },
+					{ binding: 5, resource: { buffer: this._buildBuffers.sceneBounds } },
+					{ binding: 6, resource: { buffer: this._buildBuffers.parentIdx } },
+					{ binding: 7, resource: { buffer: this._buildBuffers.hplocState } },
+					{ binding: 8, resource: { buffer: this._buildBuffers.activeList0 } },
+				],
+			} );
+			passEncoder.setPipeline( this._pipelines.setupBounds );
+			passEncoder.setBindGroup( 0, bindGroup );
+			passEncoder.dispatchWorkgroups( workgroupCount );
+			passEncoder.end();
+
+		}
+
+		// Pass 2: Morton codes (end of setup phase - end timestamp)
+		{
+
+			const passEncoder = commandEncoder.beginComputePass( {
+				timestampWrites: {
+					querySet: ts.querySet,
+					endOfPassWriteIndex: tsIdx ++,
+				},
+			} );
+			const bindGroup = device.createBindGroup( {
+				layout: this._pipelines.setupMorton.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: offsets.morton, size: 16 } },
+					{ binding: 1, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+					{ binding: 2, resource: { buffer: this._buildBuffers.sceneBounds } },
+					{ binding: 3, resource: { buffer: this._buildBuffers.mortonCodes } },
+				],
+			} );
+			passEncoder.setPipeline( this._pipelines.setupMorton );
+			passEncoder.setBindGroup( 0, bindGroup );
+			passEncoder.dispatchWorkgroups( workgroupCount );
+			passEncoder.end();
+
+		}
+
+		// === RADIX SORT PHASE ===
+		// Note: For external sorters, we can't easily inject timestamps into their internal passes.
+		// Sort time will be computed as the gap between setup end and H-PLOC start.
+		const usingExternalSorter = this._sorterType !== SorterType.BUILTIN && this._sorter;
+
+		// Track sort timestamp indices (only used for built-in sort)
+		let sortStartIdx = - 1;
+		let sortEndIdx = - 1;
+
+		// Use external sorter if configured (OneSweep)
+		if ( usingExternalSorter ) {
+
+			// External sorter records its passes to the command encoder
+			// Note: OneSweep does 4-pass ping-pong, so output ends up back in keysIn/valsIn
+			this._sorter.sort( {
+				commandEncoder,
+				keysIn: this._buildBuffers.mortonCodes,
+				keysOut: this._buildBuffers.mortonCodesAlt,
+				valsIn: this._buildBuffers.clusterIdx,
+				valsOut: this._buildBuffers.clusterIdxAlt,
+				count: primCount,
+			} );
+
+		} else {
+
+			// Built-in radix sort: stable sort for LSD radix (with timestamps)
+			sortStartIdx = tsIdx ++;
+			sortEndIdx = tsIdx ++;
+
+			// Clear intermediate buffers to ensure clean state (prevents undefined initial contents)
+			commandEncoder.clearBuffer( this._buildBuffers.groupCounts );
+			commandEncoder.clearBuffer( this._buildBuffers.groupPrefix );
+			commandEncoder.clearBuffer( this._buildBuffers.digitOffsets );
+
+			let keysIn = this._buildBuffers.mortonCodes;
+			let keysOut = this._buildBuffers.mortonCodesAlt;
+			let valsIn = this._buildBuffers.clusterIdx;
+			let valsOut = this._buildBuffers.clusterIdxAlt;
+
+			for ( let pass = 0; pass < 4; pass ++ ) {
+
+				const uniformOffset = offsets.sort[ pass ];
+				const isFirst = ( pass === 0 );
+				const isLast = ( pass === 3 );
+
+				// Clear globalDigitCount before each radix pass
+				commandEncoder.clearBuffer( this._buildBuffers.globalDigitCount );
+
+				// Histogram: count digits per workgroup
+				{
+
+					const passOptions = isFirst ? {
+						timestampWrites: { querySet: ts.querySet, beginningOfPassWriteIndex: sortStartIdx },
+					} : {};
+					const passEncoder = commandEncoder.beginComputePass( passOptions );
+					const bindGroup = device.createBindGroup( {
+						layout: this._pipelines.radixHistogram.getBindGroupLayout( 0 ),
+						entries: [
+							{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: uniformOffset, size: 16 } },
+							{ binding: 1, resource: { buffer: keysIn } },
+							{ binding: 2, resource: { buffer: this._buildBuffers.groupCounts } },
+							{ binding: 3, resource: { buffer: this._buildBuffers.globalDigitCount } },
+						],
+					} );
+					passEncoder.setPipeline( this._pipelines.radixHistogram );
+					passEncoder.setBindGroup( 0, bindGroup );
+					passEncoder.dispatchWorkgroups( sortWorkgroupCount );
+					passEncoder.end();
+
+				}
+
+				// Workgroup scan: compute exclusive prefix sum across workgroups
+				{
+
+					const passEncoder = commandEncoder.beginComputePass();
+					const bindGroup = device.createBindGroup( {
+						layout: this._pipelines.radixWorkgroupScan.getBindGroupLayout( 0 ),
+						entries: [
+							{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: uniformOffset, size: 16 } },
+							{ binding: 1, resource: { buffer: this._buildBuffers.groupCounts } },
+							{ binding: 2, resource: { buffer: this._buildBuffers.groupPrefix } },
+						],
+					} );
+					passEncoder.setPipeline( this._pipelines.radixWorkgroupScan );
+					passEncoder.setBindGroup( 0, bindGroup );
+					passEncoder.dispatchWorkgroups( 1 );
+					passEncoder.end();
+
+				}
+
+				// Digit scan: compute digit base offsets
+				{
+
+					const passEncoder = commandEncoder.beginComputePass();
+					const bindGroup = device.createBindGroup( {
+						layout: this._pipelines.radixScan.getBindGroupLayout( 0 ),
+						entries: [
+							{ binding: 1, resource: { buffer: this._buildBuffers.globalDigitCount } },
+							{ binding: 2, resource: { buffer: this._buildBuffers.digitOffsets } },
+						],
+					} );
+					passEncoder.setPipeline( this._pipelines.radixScan );
+					passEncoder.setBindGroup( 0, bindGroup );
+					passEncoder.dispatchWorkgroups( 1 );
+					passEncoder.end();
+
+				}
+
+				// Scatter: reorder keys and values
+				{
+
+					const passOptions = isLast ? {
+						timestampWrites: { querySet: ts.querySet, endOfPassWriteIndex: sortEndIdx },
+					} : {};
+					const passEncoder = commandEncoder.beginComputePass( passOptions );
+					const bindGroup = device.createBindGroup( {
+						layout: this._pipelines.radixScatter.getBindGroupLayout( 0 ),
+						entries: [
+							{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: uniformOffset, size: 16 } },
+							{ binding: 1, resource: { buffer: keysIn } },
+							{ binding: 2, resource: { buffer: keysOut } },
+							{ binding: 3, resource: { buffer: valsIn } },
+							{ binding: 4, resource: { buffer: valsOut } },
+							{ binding: 5, resource: { buffer: this._buildBuffers.groupPrefix } },
+							{ binding: 6, resource: { buffer: this._buildBuffers.digitOffsets } },
+						],
+					} );
+					passEncoder.setPipeline( this._pipelines.radixScatter );
+					passEncoder.setBindGroup( 0, bindGroup );
+					passEncoder.dispatchWorkgroups( sortWorkgroupCount );
+					passEncoder.end();
+
+				}
+
+				[ keysIn, keysOut ] = [ keysOut, keysIn ];
+				[ valsIn, valsOut ] = [ valsOut, valsIn ];
+
+			}
+
+		}
+
+		// === H-PLOC PHASE (with timestamps) ===
+		const hplocStartIdx = tsIdx ++;
+		const hplocEndIdx = tsIdx ++;
+
+		const hplocIterations = this._runHPLOCPassSync(
+			commandEncoder,
+			primCount,
+			offsets,
+			{
+				querySet: ts.querySet,
+				startIndex: hplocStartIdx,
+				endIndex: hplocEndIdx,
+			}
+		);
+
+		// === FLATTEN PHASE (optional, with timestamps) ===
+		if ( useFlatten ) {
+
+			this._runFlattenPass( commandEncoder, primCount );
+
+		}
+
+		// === READBACK ===
+		commandEncoder.copyBufferToBuffer(
+			this._buildBuffers.nodeCounter, 0,
+			this._buildBuffers.readback, 0, 4
+		);
+		commandEncoder.copyBufferToBuffer(
+			this._buildBuffers.clusterIdx, 0,
+			this._buildBuffers.readback, 4, 4
+		);
+
+		// Resolve timestamps
+		commandEncoder.resolveQuerySet( ts.querySet, 0, tsIdx, ts.resolveBuffer, 0 );
+		commandEncoder.copyBufferToBuffer( ts.resolveBuffer, 0, ts.readbackBuffer, 0, tsIdx * 8 );
+
+		// Single submit!
+		const commandBuffer = commandEncoder.finish();
+		device.queue.submit( [ commandBuffer ] );
+
+		// Check for encoding/submission errors (error scopes were pushed before command encoder creation)
+		const tErrorScopes = performance.now();
+		const oomError = await device.popErrorScope();
+		const validationError = await device.popErrorScope();
+		const errorScopeTime = performance.now() - tErrorScopes;
+
+		if ( oomError ) {
+
+			console.error( 'GPUMeshBVH: Out-of-memory error:', oomError.message );
+
+		}
+
+		if ( validationError ) {
+
+			console.error( 'GPUMeshBVH: Validation error:', validationError.message );
+
+		}
+
+		const tQueueWait = performance.now();
+		await device.queue.onSubmittedWorkDone();
+		const queueWaitTime = performance.now() - tQueueWait;
+
+		// Read build results
+		const tNodeReadback = performance.now();
+		await this._buildBuffers.readback.mapAsync( GPUMapMode.READ );
+		const data = new Uint32Array( this._buildBuffers.readback.getMappedRange() );
+		this._nodeCount = Math.min( data[ 0 ], 2 * primCount );
+		this._rootIndex = data[ 1 ];
+		this._buildBuffers.readback.unmap();
+		const nodeReadbackTime = performance.now() - tNodeReadback;
+
+		// Read timestamps (BigUint64Array for unsigned nanosecond values)
+		const tTimestampReadback = performance.now();
+		await ts.readbackBuffer.mapAsync( GPUMapMode.READ );
+		const timestamps = new BigUint64Array( ts.readbackBuffer.getMappedRange() );
+
+		// Convert BigInt nanoseconds to milliseconds (as Number)
+		const toMs = ( start, end ) => {
+
+			// Guard against invalid timestamps (device may reset timestamp counter)
+			if ( start === 0n || end === 0n ) {
+
+				console.warn( 'GPU timestamp invalid: zero value detected', { start, end } );
+				return 0;
+
+			}
+
+			// Ensure end >= start (sanity check for timestamp validity)
+			if ( end < start ) {
+
+				console.warn( 'GPU timestamp anomaly: end < start', { start, end } );
+				return 0;
+
+			}
+
+			return Number( end - start ) / 1000000;
+
+		};
+
+		const setupTime = toMs( timestamps[ 0 ], timestamps[ 1 ] );
+		const hplocTime = toMs( timestamps[ hplocStartIdx ], timestamps[ hplocEndIdx ] );
+
+		// Sort time: for external sorters, compute as gap between setup end and H-PLOC start
+		// For built-in sort, we have explicit timestamps
+		let sortTime;
+		if ( usingExternalSorter ) {
+
+			// Sort time is the gap from setup end to H-PLOC start
+			sortTime = toMs( timestamps[ 1 ], timestamps[ hplocStartIdx ] );
+
+		} else {
+
+			// Built-in sort has explicit start/end timestamps
+			sortTime = toMs( timestamps[ sortStartIdx ], timestamps[ sortEndIdx ] );
+
+		}
+
+		ts.readbackBuffer.unmap();
+		const timestampReadbackTime = performance.now() - tTimestampReadback;
+
+		this._passTimings = {
+			setup: setupTime,
+			sort: sortTime,
+			hploc: hplocTime,
+			hplocIterations,
+			gpuTimestamps: true,
+			hostErrorScopes: errorScopeTime,
+			hostQueueWait: queueWaitTime,
+			hostNodeReadback: nodeReadbackTime,
+			hostTimestampReadback: timestampReadbackTime,
+		};
+
+	}
+
+	/**
+	 * Debug build with per-phase timing (adds await overhead)
+	 * Fallback when timestamp-query feature is not available
+	 */
+	async _buildWithTiming( primCount, useFlatten ) {
+
+		const device = this.device;
+		const workgroupSize = 256;
+		const workgroupCount = Math.ceil( primCount / workgroupSize );
+
+		const timings = {
+			setupBounds: 0,
+			setupMorton: 0,
+			setup: 0,
+			sort: 0,
+			hploc: 0,
+			hplocIterations: 0,
+			flatten: 0,
+			readback: 0,
+			syncOverhead: 0,
+		};
+
+		// Setup uniforms once
+		const uniforms = new Uint32Array( [ primCount, workgroupCount, this._positionStride, 0 ] );
+		device.queue.writeBuffer( this._buildBuffers.uniforms, 0, uniforms );
+
+		// Phase 1a: Bounds computation + state initialization
+		{
+
+			const t0 = performance.now();
+
+			const commandEncoder = device.createCommandEncoder();
+			const passEncoder = commandEncoder.beginComputePass();
+			const bindGroup = device.createBindGroup( {
+				layout: this._pipelines.setupBounds.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: this._buildBuffers.uniforms } },
+					{ binding: 1, resource: { buffer: this._positionBuffer } },
+					{ binding: 2, resource: { buffer: this._indexBuffer } },
+					{ binding: 3, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+					{ binding: 4, resource: { buffer: this._buildBuffers.clusterIdx } },
+					{ binding: 5, resource: { buffer: this._buildBuffers.sceneBounds } },
+					{ binding: 6, resource: { buffer: this._buildBuffers.parentIdx } },
+					{ binding: 7, resource: { buffer: this._buildBuffers.hplocState } },
+					{ binding: 8, resource: { buffer: this._buildBuffers.activeList0 } },
+				],
+			} );
+			passEncoder.setPipeline( this._pipelines.setupBounds );
+			passEncoder.setBindGroup( 0, bindGroup );
+			passEncoder.dispatchWorkgroups( workgroupCount );
+			passEncoder.end();
+
+			device.queue.submit( [ commandEncoder.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+			timings.setupBounds = performance.now() - t0;
+
+		}
+
+		// Phase 1b: Morton codes
+		{
+
+			const t0 = performance.now();
+
+			const commandEncoder = device.createCommandEncoder();
+			const passEncoder = commandEncoder.beginComputePass();
+			const bindGroup = device.createBindGroup( {
+				layout: this._pipelines.setupMorton.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: this._buildBuffers.uniforms } },
+					{ binding: 1, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+					{ binding: 2, resource: { buffer: this._buildBuffers.sceneBounds } },
+					{ binding: 3, resource: { buffer: this._buildBuffers.mortonCodes } },
+				],
+			} );
+			passEncoder.setPipeline( this._pipelines.setupMorton );
+			passEncoder.setBindGroup( 0, bindGroup );
+			passEncoder.dispatchWorkgroups( workgroupCount );
+			passEncoder.end();
+
+			device.queue.submit( [ commandEncoder.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+			timings.setupMorton = performance.now() - t0;
+
+		}
+
+		timings.setup = timings.setupBounds + timings.setupMorton;
+
+		// Phase 2: Radix Sort
+		{
+
+			const t0 = performance.now();
+			this._runRadixSortPass( null, primCount );
+			await this.device.queue.onSubmittedWorkDone();
+			timings.sort = performance.now() - t0;
+
+		}
+
+		// Phase 3: H-PLOC
+		{
+
+			const t0 = performance.now();
+			const commandEncoder = this.device.createCommandEncoder();
+			timings.hplocIterations = this._runHPLOCPassSync( commandEncoder, primCount );
+			this.device.queue.submit( [ commandEncoder.finish() ] );
+			await this.device.queue.onSubmittedWorkDone();
+			timings.hploc = performance.now() - t0;
+
+		}
+
+		// Phase 4: Flatten (optional)
+		if ( useFlatten ) {
+
+			const t0 = performance.now();
+			const commandEncoder = this.device.createCommandEncoder();
+			this._runFlattenPass( commandEncoder, primCount );
+			this.device.queue.submit( [ commandEncoder.finish() ] );
+			await this.device.queue.onSubmittedWorkDone();
+			timings.flatten = performance.now() - t0;
+
+		}
+
+		// Readback
+		{
+
+			const t0 = performance.now();
+
+			const commandEncoder = this.device.createCommandEncoder();
+			commandEncoder.copyBufferToBuffer(
+				this._buildBuffers.nodeCounter, 0,
+				this._buildBuffers.readback, 0, 4
+			);
+			commandEncoder.copyBufferToBuffer(
+				this._buildBuffers.clusterIdx, 0,
+				this._buildBuffers.readback, 4, 4
+			);
+			this.device.queue.submit( [ commandEncoder.finish() ] );
+			await this.device.queue.onSubmittedWorkDone();
+
+			await this._buildBuffers.readback.mapAsync( GPUMapMode.READ );
+			const data = new Uint32Array( this._buildBuffers.readback.getMappedRange() );
+			this._nodeCount = Math.min( data[ 0 ], 2 * primCount );
+			this._rootIndex = data[ 1 ];
+			this._buildBuffers.readback.unmap();
+
+			timings.readback = performance.now() - t0;
+
+		}
+
+		this._passTimings = timings;
+
+	}
+
+	dispose() {
+
+		if ( this._bvhBuffer ) {
+
+			this._bvhBuffer.destroy();
+			this._bvhBuffer = null;
+
+		}
+
+		if ( this._positionBuffer && ! this._externalPositionBuffer ) {
+
+			this._positionBuffer.destroy();
+
+		}
+
+		this._positionBuffer = null;
+
+		if ( this._indexBuffer && ! this._externalIndexBuffer ) {
+
+			this._indexBuffer.destroy();
+
+		}
+
+		this._indexBuffer = null;
+
+		if ( this._buildBuffers ) {
+
+			for ( const key in this._buildBuffers ) {
+
+				this._buildBuffers[ key ].destroy();
+
+			}
+
+			this._buildBuffers = null;
+
+		}
+
+		// Release cached bind groups (lightweight refs, no .destroy() needed)
+		this._hplocBindGroups = null;
+		this._setupBindGroups = null;
+		this._sortBindGroups = null;
+		this._refitBindGroups = null;
+		this._hplocBindGroupsCacheKey = null;
+		this._setupBindGroupsCacheKey = null;
+		this._sortBindGroupsCacheKey = null;
+		this._refitBindGroupsCacheKey = null;
+
+		if ( this._timestampBuffers ) {
+
+			this._timestampBuffers.querySet.destroy();
+			this._timestampBuffers.resolveBuffer.destroy();
+			this._timestampBuffers.readbackBuffer.destroy();
+			this._timestampBuffers = null;
+
+		}
+
+		if ( this._sorter ) {
+
+			this._sorter.dispose();
+			this._sorter = null;
+
+		}
+
+	}
+
+	// ---- Private methods ----
+
+	_extractGeometryData( geometry ) {
+
+		const positionAttr = geometry.getAttribute( 'position' );
+		const indexAttr = geometry.getIndex();
+
+		if ( ! positionAttr ) {
+
+			throw new Error( 'GPUMeshBVH: geometry must have position attribute' );
+
+		}
+
+		let positions;
+		let indices;
+		let primCount;
+
+		const vertexCount = positionAttr.count;
+
+		// Zero-copy: use raw Float32Array directly if possible (no vec4 padding)
+		if ( positionAttr.isInterleavedBufferAttribute ) {
+
+			// Interleaved - must copy to packed array
+			positions = new Float32Array( vertexCount * 3 );
+			for ( let i = 0; i < vertexCount; i ++ ) {
+
+				const dstBase = i * 3;
+				positions[ dstBase ] = positionAttr.getX( i );
+				positions[ dstBase + 1 ] = positionAttr.getY( i );
+				positions[ dstBase + 2 ] = positionAttr.getZ( i );
+
+			}
+
+		} else {
+
+			// Non-interleaved: use underlying array directly (zero-copy)
+			positions = positionAttr.array;
+
+		}
+
+		if ( indexAttr ) {
+
+			// Indexed geometry - use raw index array (convert Uint16 to Uint32 if needed)
+			const srcIndices = indexAttr.array;
+			primCount = Math.floor( srcIndices.length / 3 );
+
+			if ( srcIndices instanceof Uint32Array ) {
+
+				// Zero-copy: use directly
+				indices = srcIndices;
+
+			} else {
+
+				// Convert Uint16Array to Uint32Array for WebGPU alignment
+				indices = new Uint32Array( srcIndices );
+
+			}
+
+		} else {
+
+			// Non-indexed geometry - generate sequential indices
+			primCount = Math.floor( vertexCount / 3 );
+			indices = new Uint32Array( primCount * 3 );
+
+			for ( let i = 0; i < primCount * 3; i ++ ) {
+
+				indices[ i ] = i;
+
+			}
+
+		}
+
+		return { positions, indices, primCount };
+
+	}
+
+	_allocateBuffers( primCount ) {
+
+		const device = this.device;
+		const workgroupSize = 256;
+
+		// Buffer reuse optimization: only reallocate if primCount exceeds current capacity
+		// Use power-of-2 growth to minimize reallocations
+		if ( this._buildBuffers && primCount <= this._bufferCapacity ) {
+
+			// Reuse existing buffers - no allocation needed
+			return;
+
+		}
+
+		// Calculate new capacity with growth factor (next power of 2, min 1024)
+		const newCapacity = Math.max( 1024, this._nextPowerOf2( primCount ) );
+		if ( this._verbose ) console.info( `GPUMeshBVH: Allocating buffers (primCount=${primCount}, newCapacity=${newCapacity}, oldCapacity=${this._bufferCapacity || 0})` );
+
+		// Ensure at least 1 workgroup for buffer allocations (prevents zero-size buffers)
+		const workgroupCount = Math.max( 1, Math.ceil( newCapacity / workgroupSize ) );
+
+		// Max nodes = 2 * capacity - 1 for binary tree
+		const maxNodes = 2 * newCapacity;
+
+		// Destroy old build buffers
+		if ( this._buildBuffers ) {
+
+			for ( const key in this._buildBuffers ) {
+
+				this._buildBuffers[ key ].destroy();
+
+			}
+
+		}
+
+		// Invalidate cached bind groups (they reference old buffers)
+		this._hplocBindGroups = null;
+		this._hplocBindGroupsCacheKey = null;
+		this._setupBindGroups = null;
+		this._setupBindGroupsCacheKey = null;
+		this._sortBindGroups = null;
+		this._sortBindGroupsCacheKey = null;
+		this._refitBindGroups = null;
+		this._refitBindGroupsCacheKey = null;
+		this._refitParentsDirty = true;
+
+		// Destroy old BVH buffer
+		if ( this._bvhBuffer ) {
+
+			this._bvhBuffer.destroy();
+
+		}
+
+		// Store new capacity
+		this._bufferCapacity = newCapacity;
+
+		// Build state buffers (sized to capacity for reuse)
+		this._buildBuffers = {
+			// Atomic scene bounds in sortable-u32 format:
+			// [minX, minY, minZ, maxX, maxY, maxZ]
+			// Uses native atomicMin/atomicMax for parallel reduction.
+			sceneBounds: device.createBuffer( {
+				size: 24, // 6 × u32
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Morton codes (32-bit)
+			mortonCodes: device.createBuffer( {
+				size: newCapacity * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Morton codes (double buffer for sort)
+			mortonCodesAlt: device.createBuffer( {
+				size: newCapacity * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Cluster indices
+			clusterIdx: device.createBuffer( {
+				size: newCapacity * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Cluster indices (double buffer for sort)
+			clusterIdxAlt: device.createBuffer( {
+				size: newCapacity * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Partial bounds buffers removed - atomic scene bounds eliminates reduction passes
+
+			// Parent IDs:
+			// - during build: LBVH traversal scratch (indices < primCount)
+			// - during refit: node parent map (indices < nodeCount)
+			parentIdx: device.createBuffer( {
+				size: maxNodes * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Per-node child completion counters for refit propagation
+			refitVisitCount: device.createBuffer( {
+				size: maxNodes * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// BVH2 nodes (during build)
+			// Node: bounds (24 bytes) + leftChild (4) + rightChild (4) = 32 bytes
+			bvh2Nodes: device.createBuffer( {
+				size: maxNodes * 32,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+			} ),
+
+			// Flattening scratch
+			subtreeSizes: device.createBuffer( {
+				size: maxNodes * 4,
+				usage: GPUBufferUsage.STORAGE,
+			} ),
+
+			flattenStackNodes: device.createBuffer( {
+				size: maxNodes * 4,
+				usage: GPUBufferUsage.STORAGE,
+			} ),
+
+			flattenStackOut: device.createBuffer( {
+				size: maxNodes * 4,
+				usage: GPUBufferUsage.STORAGE,
+			} ),
+
+			// Atomic counter for node allocation
+			nodeCounter: device.createBuffer( {
+				size: 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// H-PLOC persistent state buffer (for multi-dispatch)
+			// Interleaved: [left0, right0, split0, active0, left1, ...]
+			// COPY_SRC added for debugging readback
+			hplocState: device.createBuffer( {
+				size: newCapacity * 4 * 4, // 4 u32s per primitive
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+			} ),
+
+			// Indirect dispatch buffers for H-PLOC optimization
+			// Double-buffered active lists for ping-pong during indirect dispatch
+			// Note: These are initialized via GPU compute pass (initIndirectCounters + initActiveList)
+			activeList0: device.createBuffer( {
+				size: Math.max( 16, newCapacity * 4 ),
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+			} ),
+			activeList1: device.createBuffer( {
+				size: Math.max( 16, newCapacity * 4 ),
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+			} ),
+			// Atomic counters for active list sizes (initialized via GPU compute pass)
+			activeCount0: device.createBuffer( {
+				size: 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+			} ),
+			activeCount1: device.createBuffer( {
+				size: 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+			} ),
+			// Indirect dispatch arguments (initialized via GPU compute pass)
+			// [workgroupCountX, workgroupCountY, workgroupCountZ]
+			// COPY_SRC added for debugging readback
+			indirectDispatch: device.createBuffer( {
+				size: 12, // 3 × u32
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+			} ),
+
+			// Radix sort: stable sort using deterministic workgroup-order prefix scan
+			// All radix buffers include COPY_DST for explicit clearing (prevents undefined initial contents)
+			// groupCounts stores per-workgroup digit counts (histogram output)
+			groupCounts: device.createBuffer( {
+				size: workgroupCount * 256 * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// groupPrefix stores per-workgroup digit offsets (workgroup scan output)
+			groupPrefix: device.createBuffer( {
+				size: workgroupCount * 256 * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// globalDigitCount: 256 counters for total digit counts
+			// Reset to 0 before each radix pass
+			globalDigitCount: device.createBuffer( {
+				size: 256 * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			digitOffsets: device.createBuffer( {
+				size: 256 * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Uniforms - larger buffer for single-submission batching (Phase 2 optimization)
+			// Layout: multiple 256-byte aligned uniform blocks for all passes
+			uniforms: device.createBuffer( {
+				size: 4096, // Room for ~16 uniform blocks at 256-byte alignment
+				usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Combined readback buffer for nodeCount + rootIndex
+			readback: device.createBuffer( {
+				size: 8,
+				usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+			} ),
+		};
+
+		// Output buffers (final BVH)
+		// Node: bounds (24 bytes) + rightChildOrOffset (4) + splitAxisOrCount (4) = 32 bytes
+		this._bvhBuffer = device.createBuffer( {
+			size: maxNodes * 32,
+			usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+		} );
+
+		// Timestamp query buffers (for accurate per-phase timing)
+		// Phases: setup(2), sort(2), hploc(2), flatten(2) = 8 timestamps max
+		// Only create once - reuse on subsequent builds to avoid exhausting Metal's query set pool
+		if ( this._hasTimestampQuery && ! this._timestampBuffers ) {
+
+			this._timestampBuffers = {
+				querySet: device.createQuerySet( {
+					type: 'timestamp',
+					count: 8,
+				} ),
+				resolveBuffer: device.createBuffer( {
+					size: 8 * 8, // 8 timestamps × 8 bytes each (u64)
+					usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC,
+				} ),
+				readbackBuffer: device.createBuffer( {
+					size: 8 * 8,
+					usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+				} ),
+			};
+
+		}
+
+	}
+
+	_uploadGeometry( positions, indices, resetBuildState = true ) {
+
+		const device = this.device;
+
+		// Standard geometry upload always uses stride 3 and owns its buffers
+		this._positionStride = 3;
+
+		// If switching from external buffers, release references (don't destroy - we don't own them)
+		if ( this._externalPositionBuffer ) {
+
+			this._positionBuffer = null;
+			this._positionBufferCapacity = 0;
+
+		}
+
+		if ( this._externalIndexBuffer ) {
+
+			this._indexBuffer = null;
+			this._indexBufferCapacity = 0;
+
+		}
+
+		this._externalPositionBuffer = false;
+		this._externalIndexBuffer = false;
+
+		// Geometry buffer reuse: only reallocate if new data exceeds capacity
+		const positionBytes = positions.byteLength;
+		const indexBytes = indices.byteLength;
+
+		// Position buffer - reuse if capacity sufficient
+		if ( ! this._positionBuffer || positionBytes > this._positionBufferCapacity ) {
+
+			if ( this._positionBuffer ) {
+
+				this._positionBuffer.destroy();
+
+			}
+
+			// Grow with 1.5x factor for positions
+			const newCapacity = Math.max( positionBytes, Math.ceil( ( this._positionBufferCapacity || 0 ) * 1.5 ) );
+			this._positionBufferCapacity = newCapacity;
+
+			this._positionBuffer = device.createBuffer( {
+				size: newCapacity,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} );
+
+			// New buffer identity - invalidate setup/refit bind groups
+			this._setupBindGroups = null;
+			this._refitBindGroups = null;
+			this._refitBindGroupsCacheKey = null;
+
+		}
+
+		// Write position data (works for both new and reused buffers)
+		device.queue.writeBuffer( this._positionBuffer, 0, positions );
+
+		// Index buffer - reuse if capacity sufficient
+		if ( ! this._indexBuffer || indexBytes > this._indexBufferCapacity ) {
+
+			if ( this._indexBuffer ) {
+
+				this._indexBuffer.destroy();
+
+			}
+
+			// Grow with 1.5x factor for indices
+			const newCapacity = Math.max( indexBytes, Math.ceil( ( this._indexBufferCapacity || 0 ) * 1.5 ) );
+			this._indexBufferCapacity = newCapacity;
+
+			this._indexBuffer = device.createBuffer( {
+				size: newCapacity,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} );
+
+			// New buffer identity - invalidate setup/refit bind groups
+			this._setupBindGroups = null;
+			this._refitBindGroups = null;
+			this._refitBindGroupsCacheKey = null;
+
+		}
+
+		// Write index data (works for both new and reused buffers)
+		device.queue.writeBuffer( this._indexBuffer, 0, indices );
+
+		// Initialize build state (scene bounds, node counter) for full rebuilds.
+		// Refit uploads only update geometry data and preserve existing topology.
+		if ( resetBuildState ) {
+
+			this._initBuildState();
+
+		}
+
+	}
+
+	/**
+	 * Initialize build state buffers (scene bounds, node counter).
+	 * Called by both _uploadGeometry and buildAsyncFromGPUBuffers.
+	 */
+	_initBuildState() {
+
+		const device = this.device;
+
+		// Initialize atomic scene bounds in sortable-u32 space:
+		// min starts at +Infinity key, max starts at -Infinity key.
+		const boundsInitU32 = new Uint32Array( [
+			0xFF800000, 0xFF800000, 0xFF800000, // +Infinity encoded
+			0x007FFFFF, 0x007FFFFF, 0x007FFFFF, // -Infinity encoded
+		] );
+		device.queue.writeBuffer( this._buildBuffers.sceneBounds, 0, boundsInitU32 );
+
+		// Initialize node counter to primCount (leaves are pre-allocated)
+		const counterInit = new Uint32Array( [ this._primCount ] );
+		device.queue.writeBuffer( this._buildBuffers.nodeCounter, 0, counterInit );
+
+		// NOTE: parentIdx and hplocState are now initialized on GPU in computeBounds shader
+		// This removes ~3ms of CPU overhead for 30k triangles
+
+		// Write uniforms
+		const uniforms = new Uint32Array( [ this._primCount, 0, 0, 0 ] );
+		device.queue.writeBuffer( this._buildBuffers.uniforms, 0, uniforms );
+
+	}
+
+	_createPipelines() {
+
+		const device = this.device;
+
+		// Check for subgroups support (for optimized bounds reduction)
+		const hasSubgroups = device.features && device.features.has( 'subgroups' );
+
+		// Setup pass pipelines (use subgroup-optimized version when available)
+		const boundsShaderCode = hasSubgroups ? setupShaders.computeBoundsSubgroup : setupShaders.computeBounds;
+		const setupBoundsModule = device.createShaderModule( { code: boundsShaderCode } );
+		const setupBoundsPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: setupBoundsModule,
+				entryPoint: 'computeBounds',
+			},
+		} );
+
+		const setupReduceModule = device.createShaderModule( { code: setupShaders.reduceBounds } );
+		const setupReducePipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: setupReduceModule,
+				entryPoint: 'reduceBounds',
+			},
+		} );
+
+		const setupReducePartialModule = device.createShaderModule( { code: setupShaders.reduceBoundsToPartial } );
+		const setupReducePartialPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: setupReducePartialModule,
+				entryPoint: 'reduceBoundsToPartial',
+			},
+		} );
+
+		const setupMortonModule = device.createShaderModule( { code: setupShaders.computeMorton } );
+		const setupMortonPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: setupMortonModule,
+				entryPoint: 'computeMorton',
+			},
+		} );
+
+		// Radix sort pipelines (stable sort for LSD radix correctness)
+		const radixHistogramModule = device.createShaderModule( { code: radixSortShaders.histogram } );
+		const radixWorkgroupScanModule = device.createShaderModule( { code: radixSortShaders.workgroupScan } );
+		const radixScanModule = device.createShaderModule( { code: radixSortShaders.scan } );
+		const radixScatterModule = device.createShaderModule( { code: radixSortShaders.scatter } );
+
+		const radixHistogramPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: radixHistogramModule,
+				entryPoint: 'computeHistogram',
+			},
+		} );
+
+		const radixWorkgroupScanPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: radixWorkgroupScanModule,
+				entryPoint: 'workgroupScan',
+			},
+		} );
+
+		const radixScanPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: radixScanModule,
+				entryPoint: 'prefixScan',
+			},
+		} );
+
+		const radixScatterPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: radixScatterModule,
+				entryPoint: 'scatter',
+			},
+		} );
+
+		// H-PLOC pipeline - select optimal variant based on detected subgroup size
+		// 1-subgroup-per-workgroup variants (wave32, wave64) eliminate wasted barrier overhead
+		const { shaderSource: hplocCode, label: hplocVariant, workgroupSize: hplocWG } = this._selectHPLOCShaderVariant();
+		this._hplocShaderVariant = hplocVariant;
+		this._hplocWorkgroupSize = hplocWG;
+
+		const hplocModule = device.createShaderModule( {
+			label: `H-PLOC Shader (${hplocVariant})`,
+			code: hplocCode,
+		} );
+		const hplocPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: hplocModule,
+				entryPoint: 'hplocBuild',
+			},
+		} );
+
+		if ( hplocVariant !== 'fallback' && this._verbose ) {
+
+			console.info( `GPUMeshBVH: Using ${hplocVariant} H-PLOC shader (WG=${hplocWG}, subgroup size ${this._subgroupSize})` );
+
+		}
+
+		// H-PLOC indirect dispatch pipelines - select variant matching direct shader
+		// Wave32/Wave64 indirect variants enable single-pass indirect dispatch
+		let hplocIndirectCode = hplocShaderIndirect; // Fallback
+		let updateDispatchCode = hplocUpdateDispatchShaderWave64; // Default
+
+		if ( hplocVariant === 'wave32' ) {
+
+			hplocIndirectCode = hplocShaderWave32Indirect;
+			updateDispatchCode = hplocUpdateDispatchShaderWave32;
+
+		} else if ( hplocVariant === 'wave64' ) {
+
+			hplocIndirectCode = hplocShaderWave64Indirect;
+			updateDispatchCode = hplocUpdateDispatchShaderWave64;
+
+		}
+
+		const hplocIndirectModule = device.createShaderModule( {
+			label: `H-PLOC Indirect Shader (${hplocVariant})`,
+			code: hplocIndirectCode,
+		} );
+		const hplocIndirectPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: hplocIndirectModule,
+				entryPoint: 'hplocBuildIndirect',
+			},
+		} );
+
+		const updateDispatchModule = device.createShaderModule( {
+			label: `Update Dispatch Shader (${hplocVariant})`,
+			code: updateDispatchCode,
+		} );
+		const updateDispatchPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: updateDispatchModule,
+				entryPoint: 'updateIndirectDispatch',
+			},
+		} );
+
+		const initActiveListModule = device.createShaderModule( { code: hplocInitActiveListShader } );
+		const initActiveListPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: initActiveListModule,
+				entryPoint: 'initActiveList',
+			},
+		} );
+
+		// Init indirect counters pipeline - initializes all counters in GPU for reliable ordering
+		const initIndirectCountersModule = device.createShaderModule( {
+			label: 'initIndirectCounters',
+			code: hplocInitIndirectCountersShader,
+		} );
+
+		// Check for shader compilation errors
+		initIndirectCountersModule.getCompilationInfo().then( info => {
+
+			for ( const msg of info.messages ) {
+
+				if ( msg.type === 'error' ) {
+
+					console.error( `initIndirectCounters shader error: ${msg.message} at line ${msg.lineNum}` );
+
+				} else if ( msg.type === 'warning' ) {
+
+					console.warn( `initIndirectCounters shader warning: ${msg.message}` );
+
+				}
+
+			}
+
+		} );
+
+		const initIndirectCountersPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: initIndirectCountersModule,
+				entryPoint: 'initIndirectCounters',
+			},
+		} );
+
+		// Flatten pipeline
+		const flattenModule = device.createShaderModule( { code: flattenShader } );
+		const flattenSizePipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: flattenModule,
+				entryPoint: 'computeSubtreeSizes',
+			},
+		} );
+
+		const flattenPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: flattenModule,
+				entryPoint: 'flattenTree',
+			},
+		} );
+
+		// Refit pipelines
+		const refitBuildParentsModule = device.createShaderModule( {
+			label: 'refitBuildParents',
+			code: refitBuildParentsShader,
+		} );
+		const refitBuildParentsPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: refitBuildParentsModule,
+				entryPoint: 'buildParentMap',
+			},
+		} );
+
+		const refitLeavesModule = device.createShaderModule( {
+			label: 'refitBVHLeaves',
+			code: refitBVHLeavesShader,
+		} );
+		const refitLeavesPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: refitLeavesModule,
+				entryPoint: 'refitLeaves',
+			},
+		} );
+
+		const refitInternalModule = device.createShaderModule( {
+			label: 'refitBVHInternal',
+			code: getRefitBVHInternalShader( 256 ),
+		} );
+		const refitInternalPipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: {
+				module: refitInternalModule,
+				entryPoint: 'refitInternalWave',
+			},
+		} );
+
+		return {
+			setupBounds: setupBoundsPipeline,
+			setupReduce: setupReducePipeline,
+			setupReducePartial: setupReducePartialPipeline,
+			setupMorton: setupMortonPipeline,
+			radixHistogram: radixHistogramPipeline,
+			radixWorkgroupScan: radixWorkgroupScanPipeline,
+			radixScan: radixScanPipeline,
+			radixScatter: radixScatterPipeline,
+			hploc: hplocPipeline,
+			hplocIndirect: hplocIndirectPipeline,
+			updateDispatch: updateDispatchPipeline,
+			initActiveList: initActiveListPipeline,
+			initIndirectCounters: initIndirectCountersPipeline,
+			flattenSize: flattenSizePipeline,
+			flatten: flattenPipeline,
+			refitBuildParents: refitBuildParentsPipeline,
+			refitLeaves: refitLeavesPipeline,
+			refitInternal: refitInternalPipeline,
+		};
+
+	}
+
+	_runSetupPass( unusedEncoder, primCount ) {
+
+		if ( primCount === 0 ) return;
+
+		const device = this.device;
+		const workgroupSize = 256;
+		const workgroupCount = Math.ceil( primCount / workgroupSize );
+
+		const uniforms = new Uint32Array( [ primCount, workgroupCount, 0, 0 ] );
+		device.queue.writeBuffer( this._buildBuffers.uniforms, 0, uniforms );
+
+		const commandEncoder = device.createCommandEncoder();
+
+		// Pass 1: compute bounds + atomic update scene bounds + initialize state
+		// Reduction passes eliminated - native integer atomics handle scene bounds directly
+		{
+
+			const passEncoder = commandEncoder.beginComputePass();
+			const bindGroup = device.createBindGroup( {
+				layout: this._pipelines.setupBounds.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: this._buildBuffers.uniforms } },
+					{ binding: 1, resource: { buffer: this._positionBuffer } },
+					{ binding: 2, resource: { buffer: this._indexBuffer } },
+					{ binding: 3, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+					{ binding: 4, resource: { buffer: this._buildBuffers.clusterIdx } },
+					{ binding: 5, resource: { buffer: this._buildBuffers.sceneBounds } },
+					{ binding: 6, resource: { buffer: this._buildBuffers.parentIdx } },
+					{ binding: 7, resource: { buffer: this._buildBuffers.hplocState } },
+					{ binding: 8, resource: { buffer: this._buildBuffers.activeList0 } },
+				],
+			} );
+
+			passEncoder.setPipeline( this._pipelines.setupBounds );
+			passEncoder.setBindGroup( 0, bindGroup );
+			passEncoder.dispatchWorkgroups( workgroupCount );
+			passEncoder.end();
+
+		}
+
+		// Pass 2: Morton codes (scene bounds already computed via atomics)
+		{
+
+			const passEncoder = commandEncoder.beginComputePass();
+			const bindGroup = device.createBindGroup( {
+				layout: this._pipelines.setupMorton.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: this._buildBuffers.uniforms } },
+					{ binding: 1, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+					{ binding: 2, resource: { buffer: this._buildBuffers.sceneBounds } },
+					{ binding: 3, resource: { buffer: this._buildBuffers.mortonCodes } },
+				],
+			} );
+
+			passEncoder.setPipeline( this._pipelines.setupMorton );
+			passEncoder.setBindGroup( 0, bindGroup );
+			passEncoder.dispatchWorkgroups( workgroupCount );
+			passEncoder.end();
+
+		}
+
+		device.queue.submit( [ commandEncoder.finish() ] );
+
+	}
+
+	_runRadixSortPass( unusedEncoder, primCount ) {
+
+		// Use external sorter if configured (check both _sorterType and _sorter for safety)
+		if ( this._sorterType !== SorterType.BUILTIN && this._sorter ) {
+
+			// Note: OneSweep does 4-pass ping-pong, so output ends up back in keysIn/valsIn
+			const commandEncoder = this.device.createCommandEncoder();
+			this._sorter.sort( {
+				commandEncoder,
+				keysIn: this._buildBuffers.mortonCodes,
+				keysOut: this._buildBuffers.mortonCodesAlt,
+				valsIn: this._buildBuffers.clusterIdx,
+				valsOut: this._buildBuffers.clusterIdxAlt,
+				count: primCount,
+			} );
+			this.device.queue.submit( [ commandEncoder.finish() ] );
+			return;
+
+		}
+
+		// Built-in radix sort: 32-bit Morton codes, 4 passes of 8-bit digits (stable sort for LSD radix)
+		// Each pass needs different uniforms, so we submit each separately
+		const numPasses = 4;
+		const workgroupCount = Math.ceil( primCount / 256 );
+
+		// Clear intermediate buffers once at start (prevents undefined initial contents)
+		{
+
+			const clearEncoder = this.device.createCommandEncoder();
+			clearEncoder.clearBuffer( this._buildBuffers.groupCounts );
+			clearEncoder.clearBuffer( this._buildBuffers.groupPrefix );
+			clearEncoder.clearBuffer( this._buildBuffers.digitOffsets );
+			this.device.queue.submit( [ clearEncoder.finish() ] );
+
+		}
+
+		let keysIn = this._buildBuffers.mortonCodes;
+		let keysOut = this._buildBuffers.mortonCodesAlt;
+		let valsIn = this._buildBuffers.clusterIdx;
+		let valsOut = this._buildBuffers.clusterIdxAlt;
+
+		for ( let pass = 0; pass < numPasses; pass ++ ) {
+
+			const bitOffset = pass * 8;
+
+			// Update uniforms with bit offset + workgroup count
+			const uniforms = new Uint32Array( [ primCount, bitOffset, workgroupCount, 0 ] );
+			this.device.queue.writeBuffer( this._buildBuffers.uniforms, 0, uniforms );
+
+			// Reset globalDigitCount to 0 before each radix pass
+			this.device.queue.writeBuffer( this._buildBuffers.globalDigitCount, 0, new Uint32Array( 256 ) );
+
+			// Each radix pass gets its own command encoder + submit
+			const commandEncoder = this.device.createCommandEncoder();
+
+			// Histogram pass: count digits per workgroup
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				const bindGroup = this.device.createBindGroup( {
+					layout: this._pipelines.radixHistogram.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms } },
+						{ binding: 1, resource: { buffer: keysIn } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.groupCounts } },
+						{ binding: 3, resource: { buffer: this._buildBuffers.globalDigitCount } },
+					],
+				} );
+				passEncoder.setPipeline( this._pipelines.radixHistogram );
+				passEncoder.setBindGroup( 0, bindGroup );
+				passEncoder.dispatchWorkgroups( workgroupCount );
+				passEncoder.end();
+
+			}
+
+			// Workgroup scan pass: compute exclusive prefix sum across workgroups
+			// This ensures stability - workgroup 0's elements come before workgroup 1's
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				const bindGroup = this.device.createBindGroup( {
+					layout: this._pipelines.radixWorkgroupScan.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.groupCounts } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.groupPrefix } },
+					],
+				} );
+				passEncoder.setPipeline( this._pipelines.radixWorkgroupScan );
+				passEncoder.setBindGroup( 0, bindGroup );
+				passEncoder.dispatchWorkgroups( 1 );
+				passEncoder.end();
+
+			}
+
+			// Digit scan pass: compute digit base offsets
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				const bindGroup = this.device.createBindGroup( {
+					layout: this._pipelines.radixScan.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 1, resource: { buffer: this._buildBuffers.globalDigitCount } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.digitOffsets } },
+					],
+				} );
+				passEncoder.setPipeline( this._pipelines.radixScan );
+				passEncoder.setBindGroup( 0, bindGroup );
+				passEncoder.dispatchWorkgroups( 1 );
+				passEncoder.end();
+
+			}
+
+			// Scatter pass: reorder keys and values
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				const bindGroup = this.device.createBindGroup( {
+					layout: this._pipelines.radixScatter.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms } },
+						{ binding: 1, resource: { buffer: keysIn } },
+						{ binding: 2, resource: { buffer: keysOut } },
+						{ binding: 3, resource: { buffer: valsIn } },
+						{ binding: 4, resource: { buffer: valsOut } },
+						{ binding: 5, resource: { buffer: this._buildBuffers.groupPrefix } },
+						{ binding: 6, resource: { buffer: this._buildBuffers.digitOffsets } },
+					],
+				} );
+				passEncoder.setPipeline( this._pipelines.radixScatter );
+				passEncoder.setBindGroup( 0, bindGroup );
+				passEncoder.dispatchWorkgroups( workgroupCount );
+				passEncoder.end();
+
+			}
+
+			// Submit this radix pass
+			this.device.queue.submit( [ commandEncoder.finish() ] );
+
+			// Swap buffers for next pass
+			[ keysIn, keysOut ] = [ keysOut, keysIn ];
+			[ valsIn, valsOut ] = [ valsOut, valsIn ];
+
+		}
+
+		// After even number of passes, result is back in original buffers
+		// (mortonCodes, clusterIdx)
+
+	}
+
+	/**
+	 * Record setup pass to command encoder (Phase 2: single-submission batching)
+	 * Uses pre-uploaded uniforms at specified offsets
+	 * Atomic scene bounds - no reduction passes needed
+	 */
+	_recordSetupPass( commandEncoder, primCount, offsets ) {
+
+		if ( primCount === 0 ) return;
+
+		const device = this.device;
+		const workgroupSize = 256;
+		const workgroupCount = Math.ceil( primCount / workgroupSize );
+
+		// Cache setup bind groups (invalidated by _allocateBuffers and buffer identity changes)
+		const cacheKey = `${offsets.setup}_${offsets.morton}`;
+		if ( ! this._setupBindGroups || this._setupBindGroupsCacheKey !== cacheKey ) {
+
+			this._setupBindGroupsCacheKey = cacheKey;
+			this._setupBindGroups = {
+				bounds: device.createBindGroup( {
+					layout: this._pipelines.setupBounds.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: offsets.setup, size: 16 } },
+						{ binding: 1, resource: { buffer: this._positionBuffer } },
+						{ binding: 2, resource: { buffer: this._indexBuffer } },
+						{ binding: 3, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+						{ binding: 4, resource: { buffer: this._buildBuffers.clusterIdx } },
+						{ binding: 5, resource: { buffer: this._buildBuffers.sceneBounds } },
+						{ binding: 6, resource: { buffer: this._buildBuffers.parentIdx } },
+						{ binding: 7, resource: { buffer: this._buildBuffers.hplocState } },
+						{ binding: 8, resource: { buffer: this._buildBuffers.activeList0 } },
+					],
+				} ),
+				morton: device.createBindGroup( {
+					layout: this._pipelines.setupMorton.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: offsets.morton, size: 16 } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.sceneBounds } },
+						{ binding: 3, resource: { buffer: this._buildBuffers.mortonCodes } },
+					],
+				} ),
+			};
+
+		}
+
+		// Pass 1: Bounds computation + atomic scene bounds + state initialization
+		{
+
+			const passEncoder = commandEncoder.beginComputePass();
+			passEncoder.setPipeline( this._pipelines.setupBounds );
+			passEncoder.setBindGroup( 0, this._setupBindGroups.bounds );
+			passEncoder.dispatchWorkgroups( workgroupCount );
+			passEncoder.end();
+
+		}
+
+		// Pass 2: Morton codes (scene bounds already computed via atomics)
+		{
+
+			const passEncoder = commandEncoder.beginComputePass();
+			passEncoder.setPipeline( this._pipelines.setupMorton );
+			passEncoder.setBindGroup( 0, this._setupBindGroups.morton );
+			passEncoder.dispatchWorkgroups( workgroupCount );
+			passEncoder.end();
+
+		}
+
+	}
+
+	/**
+	 * Initialize external sorter if configured
+	 */
+	async _initSorter( primCount ) {
+
+		if ( this._sorterType === SorterType.ONESWEEP ) {
+
+			this._sorter = new OneSweepSorter( this.device );
+			await this._sorter.init( primCount );
+			if ( this._verbose ) console.info( `GPUMeshBVH: Using OneSweep sorter` );
+
+		}
+
+	}
+
+	/**
+	 * Detect GPU subgroup size for optimal H-PLOC shader variant selection.
+	 * Returns: 16, 32, 64, or 0 if subgroups not supported.
+	 */
+	async _detectSubgroupSize() {
+
+		if ( this._subgroupSize > 0 ) {
+
+			return this._subgroupSize;
+
+		}
+
+		if ( ! this._hasSubgroups ) {
+
+			this._subgroupSize = 0;
+			return 0;
+
+		}
+
+		const device = this.device;
+
+		try {
+
+			const module = device.createShaderModule( {
+				label: 'H-PLOC Subgroup Probe',
+				code: subgroupDetectShader,
+			} );
+
+			const pipeline = device.createComputePipeline( {
+				layout: 'auto',
+				compute: { module, entryPoint: 'main' },
+			} );
+
+			const outputBuffer = device.createBuffer( {
+				size: 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+			} );
+
+			const stagingBuffer = device.createBuffer( {
+				size: 4,
+				usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+			} );
+
+			const bindGroup = device.createBindGroup( {
+				layout: pipeline.getBindGroupLayout( 0 ),
+				entries: [ { binding: 0, resource: { buffer: outputBuffer } } ],
+			} );
+
+			const encoder = device.createCommandEncoder();
+			const pass = encoder.beginComputePass();
+			pass.setPipeline( pipeline );
+			pass.setBindGroup( 0, bindGroup );
+			pass.dispatchWorkgroups( 1 );
+			pass.end();
+			encoder.copyBufferToBuffer( outputBuffer, 0, stagingBuffer, 0, 4 );
+			device.queue.submit( [ encoder.finish() ] );
+
+			await device.queue.onSubmittedWorkDone();
+
+			await stagingBuffer.mapAsync( GPUMapMode.READ );
+			const detected = new Uint32Array( stagingBuffer.getMappedRange() )[ 0 ];
+			stagingBuffer.unmap();
+			stagingBuffer.destroy();
+			outputBuffer.destroy();
+
+			this._subgroupSize = detected !== 0 ? detected : 0;
+			if ( this._verbose ) console.info( `GPUMeshBVH: Detected subgroup size = ${this._subgroupSize}` );
+
+		} catch ( e ) {
+
+			// Keep warning - subgroup detection failure is worth noting
+			console.warn( 'GPUMeshBVH: Subgroup detection failed:', e );
+			this._subgroupSize = 0;
+
+		}
+
+		return this._subgroupSize;
+
+	}
+
+	/**
+	 * Select optimal H-PLOC shader variant based on detected subgroup size.
+	 * Returns: { shaderSource, label, workgroupSize }
+	 */
+	_selectHPLOCShaderVariant() {
+
+		const size = this._subgroupSize;
+
+		// Wave32: Apple M-series, NVIDIA
+		if ( size === 32 ) {
+
+			if ( this._verbose ) console.info( `GPUMeshBVH: Selected H-PLOC variant = wave32` );
+			return {
+				shaderSource: hplocShaderWave32,
+				label: 'wave32',
+				workgroupSize: 32,
+			};
+
+		}
+
+		// Wave64: AMD
+		if ( size === 64 ) {
+
+			if ( this._verbose ) console.info( `GPUMeshBVH: Selected H-PLOC variant = wave64` );
+			return {
+				shaderSource: hplocShaderWave64,
+				label: 'wave64',
+				workgroupSize: 64,
+			};
+
+		}
+
+		// Fallback: subgroups not supported or unusual size
+		// Use the basic non-subgroup shader with WG=64
+		if ( this._verbose ) console.info( `GPUMeshBVH: Selected H-PLOC variant = fallback (subgroupSize=${size})` );
+		return {
+			shaderSource: hplocShader,
+			label: 'fallback',
+			workgroupSize: 64,
+		};
+
+	}
+
+	/**
+	 * Record radix sort pass to command encoder (Phase 2: single-submission batching)
+	 * Uses pre-uploaded uniforms at specified offsets
+	 */
+	_recordRadixSortPass( commandEncoder, primCount, offsets ) {
+
+		// Use external sorter if configured (check both _sorterType and _sorter for safety)
+		if ( this._sorterType !== SorterType.BUILTIN && this._sorter ) {
+
+			// Note: OneSweep does 4-pass ping-pong, so output ends up back in keysIn/valsIn
+			this._sorter.sort( {
+				commandEncoder,
+				keysIn: this._buildBuffers.mortonCodes,
+				keysOut: this._buildBuffers.mortonCodesAlt,
+				valsIn: this._buildBuffers.clusterIdx,
+				valsOut: this._buildBuffers.clusterIdxAlt,
+				count: primCount,
+			} );
+			return;
+
+		}
+
+		// Built-in radix sort (stable sort for LSD radix correctness)
+		const workgroupCount = Math.ceil( primCount / 256 );
+
+		// Cache sort bind groups (invalidated by _allocateBuffers when buffers change)
+		// 13 bind groups: 4 histogram + 4 workgroupScan + 1 radixScan + 4 scatter
+		const sortCacheKey = offsets.sort.join( '_' );
+		if ( ! this._sortBindGroups || this._sortBindGroupsCacheKey !== sortCacheKey ) {
+
+			this._sortBindGroupsCacheKey = sortCacheKey;
+
+			const device = this.device;
+			const bufs = this._buildBuffers;
+			const keysBuffers = [ bufs.mortonCodes, bufs.mortonCodesAlt ];
+			const valsBuffers = [ bufs.clusterIdx, bufs.clusterIdxAlt ];
+
+			const histogram = [];
+			const workgroupScan = [];
+			const scatter = [];
+
+			for ( let pass = 0; pass < 4; pass ++ ) {
+
+				const src = pass % 2;
+				const dst = 1 - src;
+
+				histogram.push( device.createBindGroup( {
+					layout: this._pipelines.radixHistogram.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: bufs.uniforms, offset: offsets.sort[ pass ], size: 16 } },
+						{ binding: 1, resource: { buffer: keysBuffers[ src ] } },
+						{ binding: 2, resource: { buffer: bufs.groupCounts } },
+						{ binding: 3, resource: { buffer: bufs.globalDigitCount } },
+					],
+				} ) );
+
+				workgroupScan.push( device.createBindGroup( {
+					layout: this._pipelines.radixWorkgroupScan.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: bufs.uniforms, offset: offsets.sort[ pass ], size: 16 } },
+						{ binding: 1, resource: { buffer: bufs.groupCounts } },
+						{ binding: 2, resource: { buffer: bufs.groupPrefix } },
+					],
+				} ) );
+
+				scatter.push( device.createBindGroup( {
+					layout: this._pipelines.radixScatter.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: bufs.uniforms, offset: offsets.sort[ pass ], size: 16 } },
+						{ binding: 1, resource: { buffer: keysBuffers[ src ] } },
+						{ binding: 2, resource: { buffer: keysBuffers[ dst ] } },
+						{ binding: 3, resource: { buffer: valsBuffers[ src ] } },
+						{ binding: 4, resource: { buffer: valsBuffers[ dst ] } },
+						{ binding: 5, resource: { buffer: bufs.groupPrefix } },
+						{ binding: 6, resource: { buffer: bufs.digitOffsets } },
+					],
+				} ) );
+
+			}
+
+			const radixScan = this.device.createBindGroup( {
+				layout: this._pipelines.radixScan.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 1, resource: { buffer: bufs.globalDigitCount } },
+					{ binding: 2, resource: { buffer: bufs.digitOffsets } },
+				],
+			} );
+
+			this._sortBindGroups = { histogram, workgroupScan, radixScan, scatter };
+
+		}
+
+		// Clear intermediate buffers to ensure clean state (prevents undefined initial contents)
+		commandEncoder.clearBuffer( this._buildBuffers.groupCounts );
+		commandEncoder.clearBuffer( this._buildBuffers.groupPrefix );
+		commandEncoder.clearBuffer( this._buildBuffers.digitOffsets );
+
+		for ( let pass = 0; pass < 4; pass ++ ) {
+
+			// Clear globalDigitCount before each radix pass
+			commandEncoder.clearBuffer( this._buildBuffers.globalDigitCount );
+
+			// Histogram: count digits per workgroup
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				passEncoder.setPipeline( this._pipelines.radixHistogram );
+				passEncoder.setBindGroup( 0, this._sortBindGroups.histogram[ pass ] );
+				passEncoder.dispatchWorkgroups( workgroupCount );
+				passEncoder.end();
+
+			}
+
+			// Workgroup scan: compute exclusive prefix sum across workgroups for each digit
+			// This ensures stability - workgroup 0's elements come before workgroup 1's
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				passEncoder.setPipeline( this._pipelines.radixWorkgroupScan );
+				passEncoder.setBindGroup( 0, this._sortBindGroups.workgroupScan[ pass ] );
+				passEncoder.dispatchWorkgroups( 1 );
+				passEncoder.end();
+
+			}
+
+			// Digit scan: compute digit base offsets
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				passEncoder.setPipeline( this._pipelines.radixScan );
+				passEncoder.setBindGroup( 0, this._sortBindGroups.radixScan );
+				passEncoder.dispatchWorkgroups( 1 );
+				passEncoder.end();
+
+			}
+
+			// Scatter: reorder keys and values
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				passEncoder.setPipeline( this._pipelines.radixScatter );
+				passEncoder.setBindGroup( 0, this._sortBindGroups.scatter[ pass ] );
+				passEncoder.dispatchWorkgroups( workgroupCount );
+				passEncoder.end();
+
+			}
+
+		}
+
+	}
+
+	_getHPLOCMaxIterations( primCount ) {
+
+		if ( primCount <= 1 ) return 1;
+		return Math.max( 1, Math.ceil( Math.log2( primCount ) * HPLOC_MAX_ITERATION_FACTOR ) );
+
+	}
+
+	_getRefitMaxIterations( primCount ) {
+
+		if ( primCount <= 1 ) return 1;
+		return Math.max( 1, Math.ceil( Math.log2( primCount ) * REFIT_MAX_ITERATION_FACTOR ) );
+
+	}
+
+	async _buildRefitParentMap( waitForCompletion = true ) {
+
+		const primCount = this._primCount;
+		if ( primCount === 0 ) return;
+
+		const maxNodes = 2 * primCount;
+		const workgroupCount = Math.ceil( maxNodes / 256 );
+		const device = this.device;
+		const commandEncoder = device.createCommandEncoder();
+
+		const passEncoder = commandEncoder.beginComputePass();
+		const bindGroup = device.createBindGroup( {
+			layout: this._pipelines.refitBuildParents.getBindGroupLayout( 0 ),
+			entries: [
+				{ binding: 0, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+				{ binding: 1, resource: { buffer: this._buildBuffers.nodeCounter } },
+				{ binding: 2, resource: { buffer: this._buildBuffers.parentIdx } },
+				{ binding: 3, resource: { buffer: this._buildBuffers.clusterIdx } },
+			],
+		} );
+		passEncoder.setPipeline( this._pipelines.refitBuildParents );
+		passEncoder.setBindGroup( 0, bindGroup );
+		passEncoder.dispatchWorkgroups( workgroupCount );
+		passEncoder.end();
+
+		device.queue.submit( [ commandEncoder.finish() ] );
+		this._refitParentsDirty = false;
+		if ( waitForCompletion ) {
+
+			await device.queue.onSubmittedWorkDone();
+
+		}
+
+	}
+
+	_getOrCreateRefitBindGroups() {
+
+		const device = this.device;
+
+		// Refit bind group cache (reused for per-frame refit on stable buffer identities).
+		const cacheKey = {
+			positionBuffer: this._positionBuffer,
+			indexBuffer: this._indexBuffer,
+			buildBuffers: this._buildBuffers,
+			refitLeavesPipeline: this._pipelines.refitLeaves,
+			refitInternalPipeline: this._pipelines.refitInternal,
+			updateDispatchPipeline: this._pipelines.updateDispatch,
+		};
+		const prevCacheKey = this._refitBindGroupsCacheKey;
+		const needsNewBindGroups = ! this._refitBindGroups || ! prevCacheKey
+			|| prevCacheKey.positionBuffer !== cacheKey.positionBuffer
+			|| prevCacheKey.indexBuffer !== cacheKey.indexBuffer
+			|| prevCacheKey.buildBuffers !== cacheKey.buildBuffers
+			|| prevCacheKey.refitLeavesPipeline !== cacheKey.refitLeavesPipeline
+			|| prevCacheKey.refitInternalPipeline !== cacheKey.refitInternalPipeline
+			|| prevCacheKey.updateDispatchPipeline !== cacheKey.updateDispatchPipeline;
+
+		if ( needsNewBindGroups ) {
+
+			this._refitBindGroupsCacheKey = cacheKey;
+			this._refitBindGroups = {
+				leaves: device.createBindGroup( {
+					layout: this._pipelines.refitLeaves.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: 0, size: 16 } },
+						{ binding: 1, resource: { buffer: this._positionBuffer } },
+						{ binding: 2, resource: { buffer: this._indexBuffer } },
+						{ binding: 3, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+						{ binding: 4, resource: { buffer: this._buildBuffers.parentIdx } },
+						{ binding: 5, resource: { buffer: this._buildBuffers.refitVisitCount } },
+						{ binding: 6, resource: { buffer: this._buildBuffers.activeList0 } },
+						{ binding: 7, resource: { buffer: this._buildBuffers.activeCount0 } },
+					],
+				} ),
+				internal_0to1: device.createBindGroup( {
+					layout: this._pipelines.refitInternal.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.parentIdx } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.refitVisitCount } },
+						{ binding: 3, resource: { buffer: this._buildBuffers.activeList0 } },
+						{ binding: 4, resource: { buffer: this._buildBuffers.activeList1 } },
+						{ binding: 5, resource: { buffer: this._buildBuffers.activeCount0 } },
+						{ binding: 6, resource: { buffer: this._buildBuffers.activeCount1 } },
+					],
+				} ),
+				internal_1to0: device.createBindGroup( {
+					layout: this._pipelines.refitInternal.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.parentIdx } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.refitVisitCount } },
+						{ binding: 3, resource: { buffer: this._buildBuffers.activeList1 } },
+						{ binding: 4, resource: { buffer: this._buildBuffers.activeList0 } },
+						{ binding: 5, resource: { buffer: this._buildBuffers.activeCount1 } },
+						{ binding: 6, resource: { buffer: this._buildBuffers.activeCount0 } },
+					],
+				} ),
+				update_0to1: device.createBindGroup( {
+					layout: this._pipelines.updateDispatch.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.activeCount0 } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.indirectDispatch } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.activeCount1 } },
+					],
+				} ),
+				update_1to0: device.createBindGroup( {
+					layout: this._pipelines.updateDispatch.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.activeCount1 } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.indirectDispatch } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.activeCount0 } },
+					],
+				} ),
+			};
+
+		}
+
+		return this._refitBindGroups;
+
+	}
+
+	async _runRefitPass( useFlatten = false, waitForCompletion = true, debugTiming = false ) {
+
+		const primCount = this._primCount;
+		if ( primCount === 0 ) return { maxIterations: 0 };
+
+		const device = this.device;
+		const uniforms = new Uint32Array( [ primCount, this._positionStride, 0, 0 ] );
+		device.queue.writeBuffer( this._buildBuffers.uniforms, 0, uniforms );
+
+		const leafWorkgroupCount = Math.ceil( primCount / 256 );
+		const maxIterations = this._getRefitMaxIterations( primCount );
+		const commandEncoder = device.createCommandEncoder();
+
+		// Refit only touches active node indices [0, 2 * primCount), so avoid clearing
+		// the full capacity-sized buffer when geometry shrinks.
+		const maxNodesUsed = Math.max( 1, 2 * primCount );
+		commandEncoder.clearBuffer( this._buildBuffers.refitVisitCount, 0, maxNodesUsed * 4 );
+		commandEncoder.clearBuffer( this._buildBuffers.activeCount0 );
+		commandEncoder.clearBuffer( this._buildBuffers.activeCount1 );
+		const bg = this._getOrCreateRefitBindGroups();
+
+		const useGpuTimestamps = debugTiming && waitForCompletion && this._hasTimestampQuery && !! this._timestampBuffers;
+		let queryCount = 0;
+		let leavesStartIdx = 0;
+		let leavesEndIdx = 0;
+		let internalStartIdx = 0;
+		let internalEndIdx = 0;
+
+		// Multi-dispatch refit:
+		// 1) Leaf dispatch updates leaf AABBs and appends ready parents.
+		// 2) Internal dispatch waves process appended parents until convergence.
+		if ( useGpuTimestamps ) {
+
+			const ts = this._timestampBuffers;
+			leavesStartIdx = queryCount ++;
+			leavesEndIdx = queryCount ++;
+			const leavesPass = commandEncoder.beginComputePass( {
+				timestampWrites: {
+					querySet: ts.querySet,
+					beginningOfPassWriteIndex: leavesStartIdx,
+					endOfPassWriteIndex: leavesEndIdx,
+				},
+			} );
+			leavesPass.setPipeline( this._pipelines.refitLeaves );
+			leavesPass.setBindGroup( 0, bg.leaves );
+			leavesPass.dispatchWorkgroups( leafWorkgroupCount );
+			leavesPass.end();
+
+			internalStartIdx = queryCount ++;
+			internalEndIdx = queryCount ++;
+			const internalPass = commandEncoder.beginComputePass( {
+				timestampWrites: {
+					querySet: ts.querySet,
+					beginningOfPassWriteIndex: internalStartIdx,
+					endOfPassWriteIndex: internalEndIdx,
+				},
+			} );
+			for ( let iter = 0; iter < maxIterations; iter ++ ) {
+
+				const use0to1 = ( iter % 2 === 0 );
+				internalPass.setPipeline( this._pipelines.updateDispatch );
+				internalPass.setBindGroup( 0, use0to1 ? bg.update_0to1 : bg.update_1to0 );
+				internalPass.dispatchWorkgroups( 1 );
+
+				internalPass.setPipeline( this._pipelines.refitInternal );
+				internalPass.setBindGroup( 0, use0to1 ? bg.internal_0to1 : bg.internal_1to0 );
+				internalPass.dispatchWorkgroupsIndirect( this._buildBuffers.indirectDispatch, 0 );
+
+			}
+
+			internalPass.end();
+
+		} else {
+
+			const passEncoder = commandEncoder.beginComputePass();
+			passEncoder.setPipeline( this._pipelines.refitLeaves );
+			passEncoder.setBindGroup( 0, bg.leaves );
+			passEncoder.dispatchWorkgroups( leafWorkgroupCount );
+
+			for ( let iter = 0; iter < maxIterations; iter ++ ) {
+
+				const use0to1 = ( iter % 2 === 0 );
+				passEncoder.setPipeline( this._pipelines.updateDispatch );
+				passEncoder.setBindGroup( 0, use0to1 ? bg.update_0to1 : bg.update_1to0 );
+				passEncoder.dispatchWorkgroups( 1 );
+
+				passEncoder.setPipeline( this._pipelines.refitInternal );
+				passEncoder.setBindGroup( 0, use0to1 ? bg.internal_0to1 : bg.internal_1to0 );
+				passEncoder.dispatchWorkgroupsIndirect( this._buildBuffers.indirectDispatch, 0 );
+
+			}
+
+			passEncoder.end();
+
+		}
+
+		if ( useFlatten ) {
+
+			this._runFlattenPass( commandEncoder, primCount );
+
+		}
+
+		if ( useGpuTimestamps ) {
+
+			const ts = this._timestampBuffers;
+			commandEncoder.resolveQuerySet( ts.querySet, 0, queryCount, ts.resolveBuffer, 0 );
+			commandEncoder.copyBufferToBuffer( ts.resolveBuffer, 0, ts.readbackBuffer, 0, queryCount * 8 );
+
+		}
+
+		device.queue.submit( [ commandEncoder.finish() ] );
+		if ( waitForCompletion ) {
+
+			await device.queue.onSubmittedWorkDone();
+
+		}
+
+		if ( useGpuTimestamps ) {
+
+			const ts = this._timestampBuffers;
+			await ts.readbackBuffer.mapAsync( GPUMapMode.READ );
+			const timestamps = new BigUint64Array( ts.readbackBuffer.getMappedRange() );
+			const toMs = ( start, end ) => {
+
+				if ( start === 0n || end === 0n || end < start ) return 0;
+				return Number( end - start ) / 1000000;
+
+			};
+
+			const refitLeaves = toMs( timestamps[ leavesStartIdx ], timestamps[ leavesEndIdx ] );
+			const refitInternal = toMs( timestamps[ internalStartIdx ], timestamps[ internalEndIdx ] );
+			ts.readbackBuffer.unmap();
+
+			return {
+				maxIterations,
+				gpuTimestamps: true,
+				refitLeaves,
+				refitInternal,
+				refitGpuTotal: refitLeaves + refitInternal,
+			};
+
+		}
+
+		return { maxIterations, gpuTimestamps: false };
+
+	}
+
+	// Synchronous version - adds dispatches to existing command encoder
+	// uniformOffset: optional byte offset into uniforms buffer (for single-submission batching)
+	_runHPLOCPassSync( commandEncoder, primCount, offsets = { hploc: 0, initCounters: 0 }, timestampOptions = null ) {
+
+		// Support both old (uniformOffset number) and new (offsets object) calling conventions
+		const uniformOffset = typeof offsets === 'number' ? offsets : offsets.hploc;
+		const initCountersOffset = typeof offsets === 'number' ? offsets : offsets.initCounters;
+
+		// Always use indirect dispatch - active list tracking reduces total workgroup
+		// launches as primitives merge, benefiting all variants (subgroup and fallback alike)
+		return this._runHPLOCPassIndirect( commandEncoder, primCount, { hploc: uniformOffset, initCounters: initCountersOffset }, timestampOptions );
+
+	}
+
+	/**
+	 * H-PLOC with indirect dispatch - only launches workgroups for active primitives.
+	 * Uses ping-pong active lists to track which primitives still need work.
+	 * Significantly reduces total workgroup launches due to geometric decay of active count.
+	 *
+	 * @param {GPUCommandEncoder} commandEncoder
+	 * @param {number} primCount
+	 * @param {Object} offsets - { hploc, initCounters } uniform buffer offsets
+	 * @param {Object} timestampOptions - Optional: { querySet, startIndex, endIndex }
+	 */
+	_runHPLOCPassIndirect( commandEncoder, primCount, offsets = { hploc: 0, initCounters: 0 }, timestampOptions = null ) {
+
+		const device = this.device;
+		const workgroupSize = this._hplocWorkgroupSize;
+		const initialWorkgroupCount = Math.ceil( primCount / workgroupSize );
+
+		// Tree depth is ~log2(primCount). Cap is centrally tuned via factor constant.
+		const maxIterations = this._getHPLOCMaxIterations( primCount );
+
+		// Support both old (number) and new (object) calling conventions
+		const hplocOffset = typeof offsets === 'number' ? offsets : offsets.hploc;
+		const initCountersOffset = typeof offsets === 'number' ? offsets : offsets.initCounters;
+
+		// Bind group caching key - invalidate cache when offsets change
+		const cacheKey = `${hplocOffset}_${initCountersOffset}`;
+		const needsNewBindGroups = ! this._hplocBindGroups || this._hplocBindGroupsCacheKey !== cacheKey;
+
+		if ( needsNewBindGroups ) {
+
+			// Create and cache bind groups (reused across builds with same buffer capacity)
+			this._hplocBindGroupsCacheKey = cacheKey;
+			this._hplocBindGroups = {
+				initCounters: device.createBindGroup( {
+					layout: this._pipelines.initIndirectCounters.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: initCountersOffset, size: 16 } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.nodeCounter } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.activeCount0 } },
+						{ binding: 3, resource: { buffer: this._buildBuffers.activeCount1 } },
+						{ binding: 4, resource: { buffer: this._buildBuffers.indirectDispatch } },
+					],
+				} ),
+				initActiveList: device.createBindGroup( {
+					layout: this._pipelines.initActiveList.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: hplocOffset, size: 16 } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.activeList0 } },
+					],
+				} ),
+				hploc_0to1: device.createBindGroup( {
+					layout: this._pipelines.hplocIndirect.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: hplocOffset, size: 16 } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.mortonCodes } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.clusterIdx } },
+						{ binding: 3, resource: { buffer: this._buildBuffers.parentIdx } },
+						{ binding: 4, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+						{ binding: 5, resource: { buffer: this._buildBuffers.nodeCounter } },
+						{ binding: 6, resource: { buffer: this._buildBuffers.hplocState } },
+						{ binding: 7, resource: { buffer: this._buildBuffers.activeList0 } },
+						{ binding: 8, resource: { buffer: this._buildBuffers.activeList1 } },
+						{ binding: 9, resource: { buffer: this._buildBuffers.activeCount1 } },
+						{ binding: 10, resource: { buffer: this._buildBuffers.activeCount0 } },
+					],
+				} ),
+				hploc_1to0: device.createBindGroup( {
+					layout: this._pipelines.hplocIndirect.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: hplocOffset, size: 16 } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.mortonCodes } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.clusterIdx } },
+						{ binding: 3, resource: { buffer: this._buildBuffers.parentIdx } },
+						{ binding: 4, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+						{ binding: 5, resource: { buffer: this._buildBuffers.nodeCounter } },
+						{ binding: 6, resource: { buffer: this._buildBuffers.hplocState } },
+						{ binding: 7, resource: { buffer: this._buildBuffers.activeList1 } },
+						{ binding: 8, resource: { buffer: this._buildBuffers.activeList0 } },
+						{ binding: 9, resource: { buffer: this._buildBuffers.activeCount0 } },
+						{ binding: 10, resource: { buffer: this._buildBuffers.activeCount1 } },
+					],
+				} ),
+				update_1to0: device.createBindGroup( {
+					layout: this._pipelines.updateDispatch.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.activeCount1 } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.indirectDispatch } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.activeCount0 } },
+					],
+				} ),
+				update_0to1: device.createBindGroup( {
+					layout: this._pipelines.updateDispatch.getBindGroupLayout( 0 ),
+					entries: [
+						{ binding: 0, resource: { buffer: this._buildBuffers.activeCount0 } },
+						{ binding: 1, resource: { buffer: this._buildBuffers.indirectDispatch } },
+						{ binding: 2, resource: { buffer: this._buildBuffers.activeCount1 } },
+					],
+				} ),
+			};
+
+		}
+
+		// Use cached bind groups
+		const bg = this._hplocBindGroups;
+
+		// === GPU-BASED COUNTER INITIALIZATION ===
+		{
+
+			const passEncoder = commandEncoder.beginComputePass();
+			passEncoder.setPipeline( this._pipelines.initIndirectCounters );
+			passEncoder.setBindGroup( 0, bg.initCounters );
+			passEncoder.dispatchWorkgroups( 1 );
+			passEncoder.end();
+
+		}
+
+		// Active list 0 is initialized in computeBounds shader (binding 8)
+
+		// Use cached bind groups for ping-pong iterations
+		const hplocBG_0to1 = bg.hploc_0to1;
+		const hplocBG_1to0 = bg.hploc_1to0;
+		const updateBG_1to0 = bg.update_1to0;
+		const updateBG_0to1 = bg.update_0to1;
+
+		// Execute the full indirect iteration sequence in a single compute pass to reduce
+		// pass begin/end overhead while preserving dispatch order dependencies.
+		const passOptions = timestampOptions ? {
+			timestampWrites: {
+				querySet: timestampOptions.querySet,
+				beginningOfPassWriteIndex: timestampOptions.startIndex,
+				endOfPassWriteIndex: timestampOptions.endIndex,
+			},
+		} : {};
+		const passEncoder = commandEncoder.beginComputePass( passOptions );
+
+		// Iteration 0: direct dispatch (all primitives active), output to list1.
+		passEncoder.setPipeline( this._pipelines.hplocIndirect );
+		passEncoder.setBindGroup( 0, hplocBG_0to1 );
+		passEncoder.dispatchWorkgroups( initialWorkgroupCount );
+
+		// Iterations 1..maxIterations-1
+		for ( let iter = 1; iter < maxIterations; iter ++ ) {
+
+			const useList1AsInput = ( iter % 2 === 1 );
+			passEncoder.setPipeline( this._pipelines.updateDispatch );
+			passEncoder.setBindGroup( 0, useList1AsInput ? updateBG_1to0 : updateBG_0to1 );
+			passEncoder.dispatchWorkgroups( 1 );
+
+			passEncoder.setPipeline( this._pipelines.hplocIndirect );
+			passEncoder.setBindGroup( 0, useList1AsInput ? hplocBG_1to0 : hplocBG_0to1 );
+			passEncoder.dispatchWorkgroupsIndirect( this._buildBuffers.indirectDispatch, 0 );
+
+		}
+
+		passEncoder.end();
+
+		return maxIterations;
+
+	}
+
+	// Legacy async version (kept for compatibility)
+	async _runHPLOCPass( primCount ) {
+
+		const commandEncoder = this.device.createCommandEncoder();
+		const iterations = this._runHPLOCPassSync( commandEncoder, primCount );
+		this.device.queue.submit( [ commandEncoder.finish() ] );
+		await this.device.queue.onSubmittedWorkDone();
+		return iterations;
+
+	}
+
+	/**
+	 * DEBUG: Run H-PLOC with indirect dispatch, with step-by-step readback between iterations.
+	 * This helps diagnose what's going wrong with the indirect dispatch.
+	 */
+	async _debugRunHPLOCPassIndirect( primCount, uniformOffset = 0 ) {
+
+		const device = this.device;
+		const workgroupSize = this._hplocWorkgroupSize;
+		const initialWorkgroupCount = Math.ceil( primCount / workgroupSize );
+		const maxIterations = this._getHPLOCMaxIterations( primCount );
+
+		console.log( `[DEBUG H-PLOC Indirect] primCount=${primCount}, workgroupSize=${workgroupSize}, maxIterations=${maxIterations}` );
+
+		// Create readback buffers
+		const countReadback = device.createBuffer( {
+			size: 8, // 2 x u32 for activeCount0 and activeCount1
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+		const dispatchReadback = device.createBuffer( {
+			size: 12, // 3 x u32 for indirect dispatch args
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+		const stateReadback = device.createBuffer( {
+			size: Math.min( 64, primCount ) * 16, // First 64 primitives, vec4u each
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+		const activeListReadback = device.createBuffer( {
+			size: Math.min( 64, primCount ) * 4, // First 64 entries
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+
+		// Helper to read buffer contents
+		const readU32Buffer = async ( srcBuffer, srcOffset, count, readbackBuffer ) => {
+
+			const enc = device.createCommandEncoder();
+			enc.copyBufferToBuffer( srcBuffer, srcOffset, readbackBuffer, 0, count * 4 );
+			device.queue.submit( [ enc.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+			await readbackBuffer.mapAsync( GPUMapMode.READ );
+			const data = new Uint32Array( readbackBuffer.getMappedRange().slice( 0 ) );
+			readbackBuffer.unmap();
+			return data;
+
+		};
+
+		// Active list 0 is initialized in computeBounds shader (binding 8)
+
+		// Initialize counts
+		device.queue.writeBuffer( this._buildBuffers.activeCount0, 0, new Uint32Array( [ primCount ] ) );
+		device.queue.writeBuffer( this._buildBuffers.activeCount1, 0, new Uint32Array( [ 0 ] ) );
+		device.queue.writeBuffer( this._buildBuffers.indirectDispatch, 0, new Uint32Array( [ initialWorkgroupCount, 1, 1 ] ) );
+
+		// Verify initialization
+		const activeList0Init = await readU32Buffer( this._buildBuffers.activeList0, 0, Math.min( 16, primCount ), activeListReadback );
+		console.log( `[DEBUG] After init - activeList0[0..15]:`, Array.from( activeList0Init ) );
+
+		// Create bind groups
+		const createIndirectBindGroup = ( listIn, listOut, countIn, countOut ) => {
+
+			return device.createBindGroup( {
+				layout: this._pipelines.hplocIndirect.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: this._buildBuffers.uniforms, offset: uniformOffset, size: 16 } },
+					{ binding: 1, resource: { buffer: this._buildBuffers.mortonCodes } },
+					{ binding: 2, resource: { buffer: this._buildBuffers.clusterIdx } },
+					{ binding: 3, resource: { buffer: this._buildBuffers.parentIdx } },
+					{ binding: 4, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+					{ binding: 5, resource: { buffer: this._buildBuffers.nodeCounter } },
+					{ binding: 6, resource: { buffer: this._buildBuffers.hplocState } },
+					{ binding: 7, resource: { buffer: listIn } },
+					{ binding: 8, resource: { buffer: listOut } },
+					{ binding: 9, resource: { buffer: countOut } },
+					{ binding: 10, resource: { buffer: countIn } },
+				],
+			} );
+
+		};
+
+		const createUpdateDispatchBindGroup = ( countIn, countOut ) => {
+
+			return device.createBindGroup( {
+				layout: this._pipelines.updateDispatch.getBindGroupLayout( 0 ),
+				entries: [
+					{ binding: 0, resource: { buffer: countIn } },
+					{ binding: 1, resource: { buffer: this._buildBuffers.indirectDispatch } },
+					{ binding: 2, resource: { buffer: countOut } },
+				],
+			} );
+
+		};
+
+		const hplocBG_0to1 = createIndirectBindGroup(
+			this._buildBuffers.activeList0, this._buildBuffers.activeList1,
+			this._buildBuffers.activeCount0, this._buildBuffers.activeCount1
+		);
+		const hplocBG_1to0 = createIndirectBindGroup(
+			this._buildBuffers.activeList1, this._buildBuffers.activeList0,
+			this._buildBuffers.activeCount1, this._buildBuffers.activeCount0
+		);
+		const updateBG_1to0 = createUpdateDispatchBindGroup(
+			this._buildBuffers.activeCount1, this._buildBuffers.activeCount0
+		);
+		const updateBG_0to1 = createUpdateDispatchBindGroup(
+			this._buildBuffers.activeCount0, this._buildBuffers.activeCount1
+		);
+
+		// Iteration 0: direct dispatch
+		{
+
+			const enc = device.createCommandEncoder();
+			const passEncoder = enc.beginComputePass();
+			passEncoder.setPipeline( this._pipelines.hplocIndirect );
+			passEncoder.setBindGroup( 0, hplocBG_0to1 );
+			passEncoder.dispatchWorkgroups( initialWorkgroupCount );
+			passEncoder.end();
+			device.queue.submit( [ enc.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+
+		}
+
+		// Check counts after iteration 0
+		{
+
+			const enc = device.createCommandEncoder();
+			enc.copyBufferToBuffer( this._buildBuffers.activeCount0, 0, countReadback, 0, 4 );
+			enc.copyBufferToBuffer( this._buildBuffers.activeCount1, 0, countReadback, 4, 4 );
+			device.queue.submit( [ enc.finish() ] );
+			await device.queue.onSubmittedWorkDone();
+			await countReadback.mapAsync( GPUMapMode.READ );
+			const counts = new Uint32Array( countReadback.getMappedRange().slice( 0 ) );
+			countReadback.unmap();
+			console.log( `[DEBUG] After iter 0: activeCount0=${counts[ 0 ]}, activeCount1=${counts[ 1 ]}` );
+
+			// Read first few state entries - check both beginning and middle of array
+			const stateData = await readU32Buffer( this._buildBuffers.hplocState, 0, Math.min( 64, primCount ) * 4, stateReadback );
+			console.log( `[DEBUG] After iter 0 - state (first 4):` );
+			for ( let i = 0; i < Math.min( 4, primCount ); i ++ ) {
+
+				console.log( `  prim ${i}: left=${stateData[ i * 4 ]}, right=${stateData[ i * 4 + 1 ]}, split=${stateData[ i * 4 + 2 ]}, active=${stateData[ i * 4 + 3 ]}` );
+
+			}
+
+			// Also check some middle entries to see active threads
+			console.log( `[DEBUG] After iter 0 - state (sample from middle):` );
+			for ( let i = 30; i < Math.min( 34, primCount ); i ++ ) {
+
+				console.log( `  prim ${i}: left=${stateData[ i * 4 ]}, right=${stateData[ i * 4 + 1 ]}, split=${stateData[ i * 4 + 2 ]}, active=${stateData[ i * 4 + 3 ]}` );
+
+			}
+
+			// Read output active list - these are the primitive indices still active
+			const numToRead = Math.min( 16, counts[ 1 ] || 1 );
+			const activeList1 = await readU32Buffer( this._buildBuffers.activeList1, 0, numToRead, activeListReadback );
+			console.log( `[DEBUG] After iter 0 - activeList1[0..${numToRead - 1}] (primIdx values for next iter):`, Array.from( activeList1.slice( 0, numToRead ) ) );
+
+			// Look up state for first few active prims
+			if ( counts[ 1 ] > 0 ) {
+
+				console.log( `[DEBUG] State of first few active prims:` );
+				for ( let i = 0; i < Math.min( 4, numToRead ); i ++ ) {
+
+					const activePrimIdx = activeList1[ i ];
+					if ( activePrimIdx < 64 ) {
+
+						console.log( `  activeList1[${i}]=${activePrimIdx}: left=${stateData[ activePrimIdx * 4 ]}, right=${stateData[ activePrimIdx * 4 + 1 ]}, split=${stateData[ activePrimIdx * 4 + 2 ]}, active=${stateData[ activePrimIdx * 4 + 3 ]}` );
+
+					} else {
+
+						console.log( `  activeList1[${i}]=${activePrimIdx}: (beyond readback range)` );
+
+					}
+
+				}
+
+			}
+
+		}
+
+		// Subsequent iterations
+		for ( let iter = 1; iter < Math.min( maxIterations, 5 ); iter ++ ) {
+
+			const useList1AsInput = ( iter % 2 === 1 );
+
+			// Update dispatch
+			{
+
+				const enc = device.createCommandEncoder();
+				const passEncoder = enc.beginComputePass();
+				passEncoder.setPipeline( this._pipelines.updateDispatch );
+				passEncoder.setBindGroup( 0, useList1AsInput ? updateBG_1to0 : updateBG_0to1 );
+				passEncoder.dispatchWorkgroups( 1 );
+				passEncoder.end();
+				device.queue.submit( [ enc.finish() ] );
+				await device.queue.onSubmittedWorkDone();
+
+			}
+
+			// Read dispatch args
+			{
+
+				const enc = device.createCommandEncoder();
+				enc.copyBufferToBuffer( this._buildBuffers.indirectDispatch, 0, dispatchReadback, 0, 12 );
+				device.queue.submit( [ enc.finish() ] );
+				await device.queue.onSubmittedWorkDone();
+				await dispatchReadback.mapAsync( GPUMapMode.READ );
+				const dispatchArgs = new Uint32Array( dispatchReadback.getMappedRange().slice( 0 ) );
+				dispatchReadback.unmap();
+				console.log( `[DEBUG] Iter ${iter} dispatch args: [${dispatchArgs[ 0 ]}, ${dispatchArgs[ 1 ]}, ${dispatchArgs[ 2 ]}]` );
+
+			}
+
+			// Indirect dispatch H-PLOC
+			{
+
+				const enc = device.createCommandEncoder();
+				const passEncoder = enc.beginComputePass();
+				passEncoder.setPipeline( this._pipelines.hplocIndirect );
+				passEncoder.setBindGroup( 0, useList1AsInput ? hplocBG_1to0 : hplocBG_0to1 );
+				passEncoder.dispatchWorkgroupsIndirect( this._buildBuffers.indirectDispatch, 0 );
+				passEncoder.end();
+				device.queue.submit( [ enc.finish() ] );
+				await device.queue.onSubmittedWorkDone();
+
+			}
+
+			// Check counts
+			{
+
+				const enc = device.createCommandEncoder();
+				enc.copyBufferToBuffer( this._buildBuffers.activeCount0, 0, countReadback, 0, 4 );
+				enc.copyBufferToBuffer( this._buildBuffers.activeCount1, 0, countReadback, 4, 4 );
+				device.queue.submit( [ enc.finish() ] );
+				await device.queue.onSubmittedWorkDone();
+				await countReadback.mapAsync( GPUMapMode.READ );
+				const counts = new Uint32Array( countReadback.getMappedRange().slice( 0 ) );
+				countReadback.unmap();
+				console.log( `[DEBUG] After iter ${iter}: activeCount0=${counts[ 0 ]}, activeCount1=${counts[ 1 ]}` );
+
+			}
+
+		}
+
+		// Clean up debug buffers
+		countReadback.destroy();
+		dispatchReadback.destroy();
+		stateReadback.destroy();
+		activeListReadback.destroy();
+
+		return maxIterations;
+
+	}
+
+	// _readActiveCount removed - Phase 1 optimization (activeCount was unused overhead)
+
+	_runFlattenPass( commandEncoder, primCount ) {
+
+		if ( primCount === 0 ) return;
+
+		// Note: uniforms (binding 0) is declared but not used in flatten shader,
+		// so WebGPU auto-layout excludes it - only pass bindings 1-7
+
+		const passEncoderSizes = commandEncoder.beginComputePass();
+		const bindGroupSizes = this.device.createBindGroup( {
+			layout: this._pipelines.flattenSize.getBindGroupLayout( 0 ),
+			entries: [
+				{ binding: 1, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+				{ binding: 2, resource: { buffer: this._buildBuffers.clusterIdx } },
+				{ binding: 3, resource: { buffer: this._buildBuffers.nodeCounter } },
+				{ binding: 4, resource: { buffer: this._buildBuffers.subtreeSizes } },
+				{ binding: 5, resource: { buffer: this._buildBuffers.flattenStackNodes } },
+				{ binding: 6, resource: { buffer: this._buildBuffers.flattenStackOut } },
+			],
+		} );
+
+		passEncoderSizes.setPipeline( this._pipelines.flattenSize );
+		passEncoderSizes.setBindGroup( 0, bindGroupSizes );
+		passEncoderSizes.dispatchWorkgroups( 1 );
+		passEncoderSizes.end();
+
+		const passEncoder = commandEncoder.beginComputePass();
+		const bindGroup = this.device.createBindGroup( {
+			layout: this._pipelines.flatten.getBindGroupLayout( 0 ),
+			entries: [
+				{ binding: 1, resource: { buffer: this._buildBuffers.bvh2Nodes } },
+				{ binding: 2, resource: { buffer: this._buildBuffers.clusterIdx } },
+				{ binding: 3, resource: { buffer: this._buildBuffers.nodeCounter } },
+				{ binding: 4, resource: { buffer: this._buildBuffers.subtreeSizes } },
+				{ binding: 5, resource: { buffer: this._buildBuffers.flattenStackNodes } },
+				{ binding: 6, resource: { buffer: this._buildBuffers.flattenStackOut } },
+				{ binding: 7, resource: { buffer: this._bvhBuffer } },
+			],
+		} );
+
+		passEncoder.setPipeline( this._pipelines.flatten );
+		passEncoder.setBindGroup( 0, bindGroup );
+		passEncoder.dispatchWorkgroups( 1 );
+		passEncoder.end();
+
+	}
+
+	async _readNodeCount() {
+
+		const readBuffer = this.device.createBuffer( {
+			size: 4,
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+
+		const commandEncoder = this.device.createCommandEncoder();
+		commandEncoder.copyBufferToBuffer(
+			this._buildBuffers.nodeCounter, 0,
+			readBuffer, 0, 4
+		);
+		this.device.queue.submit( [ commandEncoder.finish() ] );
+
+		await readBuffer.mapAsync( GPUMapMode.READ );
+		let count = new Uint32Array( readBuffer.getMappedRange() )[ 0 ];
+		readBuffer.unmap();
+		readBuffer.destroy();
+
+		// Clamp to max possible nodes (safety for shader race conditions)
+		const maxNodes = 2 * this._primCount;
+		count = Math.min( count, maxNodes );
+
+		return count;
+
+	}
+
+	async _readRootIndex() {
+
+		// Root index is stored in clusterIdx[0] after H-PLOC completes
+		const readBuffer = this.device.createBuffer( {
+			size: 4,
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+
+		const commandEncoder = this.device.createCommandEncoder();
+		commandEncoder.copyBufferToBuffer(
+			this._buildBuffers.clusterIdx, 0,
+			readBuffer, 0, 4
+		);
+		this.device.queue.submit( [ commandEncoder.finish() ] );
+
+		await readBuffer.mapAsync( GPUMapMode.READ );
+		const rootIndex = new Uint32Array( readBuffer.getMappedRange() )[ 0 ];
+		readBuffer.unmap();
+		readBuffer.destroy();
+
+		return rootIndex;
+
+	}
+
+	/**
+	 * Helper to compute next power of 2 >= n
+	 */
+	_nextPowerOf2( n ) {
+
+		if ( n <= 0 ) return 1;
+		n --;
+		n |= n >> 1;
+		n |= n >> 2;
+		n |= n >> 4;
+		n |= n >> 8;
+		n |= n >> 16;
+		return n + 1;
+
+	}
+
+}

--- a/src/gpu/GPUMeshBVH.js
+++ b/src/gpu/GPUMeshBVH.js
@@ -2052,8 +2052,8 @@ export class GPUMeshBVH {
 			} ),
 
 			// Indirect dispatch buffers for H-PLOC optimization
-			// Double-buffered active lists for ping-pong during indirect dispatch
-			// Note: These are initialized via GPU compute pass (initIndirectCounters + initActiveList)
+			// Double-buffered active lists for ping-pong during indirect dispatch.
+			// Main build path seeds activeList0 in computeBounds; initActiveList is kept for debug replays.
 			activeList0: device.createBuffer( {
 				size: Math.max( 16, newCapacity * 4 ),
 				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,

--- a/src/gpu/GPUMeshBVHValidator.js
+++ b/src/gpu/GPUMeshBVHValidator.js
@@ -1,0 +1,1169 @@
+/**
+ * Validation utilities for GPUMeshBVH
+ * Helps catch correctness issues in sorting, BVH structure, and traversal
+ */
+
+const INVALID_IDX = 0xFFFFFFFF;
+
+export class GPUMeshBVHValidator {
+
+	constructor( gpuBVH ) {
+
+		this.gpuBVH = gpuBVH;
+		this.device = gpuBVH.device;
+
+	}
+
+	/**
+	 * Validate that morton codes are sorted correctly
+	 *
+	 * NOTE: This validation runs after the full build, so clusterIdx has been
+	 * modified by H-PLOC (contains internal node indices, not original primitive indices).
+	 * We can only verify sorting ORDER (mortonCodes[i] <= mortonCodes[i+1]).
+	 * Sort STABILITY cannot be verified post-build as original clusterIdx values are gone.
+	 *
+	 * @returns {Promise<{valid: boolean, errors: string[], stats: object}>}
+	 */
+	async validateSort() {
+
+		const errors = [];
+		const stats = {
+			primCount: this.gpuBVH._primCount,
+			outOfOrderCount: 0,
+			duplicateMortonCodes: 0,
+		};
+
+		const primCount = this.gpuBVH._primCount;
+		if ( primCount === 0 ) {
+
+			return { valid: true, errors: [], stats };
+
+		}
+
+		// Check OneSweep shader status if using OneSweep sorter
+		const sorter = this.gpuBVH.sorter;
+		if ( sorter && typeof sorter.readStatus === 'function' ) {
+
+			const status = await sorter.readStatus();
+			stats.sorterSubgroupSize = sorter.subgroupSize;
+			stats.sorterShaderVariant = sorter.shaderVariant;
+
+			if ( status.hasErrors ) {
+
+				if ( status.globalHist !== 0 ) {
+
+					errors.push( `OneSweep global_hist shader error: 0x${status.globalHist.toString( 16 )} (subgroup size check failed)` );
+
+				}
+
+				if ( status.scan !== 0 ) {
+
+					errors.push( `OneSweep scan shader error: 0x${status.scan.toString( 16 )} (subgroup size check failed)` );
+
+				}
+
+				if ( status.pass !== 0 ) {
+
+					errors.push( `OneSweep pass shader error: 0x${status.pass.toString( 16 )} (subgroup hist capacity exceeded)` );
+
+				}
+
+			}
+
+			// Read passHist to verify scan output (FLAG_INCLUSIVE with correct prefixes)
+			if ( typeof sorter.readPassHist === 'function' ) {
+
+				const passHist = await sorter.readPassHist();
+				if ( passHist ) {
+
+					const FLAG_INCLUSIVE = 2;
+					const FLAG_MASK = 3;
+					let scanErrors = 0;
+
+					// Check each pass's scan output
+					for ( let pass = 0; pass < 4; pass ++ ) {
+
+						const data = passHist[ `pass${pass}` ];
+						let lastPrefix = - 1;
+
+						for ( let digit = 0; digit < 256; digit ++ ) {
+
+							const entry = data[ digit ];
+							const flag = entry & FLAG_MASK;
+							const prefix = entry >> 2;
+
+							// Check flag is FLAG_INCLUSIVE
+							if ( flag !== FLAG_INCLUSIVE ) {
+
+								scanErrors ++;
+								if ( scanErrors <= 3 ) {
+
+									errors.push( `Pass ${pass} digit ${digit}: wrong flag ${flag} (expected ${FLAG_INCLUSIVE}), raw=0x${entry.toString( 16 )}` );
+
+								}
+
+							}
+
+							// Check prefix is monotonically increasing (prefix sum)
+							if ( lastPrefix >= 0 && prefix < lastPrefix ) {
+
+								scanErrors ++;
+								if ( scanErrors <= 3 ) {
+
+									errors.push( `Pass ${pass} digit ${digit}: prefix ${prefix} < previous ${lastPrefix} (not monotonic)` );
+
+								}
+
+							}
+
+							lastPrefix = prefix;
+
+						}
+
+						// Log the final prefix for debugging (should be close to primCount)
+						stats[ `pass${pass}FinalPrefix` ] = lastPrefix;
+
+					}
+
+					stats.scanErrors = scanErrors;
+
+				}
+
+			}
+
+		}
+
+		// Read back morton codes (clusterIdx not needed - modified by H-PLOC)
+		const mortonCodes = await this._readBuffer(
+			this.gpuBVH._buildBuffers.mortonCodes,
+			primCount * 4,
+			Uint32Array
+		);
+
+		// Check sorting: mortonCodes[i] <= mortonCodes[i+1]
+		// Also track which passes might have caused errors (based on which bits differ)
+		const PART_SIZE = 256 * 15; // OneSweep partition size (BLOCK_DIM * KEYS_PER_THREAD)
+		const threadBlocks = Math.ceil( primCount / PART_SIZE );
+		stats.partitionSize = PART_SIZE;
+		stats.threadBlocks = threadBlocks;
+		for ( let i = 0; i < primCount - 1; i ++ ) {
+
+			if ( mortonCodes[ i ] > mortonCodes[ i + 1 ] ) {
+
+				stats.outOfOrderCount ++;
+				if ( stats.outOfOrderCount <= 10 ) {
+
+					const m0 = mortonCodes[ i ];
+					const m1 = mortonCodes[ i + 1 ];
+
+					// Analyze which radix pass might have caused this
+					const digit0 = [ m0 & 0xFF, ( m0 >> 8 ) & 0xFF, ( m0 >> 16 ) & 0xFF, ( m0 >> 24 ) & 0xFF ];
+					const digit1 = [ m1 & 0xFF, ( m1 >> 8 ) & 0xFF, ( m1 >> 16 ) & 0xFF, ( m1 >> 24 ) & 0xFF ];
+
+					// Find which pass is responsible (highest differing digit)
+					let faultyPass = - 1;
+					for ( let p = 3; p >= 0; p -- ) {
+
+						if ( digit0[ p ] !== digit1[ p ] ) {
+
+							faultyPass = p;
+							break;
+
+						}
+
+					}
+
+					// Check workgroup boundary (OneSweep partition boundary)
+					const partId = Math.floor( i / PART_SIZE );
+
+					errors.push(
+						`Sort error at index ${i} (partId=${partId}): ` +
+						`morton[${i}]=0x${m0.toString( 16 ).padStart( 8, '0' )} > morton[${i + 1}]=0x${m1.toString( 16 ).padStart( 8, '0' )} ` +
+						`(digits=[${digit0.join( ',' )}] vs [${digit1.join( ',' )}], likely pass ${faultyPass})`
+					);
+
+				}
+
+			}
+
+		}
+
+		// Check for duplicate or missing indices (indicates collision in scatter)
+		// Read clusterIdx which should be a permutation of 0..primCount-1 after sort
+		// Note: This won't work post-H-PLOC as clusterIdx is modified
+		// We can only do this check if we run sort in isolation
+
+		// Count duplicate morton codes (useful for understanding tree structure)
+		let duplicateStart = 0;
+		for ( let i = 1; i <= primCount; i ++ ) {
+
+			const endOfRun = ( i === primCount ) || ( mortonCodes[ i ] !== mortonCodes[ duplicateStart ] );
+
+			if ( endOfRun ) {
+
+				const runLength = i - duplicateStart;
+				if ( runLength > 1 ) {
+
+					stats.duplicateMortonCodes += runLength;
+
+				}
+
+				duplicateStart = i;
+
+			}
+
+		}
+
+		if ( stats.outOfOrderCount > 5 ) {
+
+			errors.push( `... and ${stats.outOfOrderCount - 5} more sorting errors` );
+
+		}
+
+		// Validity is based solely on sorting order (stability cannot be verified post-H-PLOC)
+		return {
+			valid: stats.outOfOrderCount === 0,
+			errors,
+			stats,
+		};
+
+	}
+
+	/**
+	 * Validate BVH structural integrity
+	 * Call after H-PLOC build completes
+	 * @returns {Promise<{valid: boolean, errors: string[], stats: object}>}
+	 */
+	async validateBVH() {
+
+		const errors = [];
+		const stats = {
+			nodeCount: this.gpuBVH._nodeCount,
+			primCount: this.gpuBVH._primCount,
+			rootIndex: this.gpuBVH._rootIndex,
+			internalNodes: 0,
+			leafNodes: 0,
+			maxDepth: 0,
+			boundsErrors: 0,
+			childIndexErrors: 0,
+			unreachableNodes: 0,
+		};
+
+		const primCount = this.gpuBVH._primCount;
+		const nodeCount = this.gpuBVH._nodeCount;
+		const rootIndex = this.gpuBVH._rootIndex;
+
+		if ( primCount === 0 ) {
+
+			return { valid: true, errors: [], stats };
+
+		}
+
+		// Validate root index
+		if ( rootIndex >= nodeCount ) {
+
+			errors.push( `Root index ${rootIndex} out of range [0, ${nodeCount})` );
+			return { valid: false, errors, stats };
+
+		}
+
+		// Read back BVH2 nodes
+		// Layout: bounds (6 floats = 24 bytes) + leftChild (4 bytes) + rightChild (4 bytes) = 32 bytes
+		const nodeData = await this._readBuffer(
+			this.gpuBVH._buildBuffers.bvh2Nodes,
+			nodeCount * 32,
+			ArrayBuffer
+		);
+
+		const nodes = this._parseBVH2Nodes( nodeData, nodeCount );
+
+		// Track which nodes are reachable from root
+		const visited = new Set();
+
+		// Validate tree structure via DFS from root
+		const stack = [ { nodeIdx: rootIndex, depth: 0 } ];
+
+		while ( stack.length > 0 ) {
+
+			const { nodeIdx, depth } = stack.pop();
+
+			if ( visited.has( nodeIdx ) ) {
+
+				errors.push( `Cycle detected: node ${nodeIdx} visited twice` );
+				continue;
+
+			}
+
+			visited.add( nodeIdx );
+			stats.maxDepth = Math.max( stats.maxDepth, depth );
+
+			const node = nodes[ nodeIdx ];
+			const isLeaf = node.leftChild === INVALID_IDX;
+
+			if ( isLeaf ) {
+
+				stats.leafNodes ++;
+
+				// Validate leaf: rightChild is primitive index
+				if ( node.rightChild >= primCount ) {
+
+					stats.childIndexErrors ++;
+					if ( stats.childIndexErrors <= 5 ) {
+
+						errors.push(
+							`Leaf ${nodeIdx}: primIdx ${node.rightChild} >= primCount ${primCount}`
+						);
+
+					}
+
+				}
+
+			} else {
+
+				stats.internalNodes ++;
+
+				// Validate internal node: both children in range
+				if ( node.leftChild >= nodeCount ) {
+
+					stats.childIndexErrors ++;
+					if ( stats.childIndexErrors <= 5 ) {
+
+						errors.push(
+							`Internal node ${nodeIdx}: leftChild ${node.leftChild} >= nodeCount ${nodeCount}`
+						);
+
+					}
+
+				}
+
+				if ( node.rightChild >= nodeCount ) {
+
+					stats.childIndexErrors ++;
+					if ( stats.childIndexErrors <= 5 ) {
+
+						errors.push(
+							`Internal node ${nodeIdx}: rightChild ${node.rightChild} >= nodeCount ${nodeCount}`
+						);
+
+					}
+
+				}
+
+				// Validate bounds containment
+				if ( node.leftChild < nodeCount ) {
+
+					const leftChild = nodes[ node.leftChild ];
+					if ( ! this._boundsContain( node.bounds, leftChild.bounds ) ) {
+
+						stats.boundsErrors ++;
+						if ( stats.boundsErrors <= 5 ) {
+
+							errors.push(
+								`Node ${nodeIdx}: bounds do not contain left child ${node.leftChild}`
+							);
+
+						}
+
+					}
+
+					stack.push( { nodeIdx: node.leftChild, depth: depth + 1 } );
+
+				}
+
+				if ( node.rightChild < nodeCount ) {
+
+					const rightChild = nodes[ node.rightChild ];
+					if ( ! this._boundsContain( node.bounds, rightChild.bounds ) ) {
+
+						stats.boundsErrors ++;
+						if ( stats.boundsErrors <= 5 ) {
+
+							errors.push(
+								`Node ${nodeIdx}: bounds do not contain right child ${node.rightChild}`
+							);
+
+						}
+
+					}
+
+					stack.push( { nodeIdx: node.rightChild, depth: depth + 1 } );
+
+				}
+
+			}
+
+		}
+
+		// Check for unreachable nodes
+		stats.unreachableNodes = nodeCount - visited.size;
+		if ( stats.unreachableNodes > 0 ) {
+
+			errors.push( `${stats.unreachableNodes} nodes unreachable from root` );
+
+		}
+
+		// Summarize truncated errors
+		if ( stats.childIndexErrors > 5 ) {
+
+			errors.push( `... and ${stats.childIndexErrors - 5} more child index errors` );
+
+		}
+
+		if ( stats.boundsErrors > 5 ) {
+
+			errors.push( `... and ${stats.boundsErrors - 5} more bounds containment errors` );
+
+		}
+
+		const valid = stats.childIndexErrors === 0 &&
+			stats.boundsErrors === 0 &&
+			stats.unreachableNodes === 0;
+
+		return { valid, errors, stats };
+
+	}
+
+	/**
+	 * Cross-check GPU BVH intersections against CPU reference
+	 * @param {MeshBVH} cpuBVH - CPU-built BVH from three-mesh-bvh
+	 * @param {Array<{origin: Vector3, direction: Vector3}>} rays - Test rays
+	 * @param {Function} gpuIntersectFn - Function that takes rays and returns GPU hit results
+	 * @returns {Promise<{valid: boolean, errors: string[], stats: object}>}
+	 */
+	async validateIntersections( cpuBVH, rays, _gpuIntersectFn ) {
+
+		void _gpuIntersectFn;
+		const errors = [];
+		const stats = {
+			rayCount: rays.length,
+			mismatches: 0,
+			cpuHits: 0,
+			gpuHits: 0,
+		};
+
+		// This requires integration with the specific traversal implementation
+		// For now, provide the interface - implementation depends on how GPU traversal is exposed
+
+		errors.push( 'Intersection validation not yet implemented - requires GPU traversal integration' );
+
+		return { valid: false, errors, stats };
+
+	}
+
+	/**
+	 * Run all validations
+	 * @returns {Promise<{sort: object, bvh: object}>}
+	 */
+	async validateAll() {
+
+		const sortResult = await this.validateSort();
+		const bvhResult = await this.validateBVH();
+
+		return {
+			sort: sortResult,
+			bvh: bvhResult,
+		};
+
+	}
+
+	/**
+	 * Test the sorter in isolation with known data.
+	 * Creates test data, sorts it, and verifies both keys and payload.
+	 * @param {number} count - Number of elements to sort (default: use primCount)
+	 * @returns {Promise<{valid: boolean, errors: string[], stats: object}>}
+	 */
+	async validateSorterIsolated( count = null ) {
+
+		const errors = [];
+		const stats = {
+			count: count || this.gpuBVH._primCount,
+			keysOutOfOrder: 0,
+			payloadDuplicates: 0,
+			payloadMissing: 0,
+		};
+
+		const primCount = stats.count;
+		if ( primCount === 0 ) {
+
+			return { valid: true, errors: [], stats };
+
+		}
+
+		const sorter = this.gpuBVH.sorter;
+		if ( ! sorter ) {
+
+			errors.push( 'No external sorter available (using builtin sort)' );
+			return { valid: false, errors, stats };
+
+		}
+
+		const device = this.device;
+
+		// Create test buffers
+		const keysBuffer = device.createBuffer( {
+			size: primCount * 4,
+			usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+		} );
+		const valsBuffer = device.createBuffer( {
+			size: primCount * 4,
+			usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+		} );
+
+		// Generate test data: keys are the same morton codes from the build,
+		// vals are 0, 1, 2, ..., primCount-1
+		const testKeys = await this._readBuffer(
+			this.gpuBVH._buildBuffers.mortonCodes,
+			primCount * 4,
+			Uint32Array
+		);
+
+		// Copy the original unsorted morton codes
+		const origMortonCodes = new Uint32Array( testKeys );
+
+		const testVals = new Uint32Array( primCount );
+		for ( let i = 0; i < primCount; i ++ ) {
+
+			testVals[ i ] = i;
+
+		}
+
+		// Upload test data
+		device.queue.writeBuffer( keysBuffer, 0, testKeys );
+		device.queue.writeBuffer( valsBuffer, 0, testVals );
+
+		// Sort
+		const commandEncoder = device.createCommandEncoder();
+		sorter.sort( {
+			commandEncoder,
+			keysIn: keysBuffer,
+			keysOut: keysBuffer, // In-place for OneSweep (after 4 passes)
+			valsIn: valsBuffer,
+			valsOut: valsBuffer,
+			count: primCount,
+		} );
+		device.queue.submit( [ commandEncoder.finish() ] );
+		await device.queue.onSubmittedWorkDone();
+
+		// Read back results
+		const sortedKeys = await this._readBuffer( keysBuffer, primCount * 4, Uint32Array );
+		const sortedVals = await this._readBuffer( valsBuffer, primCount * 4, Uint32Array );
+
+		// Verify keys are sorted
+		for ( let i = 0; i < primCount - 1; i ++ ) {
+
+			if ( sortedKeys[ i ] > sortedKeys[ i + 1 ] ) {
+
+				stats.keysOutOfOrder ++;
+				if ( stats.keysOutOfOrder <= 5 ) {
+
+					errors.push(
+						`Key out of order at ${i}: 0x${sortedKeys[ i ].toString( 16 )} > 0x${sortedKeys[ i + 1 ].toString( 16 )}`
+					);
+
+				}
+
+			}
+
+		}
+
+		// Verify payload is a valid permutation (no duplicates, no missing)
+		const seen = new Set();
+		for ( let i = 0; i < primCount; i ++ ) {
+
+			const val = sortedVals[ i ];
+			if ( val >= primCount ) {
+
+				stats.payloadMissing ++;
+				if ( errors.length < 10 ) {
+
+					errors.push( `Invalid payload at ${i}: ${val} >= ${primCount}` );
+
+				}
+
+			} else if ( seen.has( val ) ) {
+
+				stats.payloadDuplicates ++;
+				if ( stats.payloadDuplicates <= 5 ) {
+
+					// Find where we first saw this value
+					let firstIdx = - 1;
+					for ( let j = 0; j < i; j ++ ) {
+
+						if ( sortedVals[ j ] === val ) {
+
+							firstIdx = j;
+							break;
+
+						}
+
+					}
+
+					errors.push(
+						`Duplicate payload ${val} at indices ${firstIdx} and ${i} ` +
+						`(keys: 0x${sortedKeys[ firstIdx ].toString( 16 )}, 0x${sortedKeys[ i ].toString( 16 )})`
+					);
+
+				}
+
+			} else {
+
+				seen.add( val );
+
+			}
+
+		}
+
+		stats.payloadMissing = primCount - seen.size;
+		if ( stats.payloadMissing > 0 && stats.payloadDuplicates === 0 ) {
+
+			errors.push( `${stats.payloadMissing} payload values missing (no duplicates found)` );
+
+		}
+
+		// Verify key-payload correspondence: sortedKeys[i] should equal origMortonCodes[sortedVals[i]]
+		let correspondenceErrors = 0;
+		for ( let i = 0; i < primCount; i ++ ) {
+
+			const payloadIdx = sortedVals[ i ];
+			if ( payloadIdx < primCount && sortedKeys[ i ] !== origMortonCodes[ payloadIdx ] ) {
+
+				correspondenceErrors ++;
+				if ( correspondenceErrors <= 3 ) {
+
+					errors.push(
+						`Key-payload mismatch at ${i}: key=0x${sortedKeys[ i ].toString( 16 )}, ` +
+						`expected origMortonCodes[${payloadIdx}]=0x${origMortonCodes[ payloadIdx ].toString( 16 )}`
+					);
+
+				}
+
+			}
+
+		}
+
+		// Additional check: for out-of-order elements, see if they're "swapped"
+		// (each got the other's expected position)
+		if ( stats.keysOutOfOrder > 0 ) {
+
+			// Build a map of key -> expected sorted position (using a simple CPU sort as reference)
+			const keyValuePairs = [];
+			for ( let i = 0; i < primCount; i ++ ) {
+
+				keyValuePairs.push( { key: origMortonCodes[ i ], origIdx: i } );
+
+			}
+
+			keyValuePairs.sort( ( a, b ) => {
+
+				if ( a.key !== b.key ) return a.key - b.key;
+				return a.origIdx - b.origIdx; // Stable sort by original index
+
+			} );
+
+			// Now compare: where should each element be vs where it actually ended up?
+			for ( let i = 0; i < Math.min( 10, primCount ); i ++ ) {
+
+				const expectedOrigIdx = keyValuePairs[ i ].origIdx;
+				const actualOrigIdx = sortedVals[ i ];
+
+				if ( expectedOrigIdx !== actualOrigIdx ) {
+
+					const expectedKey = origMortonCodes[ expectedOrigIdx ];
+					const actualKey = sortedKeys[ i ];
+
+					// Only report if this is near the error
+					if ( ( i >= 2490 && i <= 2495 ) || ( i >= 2556 && i <= 2561 ) ) {
+
+						stats[ `position_${i}_expected` ] = {
+							origIdx: expectedOrigIdx,
+							key: `0x${expectedKey.toString( 16 ).padStart( 8, '0' )}`,
+						};
+						stats[ `position_${i}_actual` ] = {
+							origIdx: actualOrigIdx,
+							key: `0x${actualKey.toString( 16 ).padStart( 8, '0' )}`,
+						};
+
+					}
+
+				}
+
+			}
+
+			// Also check the specific error positions (2492, 2558)
+			for ( const pos of [ 2492, 2493, 2558, 2559 ] ) {
+
+				if ( pos < primCount ) {
+
+					const expectedOrigIdx = keyValuePairs[ pos ].origIdx;
+					const actualOrigIdx = sortedVals[ pos ];
+					const expectedKey = origMortonCodes[ expectedOrigIdx ];
+					const actualKey = sortedKeys[ pos ];
+
+					stats[ `position_${pos}_expected` ] = {
+						origIdx: expectedOrigIdx,
+						key: `0x${expectedKey.toString( 16 ).padStart( 8, '0' )}`,
+					};
+					stats[ `position_${pos}_actual` ] = {
+						origIdx: actualOrigIdx,
+						key: `0x${actualKey.toString( 16 ).padStart( 8, '0' )}`,
+					};
+
+				}
+
+			}
+
+		}
+
+		stats.correspondenceErrors = correspondenceErrors;
+
+		// Additional analysis: for each out-of-order error, find where elements should have gone
+		if ( stats.keysOutOfOrder > 0 ) {
+
+			// Build reverse lookup: for each original index, where did it end up?
+			const payloadToSortedIdx = new Map();
+			for ( let i = 0; i < primCount; i ++ ) {
+
+				payloadToSortedIdx.set( sortedVals[ i ], i );
+
+			}
+
+			// For the first few out-of-order pairs, analyze in detail
+			let analysisCount = 0;
+			for ( let i = 0; i < primCount - 1 && analysisCount < 3; i ++ ) {
+
+				if ( sortedKeys[ i ] > sortedKeys[ i + 1 ] ) {
+
+					analysisCount ++;
+					const key_i = sortedKeys[ i ];
+					const key_i1 = sortedKeys[ i + 1 ];
+					const payload_i = sortedVals[ i ];
+					const payload_i1 = sortedVals[ i + 1 ];
+
+					// Where in the ORIGINAL array were these elements?
+					const origKey_i = origMortonCodes[ payload_i ];
+					const origKey_i1 = origMortonCodes[ payload_i1 ];
+
+					// The element at i should have gone to a LATER position
+					// The element at i+1 should have gone to an EARLIER position
+					// Find what's missing between them
+					const PART_SIZE = 256 * 15;
+					const partId_i = Math.floor( payload_i / PART_SIZE );
+					const partId_i1 = Math.floor( payload_i1 / PART_SIZE );
+					const subgroupSize = 32;
+					const elementsPerSubgroup = subgroupSize * 15;
+					const subgroup_i = Math.floor( ( payload_i % PART_SIZE ) / elementsPerSubgroup );
+					const subgroup_i1 = Math.floor( ( payload_i1 % PART_SIZE ) / elementsPerSubgroup );
+
+					errors.push(
+						`Analysis for error at ${i}: ` +
+						`payload[${i}]=${payload_i} (orig partId=${partId_i}, subgroup=${subgroup_i}), ` +
+						`payload[${i + 1}]=${payload_i1} (orig partId=${partId_i1}, subgroup=${subgroup_i1}), ` +
+						`origKey correspondence: key[${i}]=0x${key_i.toString( 16 )} vs orig[${payload_i}]=0x${origKey_i.toString( 16 )}, ` +
+						`key[${i + 1}]=0x${key_i1.toString( 16 )} vs orig[${payload_i1}]=0x${origKey_i1.toString( 16 )}`
+					);
+
+				}
+
+			}
+
+		}
+
+		// Cleanup
+		keysBuffer.destroy();
+		valsBuffer.destroy();
+
+		const valid = stats.keysOutOfOrder === 0 &&
+			stats.payloadDuplicates === 0 &&
+			stats.payloadMissing === 0 &&
+			correspondenceErrors === 0;
+
+		return { valid, errors, stats };
+
+	}
+
+	// ---- Private helpers ----
+
+	async _readBuffer( gpuBuffer, size, TypedArrayClass ) {
+
+		const device = this.device;
+
+		const readBuffer = device.createBuffer( {
+			size,
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+
+		const commandEncoder = device.createCommandEncoder();
+		commandEncoder.copyBufferToBuffer( gpuBuffer, 0, readBuffer, 0, size );
+		device.queue.submit( [ commandEncoder.finish() ] );
+
+		await readBuffer.mapAsync( GPUMapMode.READ );
+		const mappedRange = readBuffer.getMappedRange();
+
+		let result;
+		if ( TypedArrayClass === ArrayBuffer ) {
+
+			// Return a copy of the ArrayBuffer
+			result = mappedRange.slice( 0 );
+
+		} else {
+
+			// Return typed array copy
+			result = new TypedArrayClass( new TypedArrayClass( mappedRange ) );
+
+		}
+
+		readBuffer.unmap();
+		readBuffer.destroy();
+
+		return result;
+
+	}
+
+	_parseBVH2Nodes( buffer, nodeCount ) {
+
+		const nodes = [];
+		const floatView = new Float32Array( buffer );
+		const uintView = new Uint32Array( buffer );
+
+		// WGSL struct layout for BVH2Node (32 bytes total):
+		// struct BVH2Node {
+		//     boundsMin: vec3f,  // offset 0, size 12
+		//     leftChild: u32,    // offset 12, size 4
+		//     boundsMax: vec3f,  // offset 16, size 12 (vec3f has alignment 16)
+		//     rightChild: u32,   // offset 28, size 4
+		// };
+
+		for ( let i = 0; i < nodeCount; i ++ ) {
+
+			const base = i * 8; // 32 bytes / 4 = 8 u32s per node
+
+			nodes.push( {
+				bounds: {
+					minX: floatView[ base + 0 ], // offset 0
+					minY: floatView[ base + 1 ], // offset 4
+					minZ: floatView[ base + 2 ], // offset 8
+					maxX: floatView[ base + 4 ], // offset 16
+					maxY: floatView[ base + 5 ], // offset 20
+					maxZ: floatView[ base + 6 ], // offset 24
+				},
+				leftChild: uintView[ base + 3 ], // offset 12
+				rightChild: uintView[ base + 7 ], // offset 28
+			} );
+
+		}
+
+		return nodes;
+
+	}
+
+	_boundsContain( parent, child, epsilon = 1e-5 ) {
+
+		return (
+			child.minX >= parent.minX - epsilon &&
+			child.minY >= parent.minY - epsilon &&
+			child.minZ >= parent.minZ - epsilon &&
+			child.maxX <= parent.maxX + epsilon &&
+			child.maxY <= parent.maxY + epsilon &&
+			child.maxZ <= parent.maxZ + epsilon
+		);
+
+	}
+
+	/**
+	 * Debug method: Validate the sorter one pass at a time.
+	 * This helps identify which radix pass causes corruption.
+	 * @returns {Promise<{passResults: object[]}>}
+	 */
+	async validateSorterPerPass() {
+
+		const primCount = this.gpuBVH._primCount;
+		const device = this.device;
+		const sorter = this.gpuBVH.sorter;
+
+		if ( ! sorter || sorter.name !== 'OneSweep' ) {
+
+			return { error: 'Per-pass validation only works with OneSweep sorter' };
+
+		}
+
+		// Read original morton codes
+		const origKeys = await this._readBuffer(
+			this.gpuBVH._buildBuffers.mortonCodes,
+			primCount * 4,
+			Uint32Array
+		);
+
+		const PART_SIZE = 3840;
+		const threadBlocks = Math.ceil( primCount / PART_SIZE );
+
+		console.log( `\n=== Per-Pass Debug Validation ===` );
+		console.log( `primCount: ${primCount}, threadBlocks: ${threadBlocks}` );
+		console.log( `Last partition size: ${primCount - ( threadBlocks - 1 ) * PART_SIZE}` );
+
+		// Track specific elements we're interested in
+		const watchIndices = [ 2492, 2493, 2557, 2558, 2559 ];
+		const LANE_COUNT = 32; // Assumed
+		const KEYS_PER_THREAD = 15;
+		const ELEMENTS_PER_SUBGROUP = LANE_COUNT * KEYS_PER_THREAD; // 32 * 15 = 480
+
+		console.log( `\nOriginal values at watch indices:` );
+		for ( const idx of watchIndices ) {
+
+			if ( idx < primCount ) {
+
+				const partId = Math.floor( idx / PART_SIZE );
+				const localIdx = idx % PART_SIZE;
+				const subgroupId = Math.floor( localIdx / ELEMENTS_PER_SUBGROUP );
+				const withinSubgroup = localIdx % ELEMENTS_PER_SUBGROUP;
+				const lane = withinSubgroup % LANE_COUNT;
+				const k = Math.floor( withinSubgroup / LANE_COUNT );
+
+				console.log( `  origKeys[${idx}] = 0x${origKeys[ idx ].toString( 16 ).padStart( 8, '0' )} ` +
+					`bytes=[${origKeys[ idx ] & 0xff}, ${( origKeys[ idx ] >> 8 ) & 0xff}, ` +
+					`${( origKeys[ idx ] >> 16 ) & 0xff}, ${( origKeys[ idx ] >> 24 ) & 0xff}] ` +
+					`(part=${partId}, subgroup=${subgroupId}, lane=${lane}, k=${k})` );
+
+			}
+
+		}
+
+		// Check how many times the problematic key 0x359d00d7 appears in original data
+		const problemKey = 0x359d00d7;
+		let problemKeyCount = 0;
+		const problemKeyPositions = [];
+		for ( let i = 0; i < primCount; i ++ ) {
+
+			if ( origKeys[ i ] === problemKey ) {
+
+				problemKeyCount ++;
+				if ( problemKeyPositions.length < 5 ) {
+
+					problemKeyPositions.push( i );
+
+				}
+
+			}
+
+		}
+
+		console.log( `\nProblem key 0x${problemKey.toString( 16 )} appears ${problemKeyCount} times in original data` );
+		if ( problemKeyPositions.length > 0 ) {
+
+			console.log( `  First occurrences at indices: ${problemKeyPositions.join( ', ' )}` );
+
+		}
+
+		// Check if sorter has internal status buffer we can read
+		if ( sorter._buffers && sorter._buffers.status ) {
+
+			const statusData = await this._readBuffer( sorter._buffers.status, 16, Uint32Array );
+			console.log( `\nSorter status buffer: [${statusData[ 0 ].toString( 16 )}, ${statusData[ 1 ].toString( 16 )}, ${statusData[ 2 ].toString( 16 )}, ${statusData[ 3 ].toString( 16 )}]` );
+			if ( statusData[ 0 ] !== 0 ) console.log( `  STATUS_ERR_GLOBAL_HIST: 0x${statusData[ 0 ].toString( 16 )}` );
+			if ( statusData[ 1 ] !== 0 ) console.log( `  STATUS_ERR_SCAN: 0x${statusData[ 1 ].toString( 16 )}` );
+			if ( statusData[ 2 ] !== 0 ) console.log( `  STATUS_ERR_PASS: 0x${statusData[ 2 ].toString( 16 )}` );
+			if ( statusData[ 3 ] !== 0 ) console.log( `  STATUS_ERR_LANE_COUNT: 0x${statusData[ 3 ].toString( 16 )}` );
+
+		}
+
+		// Verify global histogram by computing CPU reference
+		console.log( `\nVerifying global histogram...` );
+		const cpuHist = new Uint32Array( 256 * 4 ); // 4 passes x 256 digits
+		for ( let i = 0; i < primCount; i ++ ) {
+
+			const key = origKeys[ i ];
+			cpuHist[ ( key & 0xff ) ] ++;
+			cpuHist[ 256 + ( ( key >> 8 ) & 0xff ) ] ++;
+			cpuHist[ 512 + ( ( key >> 16 ) & 0xff ) ] ++;
+			cpuHist[ 768 + ( ( key >> 24 ) & 0xff ) ] ++;
+
+		}
+
+		// Read GPU histogram (it's populated after the sort, so we need to re-run global_hist)
+		// For now, just compute expected totals
+		let totalCpuHist = 0;
+		for ( let i = 0; i < 256; i ++ ) totalCpuHist += cpuHist[ i ];
+		console.log( `  CPU histogram pass 0 sum: ${totalCpuHist} (expected: ${primCount})` );
+
+		// Check specific digits involved in the corruption
+		const digits2493 = {
+			d0: origKeys[ 2493 ] & 0xff,
+			d1: ( origKeys[ 2493 ] >> 8 ) & 0xff,
+			d2: ( origKeys[ 2493 ] >> 16 ) & 0xff,
+			d3: ( origKeys[ 2493 ] >> 24 ) & 0xff,
+		};
+		const digits2558 = {
+			d0: origKeys[ 2558 ] & 0xff,
+			d1: ( origKeys[ 2558 ] >> 8 ) & 0xff,
+			d2: ( origKeys[ 2558 ] >> 16 ) & 0xff,
+			d3: ( origKeys[ 2558 ] >> 24 ) & 0xff,
+		};
+		console.log( `  origKeys[2493]=0x${origKeys[ 2493 ].toString( 16 )} digits: d0=${digits2493.d0}, d1=${digits2493.d1}, d2=${digits2493.d2}, d3=${digits2493.d3}` );
+		console.log( `  origKeys[2558]=0x${origKeys[ 2558 ].toString( 16 )} digits: d0=${digits2558.d0}, d1=${digits2558.d1}, d2=${digits2558.d2}, d3=${digits2558.d3}` );
+		console.log( `  CPU histogram counts for digit d0=${digits2493.d0}: ${cpuHist[ digits2493.d0 ]}` );
+		console.log( `  CPU histogram counts for digit d0=${digits2558.d0}: ${cpuHist[ digits2558.d0 ]}` );
+
+		// Create buffers
+		const keysBuffer = device.createBuffer( {
+			size: primCount * 4,
+			usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+		} );
+		const valsBuffer = device.createBuffer( {
+			size: primCount * 4,
+			usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+		} );
+		const altKeysBuffer = device.createBuffer( {
+			size: primCount * 4,
+			usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+		} );
+		const altValsBuffer = device.createBuffer( {
+			size: primCount * 4,
+			usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+		} );
+
+		// Initialize values as 0, 1, 2, ...
+		const initVals = new Uint32Array( primCount );
+		for ( let i = 0; i < primCount; i ++ ) initVals[ i ] = i;
+
+		device.queue.writeBuffer( keysBuffer, 0, origKeys );
+		device.queue.writeBuffer( valsBuffer, 0, initVals );
+
+		const passResults = [];
+
+		// Run 4 passes, validating after each
+		for ( let pass = 0; pass < 4; pass ++ ) {
+
+			const shift = pass * 8;
+			console.log( `\n--- Pass ${pass} (bits ${shift}-${shift + 7}) ---` );
+
+			// Run single pass using sorter's internal method
+			// We need to manually run one pass of the sort
+			const commandEncoder = device.createCommandEncoder();
+
+			// Call the full sort but we'll analyze after
+			// Note: OneSweep does 4 passes internally, so we can't easily do single-pass
+			// Instead, let's just run the full sort and analyze the result
+
+			if ( pass === 0 ) {
+
+				// On first pass, run full sort
+				sorter.sort( {
+					commandEncoder,
+					keysIn: keysBuffer,
+					keysOut: keysBuffer,
+					valsIn: valsBuffer,
+					valsOut: valsBuffer,
+					count: primCount,
+				} );
+
+				device.queue.submit( [ commandEncoder.finish() ] );
+				await device.queue.onSubmittedWorkDone();
+
+				// Read final result
+				const sortedKeys = await this._readBuffer( keysBuffer, primCount * 4, Uint32Array );
+				const sortedVals = await this._readBuffer( valsBuffer, primCount * 4, Uint32Array );
+
+				// Find where watch elements ended up
+				console.log( `\nFinal positions of watch elements:` );
+				for ( const origIdx of watchIndices ) {
+
+					let foundAt = - 1;
+					let count = 0;
+					for ( let i = 0; i < primCount; i ++ ) {
+
+						if ( sortedVals[ i ] === origIdx ) {
+
+							if ( foundAt === - 1 ) foundAt = i;
+							count ++;
+
+						}
+
+					}
+
+					if ( foundAt >= 0 ) {
+
+						console.log( `  origIdx ${origIdx} (key 0x${origKeys[ origIdx ].toString( 16 ).padStart( 8, '0' )}) ` +
+							`-> position ${foundAt}${count > 1 ? ` (DUPLICATED ${count}x!)` : ''}` );
+
+					} else {
+
+						console.log( `  origIdx ${origIdx} (key 0x${origKeys[ origIdx ].toString( 16 ).padStart( 8, '0' )}) ` +
+							`-> MISSING!` );
+
+					}
+
+				}
+
+				// Check what's at the error positions
+				console.log( `\nValues at error positions:` );
+				for ( const pos of [ 2492, 2557, 629828 ] ) {
+
+					if ( pos < primCount ) {
+
+						const key = sortedKeys[ pos ];
+						const val = sortedVals[ pos ];
+						console.log( `  position ${pos}: key=0x${key.toString( 16 ).padStart( 8, '0' )}, payload=${val} ` +
+							`(orig key was 0x${origKeys[ val ].toString( 16 ).padStart( 8, '0' )})` );
+
+					}
+
+				}
+
+				// Count duplicates and missing
+				const seen = new Map();
+				let duplicates = 0;
+				for ( let i = 0; i < primCount; i ++ ) {
+
+					const val = sortedVals[ i ];
+					if ( seen.has( val ) ) {
+
+						duplicates ++;
+						if ( duplicates <= 3 ) {
+
+							console.log( `  DUPLICATE: payload ${val} at positions ${seen.get( val )} and ${i}` );
+
+						}
+
+					} else {
+
+						seen.set( val, i );
+
+					}
+
+				}
+
+				passResults.push( {
+					pass: 'all',
+					keysOutOfOrder: this._countOutOfOrder( sortedKeys ),
+					duplicates,
+					missing: primCount - seen.size,
+				} );
+				break;
+
+			}
+
+		}
+
+		// Cleanup
+		keysBuffer.destroy();
+		valsBuffer.destroy();
+		altKeysBuffer.destroy();
+		altValsBuffer.destroy();
+
+		return { passResults };
+
+	}
+
+	_countOutOfOrder( arr ) {
+
+		let count = 0;
+		for ( let i = 0; i < arr.length - 1; i ++ ) {
+
+			if ( arr[ i ] > arr[ i + 1 ] ) count ++;
+
+		}
+
+		return count;
+
+	}
+
+}

--- a/src/gpu/index.js
+++ b/src/gpu/index.js
@@ -1,0 +1,2 @@
+export { GPUMeshBVH, SorterType } from './GPUMeshBVH.js';
+export { GPUMeshBVHValidator } from './GPUMeshBVHValidator.js';

--- a/src/gpu/shaders/flatten.wgsl.js
+++ b/src/gpu/shaders/flatten.wgsl.js
@@ -1,0 +1,188 @@
+/**
+ * Flatten shader: Converts H-PLOC BVH2 format to traversal-compatible layout.
+ *
+ * H-PLOC produces nodes with absolute child indices.
+ * Traversal expects: left child at index+1, right child as relative offset.
+ *
+ * This shader performs a sequential two-pass DFS:
+ * 1) Compute subtree sizes.
+ * 2) Emit nodes in pre-order with correct relative offsets.
+ */
+
+export const flattenShader = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+// Output format matching three-mesh-bvh WebGPU traversal
+struct BVHNode {
+	boundsMinX: f32,
+	boundsMinY: f32,
+	boundsMinZ: f32,
+	boundsMaxX: f32,
+	boundsMaxY: f32,
+	boundsMaxZ: f32,
+	rightChildOrTriangleOffset: u32,
+	splitAxisOrTriangleCount: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(2) var<storage, read_write> clusterIdx: array<atomic<u32>>;
+@group(0) @binding(3) var<storage, read> nodeCounter: u32;
+@group(0) @binding(4) var<storage, read_write> subtreeSizes: array<u32>;
+@group(0) @binding(5) var<storage, read_write> stackNodes: array<u32>;
+@group(0) @binding(6) var<storage, read_write> stackOut: array<u32>;
+@group(0) @binding(7) var<storage, read_write> outputNodes: array<BVHNode>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const LEAF_FLAG: u32 = 0xFFFF0000u;
+
+// Check if node is a leaf
+fn isLeaf(node: BVH2Node) -> bool {
+	return node.leftChild == INVALID_IDX;
+}
+
+// Compute split axis from child bounds (simplified: use largest extent axis)
+fn computeSplitAxis(node: BVH2Node) -> u32 {
+	let extent = node.boundsMax - node.boundsMin;
+
+	if (extent.x >= extent.y && extent.x >= extent.z) {
+		return 0u;
+	} else if (extent.y >= extent.z) {
+		return 1u;
+	} else {
+		return 2u;
+	}
+}
+
+@compute @workgroup_size(1)
+fn computeSubtreeSizes(
+	@builtin(global_invocation_id) globalId: vec3u
+) {
+	if (globalId.x != 0u) {
+		return;
+	}
+
+	if (nodeCounter == 0u) {
+		return;
+	}
+
+	let rootIdx = atomicLoad(&clusterIdx[0]);
+	var sp: i32 = 0;
+
+	stackNodes[0] = rootIdx;
+	stackOut[0] = 0u; // state: 0 = first visit, 1 = post-visit
+
+	loop {
+		if (sp < 0) {
+			break;
+		}
+
+		let nodeIdx = stackNodes[u32(sp)];
+		let state = stackOut[u32(sp)];
+		sp = sp - 1;
+
+		let node = bvh2Nodes[nodeIdx];
+		if (state == 0u) {
+			if (isLeaf(node)) {
+				subtreeSizes[nodeIdx] = 1u;
+				continue;
+			}
+
+			sp = sp + 1;
+			stackNodes[u32(sp)] = nodeIdx;
+			stackOut[u32(sp)] = 1u;
+
+			sp = sp + 1;
+			stackNodes[u32(sp)] = node.rightChild;
+			stackOut[u32(sp)] = 0u;
+
+			sp = sp + 1;
+			stackNodes[u32(sp)] = node.leftChild;
+			stackOut[u32(sp)] = 0u;
+		} else {
+			let leftSize = subtreeSizes[node.leftChild];
+			let rightSize = subtreeSizes[node.rightChild];
+			subtreeSizes[nodeIdx] = 1u + leftSize + rightSize;
+		}
+	}
+}
+
+@compute @workgroup_size(1)
+fn flattenTree(
+	@builtin(global_invocation_id) globalId: vec3u
+) {
+	if (globalId.x != 0u) {
+		return;
+	}
+
+	if (nodeCounter == 0u) {
+		return;
+	}
+
+	let rootIdx = atomicLoad(&clusterIdx[0]);
+	var sp: i32 = 0;
+
+	stackNodes[0] = rootIdx;
+	stackOut[0] = 0u;
+
+	loop {
+		if (sp < 0) {
+			break;
+		}
+
+		let nodeIdx = stackNodes[u32(sp)];
+		let outIdx = stackOut[u32(sp)];
+		sp = sp - 1;
+
+		let srcNode = bvh2Nodes[nodeIdx];
+		var dstNode: BVHNode;
+
+		// Copy bounds
+		dstNode.boundsMinX = srcNode.boundsMin.x;
+		dstNode.boundsMinY = srcNode.boundsMin.y;
+		dstNode.boundsMinZ = srcNode.boundsMin.z;
+		dstNode.boundsMaxX = srcNode.boundsMax.x;
+		dstNode.boundsMaxY = srcNode.boundsMax.y;
+		dstNode.boundsMaxZ = srcNode.boundsMax.z;
+
+		if (isLeaf(srcNode)) {
+			dstNode.rightChildOrTriangleOffset = srcNode.rightChild;
+			dstNode.splitAxisOrTriangleCount = LEAF_FLAG | 1u;
+		} else {
+			let leftChild = srcNode.leftChild;
+			let rightChild = srcNode.rightChild;
+
+			let leftOutIdx = outIdx + 1u;
+			let rightOutIdx = outIdx + 1u + subtreeSizes[leftChild];
+			let relativeOffset = rightOutIdx - outIdx;
+
+			dstNode.rightChildOrTriangleOffset = relativeOffset;
+			dstNode.splitAxisOrTriangleCount = computeSplitAxis(srcNode);
+
+			// Push right then left so left is processed first
+			sp = sp + 1;
+			stackNodes[u32(sp)] = rightChild;
+			stackOut[u32(sp)] = rightOutIdx;
+
+			sp = sp + 1;
+			stackNodes[u32(sp)] = leftChild;
+			stackOut[u32(sp)] = leftOutIdx;
+		}
+
+		outputNodes[outIdx] = dstNode;
+	}
+}
+`;

--- a/src/gpu/shaders/hploc.wgsl.js
+++ b/src/gpu/shaders/hploc.wgsl.js
@@ -1,0 +1,3210 @@
+/**
+ * H-PLOC (Hierarchical Parallel Locally-Ordered Clustering) shader.
+ *
+ * Threading model: 1 thread per primitive (not 1 workgroup per primitive)
+ * Each thread does its own LBVH traversal.
+ * When a thread's range exceeds threshold, the workgroup collaborates on PLOC merging.
+ *
+ * Multi-dispatch version with LBVH multi-step optimization:
+ * - While range is small (≤ MERGING_THRESHOLD), do multiple LBVH steps per dispatch
+ * - This is safe because small ranges only use parentIdx atomics (device-wide visibility)
+ * - Exit loop when: sibling not arrived, OR range needs PLOC merging
+ * - Thread state is persisted in global buffers between dispatches
+ * - This optimization significantly reduces total dispatch count
+ */
+
+const sharedHplocCode = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+struct AABB {
+	min: vec3f,
+	max: vec3f,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> mortonCodes: array<u32>;
+// Phase 1 optimization: plain u32 instead of atomic - H-PLOC guarantees disjoint range access
+@group(0) @binding(2) var<storage, read_write> clusterIdx: array<u32>;
+@group(0) @binding(3) var<storage, read_write> parentIdx: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(5) var<storage, read_write> nodeCounter: atomic<u32>;
+
+// Persistent state buffer (for multi-dispatch)
+// Each primitive's state is vec4u(left, right, split, active)
+@group(0) @binding(6) var<storage, read_write> state: array<vec4u>;
+// activeCount removed - was pure overhead (never used for early termination)
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+// WG=64 is optimal - larger sizes hit shared memory/occupancy limits
+const WORKGROUP_SIZE: u32 = 64u;
+const SEARCH_RADIUS: u32 = 8u;
+// Must be <= WORKGROUP_SIZE/2 because two combining ranges could each have
+// up to MERGING_THRESHOLD clusters, and PLOC can only load WORKGROUP_SIZE total
+const MERGING_THRESHOLD: u32 = 32u;
+
+// Shared memory for PLOC merging
+var<workgroup> sharedClusterIdx: array<u32, 64>;
+var<workgroup> sharedBoundsMin: array<vec3f, 64>;
+var<workgroup> sharedBoundsMax: array<vec3f, 64>;
+var<workgroup> sharedNearestNeighbor: array<u32, 64>;
+
+// Per-thread state shared for collaboration
+var<workgroup> sharedLeft: array<u32, 64>;
+var<workgroup> sharedRight: array<u32, 64>;
+var<workgroup> sharedSplit: array<u32, 64>;
+var<workgroup> sharedActive: array<u32, 64>;
+var<workgroup> sharedNeedsMerge: array<u32, 64>;
+
+// Parallel compaction support (Hillis-Steele prefix sum)
+var<workgroup> sharedPrefixSum: array<u32, 64>;
+var<workgroup> sharedTempIdx: array<u32, 64>;
+var<workgroup> sharedTempMin: array<vec3f, 64>;
+var<workgroup> sharedTempMax: array<vec3f, 64>;
+
+// Compacted merge list (indices of threads that need PLOC merging)
+// Separate from other arrays to avoid corruption during PLOC inner loop
+var<workgroup> sharedMergeList: array<u32, 64>;
+
+// Broadcast variables (read via workgroupUniformLoad for uniform control flow)
+var<workgroup> uAnyActive: u32;
+var<workgroup> uMergeLeft: u32;
+var<workgroup> uMergeRight: u32;
+var<workgroup> uMergeSplit: u32;
+var<workgroup> uIsFinal: u32;
+var<workgroup> uNewNumPrim: u32;
+var<workgroup> uNeedsMergeT: u32;
+
+// Returns common prefix length (higher = more similar, lower = more divergent)
+// Uses countLeadingZeros for canonical LBVH parent selection
+fn delta(a: u32, b: u32) -> u32 {
+	let mcA = mortonCodes[a];
+	let mcB = mortonCodes[b];
+	let xorVal = mcA ^ mcB;
+	if (xorVal == 0u) {
+		// Equal morton codes: use index to break ties
+		// Add 32 to ensure this is always > any CLZ(xorVal)
+		return 32u + countLeadingZeros(a ^ b);
+	}
+	return countLeadingZeros(xorVal);
+}
+
+fn findParentId(left: u32, right: u32, primCount: u32) -> u32 {
+	if (left == 0u) {
+		return right;
+	}
+	if (right == primCount - 1u) {
+		return left - 1u;
+	}
+
+	let deltaRight = delta(right, right + 1u);
+	let deltaLeft = delta(left - 1u, left);
+
+	// With CLZ-based delta: higher = longer prefix = less divergent
+	// Return right when right boundary is LESS divergent (higher CLZ)
+	if (deltaRight > deltaLeft) {
+		return right;
+	}
+	return left - 1u;
+}
+
+fn aabbArea(boundsMin: vec3f, boundsMax: vec3f) -> f32 {
+	let extent = boundsMax - boundsMin;
+	return 2.0 * (extent.x * extent.y + extent.y * extent.z + extent.z * extent.x);
+}
+
+@compute @workgroup_size(64)
+fn hplocBuild(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(workgroup_id) workgroupId: vec3u
+) {
+	let localIdx = localId.x;
+	let primIdx = globalId.x;  // One thread per primitive
+
+	// OOB guard: threads beyond primCount are inactive and don't access state
+	// IMPORTANT: Don't use select() for OOB guard - WGSL may evaluate both arguments
+	let isOOB = primIdx >= uniforms.primCount;
+
+	// Load persistent state from global buffer (vec4u per primitive)
+	// OOB threads use dummy values (won't be written back)
+	var stateVec = vec4u(0u);
+	if (!isOOB) {
+		stateVec = state[primIdx];
+	}
+	var left = stateVec.x;
+	var right = stateVec.y;
+	var split = stateVec.z;
+	var isActive = stateVec.w != 0u && !isOOB;
+
+	// Store state in shared memory for workgroup collaboration
+	sharedLeft[localIdx] = left;
+	sharedRight[localIdx] = right;
+	sharedSplit[localIdx] = split;
+	sharedActive[localIdx] = select(0u, 1u, isActive);
+	sharedNeedsMerge[localIdx] = 0u;
+
+	workgroupBarrier();
+
+	// Check if any thread in workgroup is still active
+	if (localIdx == 0u) {
+		var anyActive = 0u;
+		for (var i = 0u; i < WORKGROUP_SIZE; i = i + 1u) {
+			anyActive = anyActive | sharedActive[i];
+		}
+		uAnyActive = anyActive;
+	}
+	// workgroupUniformLoad includes an implicit barrier AND tells compiler the value is uniform
+	// This is required for uniform control flow analysis
+	let anyActive = workgroupUniformLoad(&uAnyActive);
+
+	// Early exit if no active threads - still need to save state
+	if (anyActive == 0u) {
+		// Save state (unchanged) - OOB threads don't write
+		if (!isOOB) {
+			state[primIdx] = vec4u(left, right, split, 0u);
+		}
+		return;
+	}
+
+	// ===== MULTI-STEP LBVH OPTIMIZATION =====
+	// Do multiple LBVH traversal steps while range is small (no PLOC merging needed).
+	// This is safe because small ranges don't write to clusterIdx - only parentIdx via atomics.
+	// Atomics have device-wide visibility within a single dispatch.
+	// Exit loop when: sibling not arrived, OR range needs PLOC merging.
+	// IMPORTANT: Always try at least one LBVH step, THEN check if more steps are safe.
+
+	var rangeSize = right - left + 1u;
+
+	while (isActive) {
+		// LBVH traversal step FIRST (always try at least one per dispatch)
+		let parentId = findParentId(left, right, uniforms.primCount);
+		var previousId = INVALID_IDX;
+
+		if (parentId == right) {
+			previousId = atomicExchange(&parentIdx[right], left);
+			if (previousId != INVALID_IDX) {
+				split = right + 1u;
+				right = previousId;
+			}
+		} else {
+			previousId = atomicExchange(&parentIdx[left - 1u], right);
+			if (previousId != INVALID_IDX) {
+				split = left;
+				left = previousId;
+			}
+		}
+
+		// If sibling hasn't arrived yet, become inactive and wait for next dispatch
+		if (previousId == INVALID_IDX) {
+			isActive = false;
+			break;
+		}
+
+		// Sibling arrived - update range size
+		rangeSize = right - left + 1u;
+
+		// Check if PLOC merging is needed - must exit loop for cross-workgroup coordination
+		if (rangeSize > MERGING_THRESHOLD || rangeSize == uniforms.primCount) {
+			break;
+		}
+
+		// Range is still small - safe to continue with another LBVH step
+	}
+
+	// Update shared state
+	sharedLeft[localIdx] = left;
+	sharedRight[localIdx] = right;
+	sharedSplit[localIdx] = split;
+	sharedActive[localIdx] = select(0u, 1u, isActive);
+
+	// Check if this thread needs merging
+	let isFinal = isActive && (rangeSize == uniforms.primCount);
+	let needsMerge = isActive && ((rangeSize > MERGING_THRESHOLD) || isFinal);
+	sharedNeedsMerge[localIdx] = select(0u, 1u, needsMerge);
+
+	workgroupBarrier();
+
+	// Build compacted merge list to avoid O(WORKGROUP_SIZE) barriers
+	// Previously: 64 iterations with workgroupUniformLoad each = 64 implicit barriers
+	// Now: numMerges + 1 barriers (typical case: 1-3 merges = ~60 barriers saved)
+	// NOTE: Use dedicated sharedMergeList array to avoid corruption by PLOC inner loop
+	if (localIdx == 0u) {
+		var mergeCount = 0u;
+		for (var i = 0u; i < WORKGROUP_SIZE; i = i + 1u) {
+			if (sharedNeedsMerge[i] != 0u) {
+				sharedMergeList[mergeCount] = i;
+				mergeCount = mergeCount + 1u;
+			}
+		}
+		uNewNumPrim = mergeCount;
+	}
+	let numMerges = workgroupUniformLoad(&uNewNumPrim);
+
+	// Process only threads that need merging (compacted list)
+	for (var m = 0u; m < numMerges; m = m + 1u) {
+		// Broadcast which thread index to process
+		if (localIdx == 0u) {
+			uNeedsMergeT = sharedMergeList[m];
+		}
+		let t = workgroupUniformLoad(&uNeedsMergeT);
+
+		// Broadcast this thread's state to all
+		if (localIdx == 0u) {
+			uMergeLeft = sharedLeft[t];
+			uMergeRight = sharedRight[t];
+			uMergeSplit = sharedSplit[t];
+			let tRangeSize = sharedRight[t] - sharedLeft[t] + 1u;
+			uIsFinal = select(0u, 1u, tRangeSize == uniforms.primCount);
+		}
+		// workgroupUniformLoad handles synchronization AND marks value as uniform
+		let mergeLeft = workgroupUniformLoad(&uMergeLeft);
+		let mergeRight = workgroupUniformLoad(&uMergeRight);
+		let mergeSplit = workgroupUniformLoad(&uMergeSplit);
+		let mergeFinal = workgroupUniformLoad(&uIsFinal) != 0u;
+
+		// Load clusters from left and right ranges
+		// Load up to half WORKGROUP_SIZE from each child to maximize coverage
+		// Left child: [mergeLeft, mergeSplit)
+		// Right child: [mergeSplit, mergeRight+1)
+		let totalLeft = mergeSplit - mergeLeft;
+		let totalRight = mergeRight - mergeSplit + 1u;
+		let halfWorkgroup = WORKGROUP_SIZE / 2u;
+		let leftCount = min(totalLeft, halfWorkgroup);
+		let rightCount = min(totalRight, halfWorkgroup);
+		// Remember original loaded count - we need to write this many back
+		let originalLoadedCount = leftCount + rightCount;
+		var numPrim = originalLoadedCount;
+
+		// Load cluster indices (some might be INVALID from previous merges)
+		var loadedIdx = INVALID_IDX;
+		if (localIdx < numPrim) {
+			var loadIdx: u32;
+			if (localIdx < leftCount) {
+				loadIdx = mergeLeft + localIdx;
+			} else {
+				loadIdx = mergeSplit + (localIdx - leftCount);
+			}
+			loadedIdx = clusterIdx[loadIdx];
+		}
+		sharedClusterIdx[localIdx] = loadedIdx;
+		workgroupBarrier();
+
+		// Thread 0 compacts valid clusters (skip INVALID)
+		if (localIdx == 0u) {
+			var validCount = 0u;
+			for (var i = 0u; i < numPrim; i = i + 1u) {
+				let idx = sharedClusterIdx[i];
+				if (idx != INVALID_IDX) {
+					sharedNearestNeighbor[validCount] = idx;
+					validCount = validCount + 1u;
+				}
+			}
+			uNewNumPrim = validCount;
+		}
+		// workgroupUniformLoad handles synchronization AND marks value as uniform
+		numPrim = workgroupUniformLoad(&uNewNumPrim);
+
+		// Copy compacted indices back and load bounds
+		// Also mark positions beyond numPrim as INVALID
+		if (localIdx < numPrim) {
+			let cIdx = sharedNearestNeighbor[localIdx];
+			sharedClusterIdx[localIdx] = cIdx;
+
+			let node = bvh2Nodes[cIdx];
+			sharedBoundsMin[localIdx] = node.boundsMin;
+			sharedBoundsMax[localIdx] = node.boundsMax;
+		} else if (localIdx < originalLoadedCount) {
+			// Mark remaining positions as INVALID
+			sharedClusterIdx[localIdx] = INVALID_IDX;
+		}
+		workgroupBarrier();
+
+		// Merge threshold: 1 if final (merge down to single root), else MERGING_THRESHOLD
+		let threshold = select(MERGING_THRESHOLD, 1u, mergeFinal);
+
+		// PLOC merging iterations
+		for (var mergeIter = 0u; mergeIter < 32u; mergeIter = mergeIter + 1u) {
+			if (numPrim <= threshold) {
+				break;  // Uniform - numPrim is same for all threads
+			}
+
+			// Find nearest neighbor
+			var nearestIdx = INVALID_IDX;
+			var nearestCost = 1e30f;
+
+			if (localIdx < numPrim) {
+				let myMin = sharedBoundsMin[localIdx];
+				let myMax = sharedBoundsMax[localIdx];
+
+				let searchStart = select(0u, localIdx - SEARCH_RADIUS, localIdx >= SEARCH_RADIUS);
+				let searchEnd = min(localIdx + SEARCH_RADIUS + 1u, numPrim);
+
+				for (var j = searchStart; j < searchEnd; j = j + 1u) {
+					if (j != localIdx) {
+						let otherMin = sharedBoundsMin[j];
+						let otherMax = sharedBoundsMax[j];
+						let mergedMin = min(myMin, otherMin);
+						let mergedMax = max(myMax, otherMax);
+						let cost = aabbArea(mergedMin, mergedMax);
+
+						if (cost < nearestCost) {
+							nearestCost = cost;
+							nearestIdx = j;
+						}
+					}
+				}
+				sharedNearestNeighbor[localIdx] = nearestIdx;
+			}
+			workgroupBarrier();
+
+			// Determine merges (mutual nearest neighbors, lower index merges)
+			var shouldMerge = false;
+			if (localIdx < numPrim) {
+				let myNearest = sharedNearestNeighbor[localIdx];
+				if (myNearest != INVALID_IDX && myNearest < numPrim) {
+					let theirNearest = sharedNearestNeighbor[myNearest];
+					if (theirNearest == localIdx && localIdx < myNearest) {
+						shouldMerge = true;
+					}
+				}
+			}
+			workgroupBarrier();
+
+			// Perform merges and create BVH nodes
+			// Phase 1 optimization: removed redundant atomicLoad - the atomicAdd handles overflow
+			let maxNodes = 2u * uniforms.primCount;
+			if (shouldMerge) {
+				let myNearest = sharedNearestNeighbor[localIdx];
+				let leftCluster = sharedClusterIdx[localIdx];
+				let rightCluster = sharedClusterIdx[myNearest];
+
+				let mergedMin = min(sharedBoundsMin[localIdx], sharedBoundsMin[myNearest]);
+				let mergedMax = max(sharedBoundsMax[localIdx], sharedBoundsMax[myNearest]);
+
+				let newNodeIdx = atomicAdd(&nodeCounter, 1u);
+				if (newNodeIdx < maxNodes) {
+					bvh2Nodes[newNodeIdx].boundsMin = mergedMin;
+					bvh2Nodes[newNodeIdx].boundsMax = mergedMax;
+					bvh2Nodes[newNodeIdx].leftChild = leftCluster;
+					bvh2Nodes[newNodeIdx].rightChild = rightCluster;
+
+					sharedClusterIdx[localIdx] = newNodeIdx;
+					sharedBoundsMin[localIdx] = mergedMin;
+					sharedBoundsMax[localIdx] = mergedMax;
+				}
+			}
+			workgroupBarrier();
+
+			// Parallel compaction using Hillis-Steele prefix sum
+			// Step 1: Each thread determines if it survives
+			var survives = false;
+			if (localIdx < numPrim) {
+				survives = true;
+				let myNearest = sharedNearestNeighbor[localIdx];
+				if (myNearest != INVALID_IDX && myNearest < numPrim) {
+					let theirNearest = sharedNearestNeighbor[myNearest];
+					// I was merged INTO if their nearest is me AND they have lower index
+					if (theirNearest == localIdx && myNearest < localIdx) {
+						survives = false;
+					}
+				}
+			}
+
+			// Step 2: Store survival flag for prefix sum
+			sharedPrefixSum[localIdx] = select(0u, 1u, survives);
+			workgroupBarrier();
+
+			// Step 3: Hillis-Steele inclusive prefix sum (log2(32) = 5 iterations)
+			for (var stride = 1u; stride < WORKGROUP_SIZE; stride = stride * 2u) {
+				var addVal = 0u;
+				if (localIdx >= stride) {
+					addVal = sharedPrefixSum[localIdx - stride];
+				}
+				workgroupBarrier();
+				sharedPrefixSum[localIdx] = sharedPrefixSum[localIdx] + addVal;
+				workgroupBarrier();
+			}
+
+			// Step 4: Get total survivors (uniform read)
+			if (localIdx == 0u) {
+				// Last valid element contains total count
+				uNewNumPrim = select(0u, sharedPrefixSum[numPrim - 1u], numPrim > 0u);
+			}
+			// workgroupUniformLoad handles synchronization AND marks value as uniform
+			let newNumPrim = workgroupUniformLoad(&uNewNumPrim);
+
+			// Step 5: Parallel scatter to temp arrays
+			if (survives && localIdx < numPrim) {
+				let writePos = sharedPrefixSum[localIdx] - 1u;  // Convert inclusive to exclusive
+				sharedTempIdx[writePos] = sharedClusterIdx[localIdx];
+				sharedTempMin[writePos] = sharedBoundsMin[localIdx];
+				sharedTempMax[writePos] = sharedBoundsMax[localIdx];
+			}
+			workgroupBarrier();
+
+			// Step 6: Copy back from temp and mark remaining as INVALID
+			if (localIdx < newNumPrim) {
+				sharedClusterIdx[localIdx] = sharedTempIdx[localIdx];
+				sharedBoundsMin[localIdx] = sharedTempMin[localIdx];
+				sharedBoundsMax[localIdx] = sharedTempMax[localIdx];
+			} else if (localIdx < numPrim) {
+				sharedClusterIdx[localIdx] = INVALID_IDX;
+			}
+			numPrim = newNumPrim;
+			workgroupBarrier();
+		}
+
+		// Write results back to clusterIdx
+		// Write ALL originalLoadedCount entries to [mergeLeft, mergeLeft + originalLoadedCount)
+		// This matches CUDA's StoreIndices which writes numLeft + numRight entries
+		// Positions [numPrim, originalLoadedCount) contain INVALID_IDX from compaction
+		if (localIdx < originalLoadedCount) {
+			clusterIdx[mergeLeft + localIdx] = sharedClusterIdx[localIdx];
+		}
+		// storageBarrier not needed - GPU barrier between dispatches handles visibility
+		workgroupBarrier();
+
+		// Clear the merge flag for this thread
+		sharedNeedsMerge[t] = 0u;
+
+		// Final merge complete: deactivate this thread (tree is done)
+		// After final merge, numPrim=1 means root is built
+		if (mergeFinal && numPrim <= 1u) {
+			sharedActive[t] = 0u;
+			// Update local isActive if this is our thread
+			if (localIdx == t) {
+				isActive = false;
+			}
+		}
+		workgroupBarrier();
+	}
+
+	// ===== END OF ONE ITERATION =====
+
+	// Save state to global buffer for next dispatch (vec4u per primitive)
+	// OOB threads don't write back
+	if (!isOOB) {
+		state[primIdx] = vec4u(left, right, split, select(0u, 1u, isActive));
+	}
+}
+`;
+
+export const hplocShader = sharedHplocCode;
+
+/**
+ * Indirect dispatch version of H-PLOC for reduced workgroup launches.
+ *
+ * Instead of launching threads for ALL primitives every iteration,
+ * we maintain an "active list" of primitives that still need work.
+ * Each dispatch only processes active primitives, and writes still-active
+ * ones to the output list for the next iteration.
+ *
+ * Reduces total workgroup launches from O(primCount × iterations) to
+ * O(sum of active counts), which is much smaller due to geometric decay.
+ */
+export const hplocShaderIndirect = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> mortonCodes: array<u32>;
+@group(0) @binding(2) var<storage, read_write> clusterIdx: array<u32>;
+@group(0) @binding(3) var<storage, read_write> parentIdx: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(5) var<storage, read_write> nodeCounter: atomic<u32>;
+@group(0) @binding(6) var<storage, read_write> state: array<vec4u>;
+
+// Indirect dispatch buffers
+@group(0) @binding(7) var<storage, read> activeListIn: array<u32>;
+@group(0) @binding(8) var<storage, read_write> activeListOut: array<u32>;
+@group(0) @binding(9) var<storage, read_write> activeCountOut: atomic<u32>;
+// Note: activeCountIn needs read_write for atomicLoad even though we only read it
+@group(0) @binding(10) var<storage, read_write> activeCountIn: atomic<u32>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = 64u;
+const SEARCH_RADIUS: u32 = 8u;
+const MERGING_THRESHOLD: u32 = 32u;
+
+// Shared memory for PLOC merging
+var<workgroup> sharedClusterIdx: array<u32, 64>;
+var<workgroup> sharedBoundsMin: array<vec3f, 64>;
+var<workgroup> sharedBoundsMax: array<vec3f, 64>;
+var<workgroup> sharedNearestNeighbor: array<u32, 64>;
+
+var<workgroup> sharedLeft: array<u32, 64>;
+var<workgroup> sharedRight: array<u32, 64>;
+var<workgroup> sharedSplit: array<u32, 64>;
+var<workgroup> sharedActive: array<u32, 64>;
+var<workgroup> sharedNeedsMerge: array<u32, 64>;
+
+var<workgroup> sharedPrefixSum: array<u32, 64>;
+var<workgroup> sharedTempIdx: array<u32, 64>;
+var<workgroup> sharedTempMin: array<vec3f, 64>;
+var<workgroup> sharedTempMax: array<vec3f, 64>;
+
+var<workgroup> sharedMergeList: array<u32, 64>;
+
+var<workgroup> uAnyActive: u32;
+var<workgroup> uMergeLeft: u32;
+var<workgroup> uMergeRight: u32;
+var<workgroup> uMergeSplit: u32;
+var<workgroup> uIsFinal: u32;
+var<workgroup> uNewNumPrim: u32;
+var<workgroup> uNeedsMergeT: u32;
+var<workgroup> uActiveCount: u32;
+var<workgroup> uLiveCount: u32;
+var<workgroup> uActiveListBase: u32;
+
+// Returns common prefix length (higher = more similar, lower = more divergent)
+// Uses countLeadingZeros for canonical LBVH parent selection
+fn delta(a: u32, b: u32) -> u32 {
+	let mcA = mortonCodes[a];
+	let mcB = mortonCodes[b];
+	let xorVal = mcA ^ mcB;
+	if (xorVal == 0u) {
+		// Equal morton codes: use index to break ties
+		// Add 32 to ensure this is always > any CLZ(xorVal)
+		return 32u + countLeadingZeros(a ^ b);
+	}
+	return countLeadingZeros(xorVal);
+}
+
+fn findParentId(left: u32, right: u32, primCount: u32) -> u32 {
+	if (left == 0u) {
+		return right;
+	}
+	if (right == primCount - 1u) {
+		return left - 1u;
+	}
+
+	let deltaRight = delta(right, right + 1u);
+	let deltaLeft = delta(left - 1u, left);
+
+	// With CLZ-based delta: higher = longer prefix = less divergent
+	// Return right when right boundary is LESS divergent (higher CLZ)
+	if (deltaRight > deltaLeft) {
+		return right;
+	}
+	return left - 1u;
+}
+
+fn aabbArea(boundsMin: vec3f, boundsMax: vec3f) -> f32 {
+	let extent = boundsMax - boundsMin;
+	return 2.0 * (extent.x * extent.y + extent.y * extent.z + extent.z * extent.x);
+}
+
+@compute @workgroup_size(64)
+fn hplocBuildIndirect(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(workgroup_id) workgroupId: vec3u
+) {
+	let localIdx = localId.x;
+	let threadIdx = globalId.x;  // Index into active list
+
+	// Read active count once per workgroup and broadcast (uniform value)
+	if (localIdx == 0u) {
+		uActiveCount = atomicLoad(&activeCountIn);
+	}
+	let activeCount = workgroupUniformLoad(&uActiveCount);
+
+	// OOB guard: check if this thread has valid work
+	// threadIdx could be >= activeCount for the last workgroup
+	var isOOB = threadIdx >= activeCount;
+
+	// Read primitive index from active list (instead of using globalId directly)
+	// This is the key difference from hplocBuild - we only process active primitives
+	var primIdx = 0u;
+	if (!isOOB) {
+		primIdx = activeListIn[threadIdx];
+		// Double-check the primIdx is valid
+		isOOB = primIdx >= uniforms.primCount;
+	}
+
+	// Load persistent state
+	var stateVec = vec4u(0u);
+	if (!isOOB) {
+		stateVec = state[primIdx];
+	}
+	var left = stateVec.x;
+	var right = stateVec.y;
+	var split = stateVec.z;
+	var isActive = stateVec.w != 0u && !isOOB;
+
+	// Store state in shared memory for workgroup collaboration
+	sharedLeft[localIdx] = left;
+	sharedRight[localIdx] = right;
+	sharedSplit[localIdx] = split;
+	sharedActive[localIdx] = select(0u, 1u, isActive);
+	sharedNeedsMerge[localIdx] = 0u;
+
+	workgroupBarrier();
+
+	// Check if any thread in workgroup is still active
+	if (localIdx == 0u) {
+		var anyActive = 0u;
+		for (var i = 0u; i < WORKGROUP_SIZE; i = i + 1u) {
+			anyActive = anyActive | sharedActive[i];
+		}
+		uAnyActive = anyActive;
+	}
+	let anyActive = workgroupUniformLoad(&uAnyActive);
+
+	// Early exit if no active threads
+	if (anyActive == 0u) {
+		return;
+	}
+
+	// ===== MULTI-STEP LBVH OPTIMIZATION =====
+	var rangeSize = right - left + 1u;
+
+	while (isActive) {
+		let parentId = findParentId(left, right, uniforms.primCount);
+		var previousId = INVALID_IDX;
+
+		if (parentId == right) {
+			previousId = atomicExchange(&parentIdx[right], left);
+			if (previousId != INVALID_IDX) {
+				split = right + 1u;
+				right = previousId;
+			}
+		} else {
+			previousId = atomicExchange(&parentIdx[left - 1u], right);
+			if (previousId != INVALID_IDX) {
+				split = left;
+				left = previousId;
+			}
+		}
+
+		if (previousId == INVALID_IDX) {
+			isActive = false;
+			break;
+		}
+
+		rangeSize = right - left + 1u;
+
+		if (rangeSize > MERGING_THRESHOLD || rangeSize == uniforms.primCount) {
+			break;
+		}
+	}
+
+	// Update shared state
+	sharedLeft[localIdx] = left;
+	sharedRight[localIdx] = right;
+	sharedSplit[localIdx] = split;
+	sharedActive[localIdx] = select(0u, 1u, isActive);
+
+	// Check if this thread needs merging
+	let isFinal = isActive && (rangeSize == uniforms.primCount);
+	let needsMerge = isActive && ((rangeSize > MERGING_THRESHOLD) || isFinal);
+	sharedNeedsMerge[localIdx] = select(0u, 1u, needsMerge);
+
+	workgroupBarrier();
+
+	// Build compacted merge list
+	if (localIdx == 0u) {
+		var mergeCount = 0u;
+		for (var i = 0u; i < WORKGROUP_SIZE; i = i + 1u) {
+			if (sharedNeedsMerge[i] != 0u) {
+				sharedMergeList[mergeCount] = i;
+				mergeCount = mergeCount + 1u;
+			}
+		}
+		uNewNumPrim = mergeCount;
+	}
+	let numMerges = workgroupUniformLoad(&uNewNumPrim);
+
+	// Process only threads that need merging (compacted list)
+	for (var m = 0u; m < numMerges; m = m + 1u) {
+		if (localIdx == 0u) {
+			uNeedsMergeT = sharedMergeList[m];
+		}
+		let t = workgroupUniformLoad(&uNeedsMergeT);
+
+		if (localIdx == 0u) {
+			uMergeLeft = sharedLeft[t];
+			uMergeRight = sharedRight[t];
+			uMergeSplit = sharedSplit[t];
+			let tRangeSize = sharedRight[t] - sharedLeft[t] + 1u;
+			uIsFinal = select(0u, 1u, tRangeSize == uniforms.primCount);
+		}
+		let mergeLeft = workgroupUniformLoad(&uMergeLeft);
+		let mergeRight = workgroupUniformLoad(&uMergeRight);
+		let mergeSplit = workgroupUniformLoad(&uMergeSplit);
+		let mergeFinal = workgroupUniformLoad(&uIsFinal) != 0u;
+
+		let totalLeft = mergeSplit - mergeLeft;
+		let totalRight = mergeRight - mergeSplit + 1u;
+		let halfWorkgroup = WORKGROUP_SIZE / 2u;
+		let leftCount = min(totalLeft, halfWorkgroup);
+		let rightCount = min(totalRight, halfWorkgroup);
+		let originalLoadedCount = leftCount + rightCount;
+		var numPrim = originalLoadedCount;
+
+		var loadedIdx = INVALID_IDX;
+		if (localIdx < numPrim) {
+			var loadIdx: u32;
+			if (localIdx < leftCount) {
+				loadIdx = mergeLeft + localIdx;
+			} else {
+				loadIdx = mergeSplit + (localIdx - leftCount);
+			}
+			loadedIdx = clusterIdx[loadIdx];
+		}
+		sharedClusterIdx[localIdx] = loadedIdx;
+		workgroupBarrier();
+
+		if (localIdx == 0u) {
+			var validCount = 0u;
+			for (var i = 0u; i < numPrim; i = i + 1u) {
+				let idx = sharedClusterIdx[i];
+				if (idx != INVALID_IDX) {
+					sharedNearestNeighbor[validCount] = idx;
+					validCount = validCount + 1u;
+				}
+			}
+			uNewNumPrim = validCount;
+		}
+		numPrim = workgroupUniformLoad(&uNewNumPrim);
+
+		if (localIdx < numPrim) {
+			let cIdx = sharedNearestNeighbor[localIdx];
+			sharedClusterIdx[localIdx] = cIdx;
+
+			let node = bvh2Nodes[cIdx];
+			sharedBoundsMin[localIdx] = node.boundsMin;
+			sharedBoundsMax[localIdx] = node.boundsMax;
+		} else if (localIdx < originalLoadedCount) {
+			sharedClusterIdx[localIdx] = INVALID_IDX;
+		}
+		workgroupBarrier();
+
+		let threshold = select(MERGING_THRESHOLD, 1u, mergeFinal);
+
+		// PLOC merging iterations
+		for (var mergeIter = 0u; mergeIter < 32u; mergeIter = mergeIter + 1u) {
+			if (numPrim <= threshold) {
+				break;
+			}
+
+			var nearestIdx = INVALID_IDX;
+			var nearestCost = 1e30f;
+
+			if (localIdx < numPrim) {
+				let myMin = sharedBoundsMin[localIdx];
+				let myMax = sharedBoundsMax[localIdx];
+
+				let searchStart = select(0u, localIdx - SEARCH_RADIUS, localIdx >= SEARCH_RADIUS);
+				let searchEnd = min(localIdx + SEARCH_RADIUS + 1u, numPrim);
+
+				for (var j = searchStart; j < searchEnd; j = j + 1u) {
+					if (j != localIdx) {
+						let otherMin = sharedBoundsMin[j];
+						let otherMax = sharedBoundsMax[j];
+						let mergedMin = min(myMin, otherMin);
+						let mergedMax = max(myMax, otherMax);
+						let cost = aabbArea(mergedMin, mergedMax);
+
+						if (cost < nearestCost) {
+							nearestCost = cost;
+							nearestIdx = j;
+						}
+					}
+				}
+				sharedNearestNeighbor[localIdx] = nearestIdx;
+			}
+			workgroupBarrier();
+
+			var shouldMerge = false;
+			if (localIdx < numPrim) {
+				let myNearest = sharedNearestNeighbor[localIdx];
+				if (myNearest != INVALID_IDX && myNearest < numPrim) {
+					let theirNearest = sharedNearestNeighbor[myNearest];
+					if (theirNearest == localIdx && localIdx < myNearest) {
+						shouldMerge = true;
+					}
+				}
+			}
+			workgroupBarrier();
+
+			let maxNodes = 2u * uniforms.primCount;
+			if (shouldMerge) {
+				let myNearest = sharedNearestNeighbor[localIdx];
+				let leftCluster = sharedClusterIdx[localIdx];
+				let rightCluster = sharedClusterIdx[myNearest];
+
+				let mergedMin = min(sharedBoundsMin[localIdx], sharedBoundsMin[myNearest]);
+				let mergedMax = max(sharedBoundsMax[localIdx], sharedBoundsMax[myNearest]);
+
+				let newNodeIdx = atomicAdd(&nodeCounter, 1u);
+				if (newNodeIdx < maxNodes) {
+					bvh2Nodes[newNodeIdx].boundsMin = mergedMin;
+					bvh2Nodes[newNodeIdx].boundsMax = mergedMax;
+					bvh2Nodes[newNodeIdx].leftChild = leftCluster;
+					bvh2Nodes[newNodeIdx].rightChild = rightCluster;
+
+					sharedClusterIdx[localIdx] = newNodeIdx;
+					sharedBoundsMin[localIdx] = mergedMin;
+					sharedBoundsMax[localIdx] = mergedMax;
+				}
+			}
+			workgroupBarrier();
+
+			var survives = false;
+			if (localIdx < numPrim) {
+				survives = true;
+				let myNearest = sharedNearestNeighbor[localIdx];
+				if (myNearest != INVALID_IDX && myNearest < numPrim) {
+					let theirNearest = sharedNearestNeighbor[myNearest];
+					if (theirNearest == localIdx && myNearest < localIdx) {
+						survives = false;
+					}
+				}
+			}
+
+			sharedPrefixSum[localIdx] = select(0u, 1u, survives);
+			workgroupBarrier();
+
+			for (var stride = 1u; stride < WORKGROUP_SIZE; stride = stride * 2u) {
+				var addVal = 0u;
+				if (localIdx >= stride) {
+					addVal = sharedPrefixSum[localIdx - stride];
+				}
+				workgroupBarrier();
+				sharedPrefixSum[localIdx] = sharedPrefixSum[localIdx] + addVal;
+				workgroupBarrier();
+			}
+
+			if (localIdx == 0u) {
+				uNewNumPrim = select(0u, sharedPrefixSum[numPrim - 1u], numPrim > 0u);
+			}
+			let newNumPrim = workgroupUniformLoad(&uNewNumPrim);
+
+			if (survives && localIdx < numPrim) {
+				let writePos = sharedPrefixSum[localIdx] - 1u;
+				sharedTempIdx[writePos] = sharedClusterIdx[localIdx];
+				sharedTempMin[writePos] = sharedBoundsMin[localIdx];
+				sharedTempMax[writePos] = sharedBoundsMax[localIdx];
+			}
+			workgroupBarrier();
+
+			if (localIdx < newNumPrim) {
+				sharedClusterIdx[localIdx] = sharedTempIdx[localIdx];
+				sharedBoundsMin[localIdx] = sharedTempMin[localIdx];
+				sharedBoundsMax[localIdx] = sharedTempMax[localIdx];
+			} else if (localIdx < numPrim) {
+				sharedClusterIdx[localIdx] = INVALID_IDX;
+			}
+			numPrim = newNumPrim;
+			workgroupBarrier();
+		}
+
+		if (localIdx < originalLoadedCount) {
+			clusterIdx[mergeLeft + localIdx] = sharedClusterIdx[localIdx];
+		}
+		workgroupBarrier();
+
+		sharedNeedsMerge[t] = 0u;
+
+		if (mergeFinal && numPrim <= 1u) {
+			sharedActive[t] = 0u;
+			if (localIdx == t) {
+				isActive = false;
+			}
+		}
+		workgroupBarrier();
+	}
+
+	// Save state
+	if (!isOOB) {
+		state[primIdx] = vec4u(left, right, split, select(0u, 1u, isActive));
+	}
+
+	// Workgroup-aggregated output compaction: one global atomicAdd per workgroup.
+	let live = isActive && !isOOB;
+	sharedPrefixSum[localIdx] = select(0u, 1u, live);
+	workgroupBarrier();
+
+	for (var stride = 1u; stride < WORKGROUP_SIZE; stride = stride * 2u) {
+		var addVal = 0u;
+		if (localIdx >= stride) {
+			addVal = sharedPrefixSum[localIdx - stride];
+		}
+		workgroupBarrier();
+		sharedPrefixSum[localIdx] = sharedPrefixSum[localIdx] + addVal;
+		workgroupBarrier();
+	}
+
+	if (localIdx == 0u) {
+		uLiveCount = sharedPrefixSum[WORKGROUP_SIZE - 1u];
+		var base = 0u;
+		if (uLiveCount > 0u) {
+			base = atomicAdd(&activeCountOut, uLiveCount);
+		}
+		uActiveListBase = base;
+	}
+
+	let liveCount = workgroupUniformLoad(&uLiveCount);
+	let activeBase = workgroupUniformLoad(&uActiveListBase);
+	if (live && liveCount > 0u) {
+		let outIdx = activeBase + (sharedPrefixSum[localIdx] - 1u);
+		activeListOut[outIdx] = primIdx;
+	}
+}
+`;
+
+/**
+ * Tiny shader to update the indirect dispatch arguments.
+ * Reads activeCount and writes ceil(count / WORKGROUP_SIZE) to indirectDispatch buffer.
+ */
+/**
+ * Update dispatch shader variants - compute workgroup count and clear output counter.
+ * The atomicStore replaces commandEncoder.clearBuffer(), enabling single-pass indirect dispatch.
+ */
+export const hplocUpdateDispatchShaderWave32 = /* wgsl */ `
+@group(0) @binding(0) var<storage, read_write> activeCountIn: atomic<u32>;
+@group(0) @binding(1) var<storage, read_write> indirectDispatch: array<u32>;
+@group(0) @binding(2) var<storage, read_write> activeCountOut: atomic<u32>;
+
+const WORKGROUP_SIZE: u32 = 32u;
+
+@compute @workgroup_size(1)
+fn updateIndirectDispatch() {
+	let count = atomicLoad(&activeCountIn);
+	let workgroups = (count + WORKGROUP_SIZE - 1u) / WORKGROUP_SIZE;
+	// Allow 0 workgroups - makes remaining iterations after convergence essentially free
+	// WebGPU spec allows dispatchWorkgroupsIndirect with 0 workgroups (no-op)
+	indirectDispatch[0] = workgroups;
+	indirectDispatch[1] = 1u;
+	indirectDispatch[2] = 1u;
+
+	// Clear OUTPUT counter for next iteration - replaces commandEncoder.clearBuffer()
+	atomicStore(&activeCountOut, 0u);
+}
+`;
+
+export const hplocUpdateDispatchShaderWave64 = /* wgsl */ `
+@group(0) @binding(0) var<storage, read_write> activeCountIn: atomic<u32>;
+@group(0) @binding(1) var<storage, read_write> indirectDispatch: array<u32>;
+@group(0) @binding(2) var<storage, read_write> activeCountOut: atomic<u32>;
+
+const WORKGROUP_SIZE: u32 = 64u;
+
+@compute @workgroup_size(1)
+fn updateIndirectDispatch() {
+	let count = atomicLoad(&activeCountIn);
+	let workgroups = (count + WORKGROUP_SIZE - 1u) / WORKGROUP_SIZE;
+	// Allow 0 workgroups - makes remaining iterations after convergence essentially free
+	// WebGPU spec allows dispatchWorkgroupsIndirect with 0 workgroups (no-op)
+	indirectDispatch[0] = workgroups;
+	indirectDispatch[1] = 1u;
+	indirectDispatch[2] = 1u;
+
+	// Clear OUTPUT counter for next iteration - replaces commandEncoder.clearBuffer()
+	atomicStore(&activeCountOut, 0u);
+}
+`;
+
+// Legacy shader for backwards compatibility (old 2-binding layout without output clear)
+export const hplocUpdateDispatchShader = /* wgsl */ `
+@group(0) @binding(0) var<storage, read_write> activeCount: atomic<u32>;
+@group(0) @binding(1) var<storage, read_write> indirectDispatch: array<u32>;
+
+const WORKGROUP_SIZE: u32 = 64u;
+
+@compute @workgroup_size(1)
+fn updateIndirectDispatch() {
+	let count = atomicLoad(&activeCount);
+	let workgroups = (count + WORKGROUP_SIZE - 1u) / WORKGROUP_SIZE;
+	// Allow 0 workgroups - makes remaining iterations after convergence essentially free
+	indirectDispatch[0] = workgroups;
+	indirectDispatch[1] = 1u;
+	indirectDispatch[2] = 1u;
+}
+`;
+
+/**
+ * Initialize the active list with all primitive indices (0, 1, 2, ..., primCount-1)
+ */
+export const hplocInitActiveListShader = /* wgsl */ `
+struct Uniforms {
+	primCount: u32,
+	pad0: u32,
+	pad1: u32,
+	pad2: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read_write> activeList: array<u32>;
+
+@compute @workgroup_size(256)
+fn initActiveList(@builtin(global_invocation_id) globalId: vec3u) {
+	let idx = globalId.x;
+	if (idx < uniforms.primCount) {
+		activeList[idx] = idx;
+	}
+}
+`;
+
+/**
+ * Initialize all indirect dispatch counters in a single GPU pass.
+ * This ensures counters are set at the correct point in command execution,
+ * eliminating race conditions with writeBuffer initialization.
+ */
+export const hplocInitIndirectCountersShader = /* wgsl */ `
+struct Uniforms {
+	primCount: u32,
+	initialWorkgroups: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read_write> nodeCounter: atomic<u32>;
+@group(0) @binding(2) var<storage, read_write> activeCount0: atomic<u32>;
+@group(0) @binding(3) var<storage, read_write> activeCount1: atomic<u32>;
+@group(0) @binding(4) var<storage, read_write> indirectDispatch: array<u32>;
+
+@compute @workgroup_size(1)
+fn initIndirectCounters() {
+	// Initialize nodeCounter to primCount (leaves are pre-allocated)
+	atomicStore(&nodeCounter, uniforms.primCount);
+
+	// Initialize active counts for ping-pong buffers
+	atomicStore(&activeCount0, uniforms.primCount);
+	atomicStore(&activeCount1, 0u);
+
+	// Initialize indirect dispatch arguments
+	// initialWorkgroups is always >= 1 when primCount > 0 (guaranteed by caller)
+	indirectDispatch[0] = uniforms.initialWorkgroups;
+	indirectDispatch[1] = 1u;
+	indirectDispatch[2] = 1u;
+}
+`;
+
+/**
+ * Subgroup-optimized H-PLOC shader - Wave = Subgroup architecture
+ *
+ * Key optimizations:
+ * 1. WG=128 with independent subgroups
+ * 2. Ballot+ctz lane selection per subgroup (O(active) selection)
+ * 3. Dynamic MERGING_THRESHOLD = subgroupSize/2 per paper
+ * 4. Wave-aggregated node allocation
+ * 5. Subgroup prefix sums for compaction
+ *
+ * IMPORTANT FIXES vs the previous (buggy) attempt:
+ * - FIX: Do NOT reuse sharedClusterIdx/sharedNearestNeighbor/sharedTempIdx to store per-thread (left/right/split).
+ *        Doing so corrupts later merges in the same dispatch.
+ * - FIX: Only the selected lane in the owning subgroup gets its local state updated (deactivation).
+ * - FIX: Barrier-safe control flow: no per-subgroup early breaks around workgroupBarrier().
+ *
+ * Note: WGSL currently only has workgroupBarrier(), so subgroup merges are executed in lockstep across the workgroup.
+ */
+/**
+ * H-PLOC Wave32 shader - 1-subgroup-per-workgroup design
+ *
+ * Optimized for GPUs with subgroup size 32 (Apple M-series, NVIDIA).
+ * Key optimizations:
+ * 1. @workgroup_size(32) = subgroup size, so entire workgroup is one subgroup
+ * 2. workgroupBarrier() is essentially free (no other subgroups to wait)
+ * 3. Shared memory sized to exactly 32 elements
+ * 4. MERGING_THRESHOLD = 16 (32/2) per paper's constraint
+ * 5. No subgroupId partitioning needed
+ * 6. Subgroup prefix sums for O(1) compaction
+ */
+export const hplocShaderWave32 = /* wgsl */ `
+
+enable subgroups;
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupAdd(x: u32) -> u32 { return subgroupAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupExclusiveAdd(x: u32) -> u32 { return subgroupExclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupBallot(pred: bool) -> vec4<u32> { return subgroupBallot(pred); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffle(x: u32, lane: u32) -> u32 { return subgroupShuffle(x, lane); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffleF(x: f32, lane: u32) -> f32 { return subgroupShuffle(x, lane); }
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> mortonCodes: array<u32>;
+@group(0) @binding(2) var<storage, read_write> clusterIdx: array<u32>;
+@group(0) @binding(3) var<storage, read_write> parentIdx: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(5) var<storage, read_write> nodeCounter: atomic<u32>;
+@group(0) @binding(6) var<storage, read_write> state: array<vec4u>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = 32u;
+const SEARCH_RADIUS: u32 = 8u;
+// MERGING_THRESHOLD = WORKGROUP_SIZE/2 because two combining ranges could each
+// have up to MERGING_THRESHOLD clusters, and we can only load WORKGROUP_SIZE total
+const MERGING_THRESHOLD: u32 = 16u;
+const MAX_MERGE_ITERS: u32 = 32u;
+const MAX_ROUNDS: u32 = 32u;
+
+// Shared memory - sized to exactly WORKGROUP_SIZE (32)
+var<workgroup> sharedClusterIdx: array<u32, 32>;
+var<workgroup> sharedBoundsMin: array<vec3f, 32>;
+var<workgroup> sharedBoundsMax: array<vec3f, 32>;
+var<workgroup> sharedNearestNeighbor: array<u32, 32>;
+var<workgroup> sharedTempIdx: array<u32, 32>;
+var<workgroup> sharedTempMin: array<vec3f, 32>;
+var<workgroup> sharedTempMax: array<vec3f, 32>;
+
+// Broadcast variables (read via workgroupUniformLoad for uniform control flow)
+var<workgroup> uHasMerge: u32;
+var<workgroup> uSelLane: u32;
+var<workgroup> uMergeLeft: u32;
+var<workgroup> uMergeRight: u32;
+var<workgroup> uMergeSplit: u32;
+var<workgroup> uMergeFinal: u32;
+var<workgroup> uNumPrim: u32;
+var<workgroup> uValidCount: u32;
+
+// Returns common prefix length (higher = more similar, lower = more divergent)
+// Uses countLeadingZeros for canonical LBVH parent selection
+fn delta(a: u32, b: u32) -> u32 {
+	let mcA = mortonCodes[a];
+	let mcB = mortonCodes[b];
+	let xorVal = mcA ^ mcB;
+	// Equal morton codes: add 32 to ensure this is always > any CLZ(xorVal)
+	return select(countLeadingZeros(xorVal), 32u + countLeadingZeros(a ^ b), xorVal == 0u);
+}
+
+fn findParentId(left: u32, right: u32, primCount: u32) -> u32 {
+	if (left == 0u) { return right; }
+	if (right == primCount - 1u) { return left - 1u; }
+	let deltaRight = delta(right, right + 1u);
+	let deltaLeft = delta(left - 1u, left);
+	// With CLZ-based delta: higher = longer prefix = less divergent
+	// Return right when right boundary is LESS divergent (higher CLZ)
+	return select(left - 1u, right, deltaRight > deltaLeft);
+}
+
+fn aabbArea(boundsMin: vec3f, boundsMax: vec3f) -> f32 {
+	let extent = boundsMax - boundsMin;
+	return 2.0 * (extent.x * extent.y + extent.y * extent.z + extent.z * extent.x);
+}
+
+// Count trailing zeros in ballot.x (32 bits)
+fn ballotCtz(ballot: vec4<u32>) -> u32 {
+	return countTrailingZeros(ballot.x);
+}
+
+fn ballotAny(ballot: vec4<u32>) -> bool {
+	return ballot.x != 0u;
+}
+
+fn ballotCount(ballot: vec4<u32>) -> u32 {
+	return countOneBits(ballot.x);
+}
+
+@compute @workgroup_size(32)
+fn hplocBuild(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(subgroup_invocation_id) laneId: u32,
+	@builtin(subgroup_size) subgroupSize: u32
+) {
+	let localIdx = localId.x;
+	let primIdx = globalId.x;
+
+	// Runtime check: this shader requires subgroup size 32
+	if (subgroupSize != 32u) {
+		// Save state unchanged and exit
+		if (primIdx < uniforms.primCount) {
+			// Don't touch state - let fallback shader handle it
+		}
+		return;
+	}
+
+	let isOOB = primIdx >= uniforms.primCount;
+
+	// Load persistent state
+	var stateVec = vec4u(0u);
+	if (!isOOB) {
+		stateVec = state[primIdx];
+	}
+	var left = stateVec.x;
+	var right = stateVec.y;
+	var split = stateVec.z;
+	var isActive = stateVec.w != 0u && !isOOB;
+
+	// ===== MULTI-STEP LBVH OPTIMIZATION =====
+	var rangeSize = right - left + 1u;
+
+	while (isActive) {
+		let parentId = findParentId(left, right, uniforms.primCount);
+		var previousId = INVALID_IDX;
+
+		if (parentId == right) {
+			previousId = atomicExchange(&parentIdx[right], left);
+			if (previousId != INVALID_IDX) {
+				split = right + 1u;
+				right = previousId;
+			}
+		} else {
+			previousId = atomicExchange(&parentIdx[left - 1u], right);
+			if (previousId != INVALID_IDX) {
+				split = left;
+				left = previousId;
+			}
+		}
+
+		if (previousId == INVALID_IDX) {
+			isActive = false;
+			break;
+		}
+
+		rangeSize = right - left + 1u;
+
+		if (rangeSize > MERGING_THRESHOLD || rangeSize == uniforms.primCount) {
+			break;
+		}
+	}
+
+	// Determine if this thread needs a PLOC merge
+	let isFinal = isActive && (rangeSize == uniforms.primCount);
+	var needsMerge = isActive && ((rangeSize > MERGING_THRESHOLD) || isFinal);
+
+	// ===== BALLOT+CTZ MERGE SELECTION =====
+	// In 1-subgroup-per-workgroup, no cross-subgroup coordination needed
+	// Use workgroupUniformLoad to satisfy WGSL uniform control flow requirements
+	for (var round = 0u; round < MAX_ROUNDS; round = round + 1u) {
+		let ballot = unsafeSubgroupBallot(needsMerge);
+
+		// Broadcast hasMerge via workgroup variable for uniform control flow
+		if (laneId == 0u) {
+			uHasMerge = select(0u, 1u, ballotAny(ballot));
+		}
+		let hasMerge = workgroupUniformLoad(&uHasMerge) != 0u;
+
+		if (!hasMerge) {
+			break; // Uniform across entire workgroup
+		}
+
+		// Select first lane needing merge and broadcast via workgroup variables
+		if (laneId == 0u) {
+			let selLane = ballotCtz(ballot);
+			uSelLane = selLane;
+		}
+		let selLane = workgroupUniformLoad(&uSelLane);
+
+		// Broadcast merge parameters
+		if (laneId == selLane) {
+			uMergeLeft = left;
+			uMergeRight = right;
+			uMergeSplit = split;
+			uMergeFinal = select(0u, 1u, (right - left + 1u) == uniforms.primCount);
+		}
+		let mergeLeft = workgroupUniformLoad(&uMergeLeft);
+		let mergeRight = workgroupUniformLoad(&uMergeRight);
+		let mergeSplit = workgroupUniformLoad(&uMergeSplit);
+		let mergeFinal = workgroupUniformLoad(&uMergeFinal) != 0u;
+
+		// Compute how many clusters to load from each side
+		let totalLeft = mergeSplit - mergeLeft;
+		let totalRight = mergeRight - mergeSplit + 1u;
+		let halfWave = MERGING_THRESHOLD; // 16
+		let leftCount = min(totalLeft, halfWave);
+		let rightCount = min(totalRight, halfWave);
+		let originalLoadedCount = leftCount + rightCount;
+		var numPrim = originalLoadedCount;
+
+		let threshold = select(MERGING_THRESHOLD, 1u, mergeFinal);
+
+		// ===== Load cluster indices =====
+		var loadedIdx = INVALID_IDX;
+		if (laneId < numPrim) {
+			var loadIdx: u32;
+			if (laneId < leftCount) {
+				loadIdx = mergeLeft + laneId;
+			} else {
+				loadIdx = mergeSplit + (laneId - leftCount);
+			}
+			loadedIdx = clusterIdx[loadIdx];
+		}
+		sharedClusterIdx[laneId] = loadedIdx;
+		workgroupBarrier();
+
+		// ===== Compact valid clusters (skip INVALID) =====
+		let isValid = laneId < numPrim && loadedIdx != INVALID_IDX;
+		let validBallot = unsafeSubgroupBallot(isValid);
+
+		// Broadcast valid count for uniform control flow
+		if (laneId == 0u) {
+			uValidCount = ballotCount(validBallot);
+		}
+		let validCount = workgroupUniformLoad(&uValidCount);
+		let validPrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, isValid));
+
+		if (isValid) {
+			sharedTempIdx[validPrefix] = loadedIdx;
+		}
+		workgroupBarrier();
+
+		numPrim = validCount;
+
+		// Load bounds for compacted cluster list
+		var myClusterIdx = INVALID_IDX;
+		var myBoundsMin = vec3f(0.0);
+		var myBoundsMax = vec3f(0.0);
+
+		if (laneId < numPrim) {
+			myClusterIdx = sharedTempIdx[laneId];
+			let node = bvh2Nodes[myClusterIdx];
+			myBoundsMin = node.boundsMin;
+			myBoundsMax = node.boundsMax;
+		}
+
+		sharedClusterIdx[laneId] = myClusterIdx;
+		sharedBoundsMin[laneId] = myBoundsMin;
+		sharedBoundsMax[laneId] = myBoundsMax;
+		workgroupBarrier();
+
+		// ===== PLOC merge loop =====
+		for (var mergeIter = 0u; mergeIter < MAX_MERGE_ITERS; mergeIter = mergeIter + 1u) {
+			// Broadcast numPrim for uniform control flow
+			if (laneId == 0u) {
+				uNumPrim = numPrim;
+			}
+			let uniformNumPrim = workgroupUniformLoad(&uNumPrim);
+			if (uniformNumPrim <= threshold) {
+				break; // Uniform - entire workgroup breaks together
+			}
+
+			// Find nearest neighbor (right-only + propagate to left)
+			var nearestIdx = INVALID_IDX;
+			var nearestCost = 1e30f;
+
+			let laneActive = laneId < uniformNumPrim;
+			var myMin = vec3f(0.0);
+			var myMax = vec3f(0.0);
+			if (laneActive) {
+				myMin = sharedBoundsMin[laneId];
+				myMax = sharedBoundsMax[laneId];
+			}
+
+			for (var r = 1u; r <= SEARCH_RADIUS; r = r + 1u) {
+				var costRight = 1e30f;
+				if (laneActive) {
+					let j = laneId + r;
+					if (j < uniformNumPrim) {
+						let otherMin = sharedBoundsMin[j];
+						let otherMax = sharedBoundsMax[j];
+						let mergedMin = min(myMin, otherMin);
+						let mergedMax = max(myMax, otherMax);
+						costRight = aabbArea(mergedMin, mergedMax);
+
+						if (costRight < nearestCost) {
+							nearestCost = costRight;
+							nearestIdx = j;
+						}
+					}
+				}
+
+				var leftLane = 0u;
+				if (laneId >= r) {
+					leftLane = laneId - r;
+				}
+				let incomingCost = unsafeSubgroupShuffleF(costRight, leftLane);
+
+				if (laneActive && laneId >= r && incomingCost < nearestCost) {
+					nearestCost = incomingCost;
+					nearestIdx = leftLane;
+				}
+			}
+			sharedNearestNeighbor[laneId] = nearestIdx;
+			workgroupBarrier();
+
+			// Determine mutual nearest neighbor pairs (lower index merges)
+			var shouldMerge = false;
+			if (laneId < numPrim && nearestIdx != INVALID_IDX && nearestIdx < numPrim) {
+				let theirNearest = sharedNearestNeighbor[nearestIdx];
+				if (theirNearest == laneId && laneId < nearestIdx) {
+					shouldMerge = true;
+				}
+			}
+
+			// Wave-aggregated node allocation
+			let mergeCount = unsafeSubgroupAdd(select(0u, 1u, shouldMerge));
+			let mergePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, shouldMerge));
+
+			var allocBase = 0u;
+			if (laneId == 0u && mergeCount > 0u) {
+				allocBase = atomicAdd(&nodeCounter, mergeCount);
+			}
+			allocBase = unsafeSubgroupShuffle(allocBase, 0u);
+
+			// Perform merges
+			let maxNodes = 2u * uniforms.primCount;
+			if (shouldMerge) {
+				let leftCluster = sharedClusterIdx[laneId];
+				let rightCluster = sharedClusterIdx[nearestIdx];
+
+				let mergedMin = min(sharedBoundsMin[laneId], sharedBoundsMin[nearestIdx]);
+				let mergedMax = max(sharedBoundsMax[laneId], sharedBoundsMax[nearestIdx]);
+
+				let newNodeIdx = allocBase + mergePrefix;
+				if (newNodeIdx < maxNodes) {
+					bvh2Nodes[newNodeIdx].boundsMin = mergedMin;
+					bvh2Nodes[newNodeIdx].boundsMax = mergedMax;
+					bvh2Nodes[newNodeIdx].leftChild = leftCluster;
+					bvh2Nodes[newNodeIdx].rightChild = rightCluster;
+
+					sharedClusterIdx[laneId] = newNodeIdx;
+					sharedBoundsMin[laneId] = mergedMin;
+					sharedBoundsMax[laneId] = mergedMax;
+				}
+			}
+			workgroupBarrier();
+
+			// Compaction: determine who survives
+			var survives = false;
+			if (laneId < uniformNumPrim) {
+				survives = true;
+				let myNearest = sharedNearestNeighbor[laneId];
+				if (myNearest != INVALID_IDX && myNearest < uniformNumPrim) {
+					let theirNearest = sharedNearestNeighbor[myNearest];
+					if (theirNearest == laneId && myNearest < laneId) {
+						survives = false;
+					}
+				}
+			}
+
+			let localSurviveCount = unsafeSubgroupAdd(select(0u, 1u, survives));
+			let survivePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, survives));
+
+			if (survives) {
+				sharedTempIdx[survivePrefix] = sharedClusterIdx[laneId];
+				sharedTempMin[survivePrefix] = sharedBoundsMin[laneId];
+				sharedTempMax[survivePrefix] = sharedBoundsMax[laneId];
+			}
+
+			// Broadcast survive count for uniform control flow
+			if (laneId == 0u) {
+				uNumPrim = localSurviveCount;
+			}
+			let surviveCount = workgroupUniformLoad(&uNumPrim);
+
+			if (laneId < surviveCount) {
+				sharedClusterIdx[laneId] = sharedTempIdx[laneId];
+				sharedBoundsMin[laneId] = sharedTempMin[laneId];
+				sharedBoundsMax[laneId] = sharedTempMax[laneId];
+			}
+			workgroupBarrier();
+
+			numPrim = surviveCount;
+		}
+
+		// Broadcast final numPrim for uniform control flow
+		if (laneId == 0u) {
+			uNumPrim = numPrim;
+		}
+		let finalNumPrim = workgroupUniformLoad(&uNumPrim);
+
+		// ===== Write results back to global clusterIdx =====
+		if (laneId < originalLoadedCount) {
+			let outIdx = select(INVALID_IDX, sharedClusterIdx[laneId], laneId < finalNumPrim);
+			clusterIdx[mergeLeft + laneId] = outIdx;
+		}
+
+		// Only the selected lane clears its needsMerge and updates isActive
+		if (laneId == selLane) {
+			needsMerge = false;
+			if (mergeFinal && finalNumPrim <= 1u) {
+				isActive = false;
+			}
+		}
+
+		workgroupBarrier();
+	}
+
+	// Save state
+	if (!isOOB) {
+		state[primIdx] = vec4u(left, right, split, select(0u, 1u, isActive));
+	}
+}
+`;
+
+/**
+ * H-PLOC Wave32 Indirect shader - single-pass indirect dispatch version
+ *
+ * Same as wave32 but with active list input/output for reduced workgroup launches.
+ * Key additions:
+ * - Reads primIdx from activeListIn instead of globalId.x
+ * - Writes still-active primitives to activeListOut
+ * - Enables single compute pass with atomicStore output clear in updateDispatch
+ */
+export const hplocShaderWave32Indirect = /* wgsl */ `
+
+enable subgroups;
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupAdd(x: u32) -> u32 { return subgroupAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupExclusiveAdd(x: u32) -> u32 { return subgroupExclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupBallot(pred: bool) -> vec4<u32> { return subgroupBallot(pred); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffle(x: u32, lane: u32) -> u32 { return subgroupShuffle(x, lane); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffleF(x: f32, lane: u32) -> f32 { return subgroupShuffle(x, lane); }
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> mortonCodes: array<u32>;
+@group(0) @binding(2) var<storage, read_write> clusterIdx: array<u32>;
+@group(0) @binding(3) var<storage, read_write> parentIdx: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(5) var<storage, read_write> nodeCounter: atomic<u32>;
+@group(0) @binding(6) var<storage, read_write> state: array<vec4u>;
+// Indirect dispatch active list bindings
+@group(0) @binding(7) var<storage, read> activeListIn: array<u32>;
+@group(0) @binding(8) var<storage, read_write> activeListOut: array<u32>;
+@group(0) @binding(9) var<storage, read_write> activeCountOut: atomic<u32>;
+@group(0) @binding(10) var<storage, read_write> activeCountIn: atomic<u32>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = 32u;
+const SEARCH_RADIUS: u32 = 8u;
+const MERGING_THRESHOLD: u32 = 16u;
+const MAX_MERGE_ITERS: u32 = 32u;
+const MAX_ROUNDS: u32 = 32u;
+
+var<workgroup> sharedClusterIdx: array<u32, 32>;
+var<workgroup> sharedBoundsMin: array<vec3f, 32>;
+var<workgroup> sharedBoundsMax: array<vec3f, 32>;
+var<workgroup> sharedNearestNeighbor: array<u32, 32>;
+var<workgroup> sharedTempIdx: array<u32, 32>;
+var<workgroup> sharedTempMin: array<vec3f, 32>;
+var<workgroup> sharedTempMax: array<vec3f, 32>;
+
+var<workgroup> uHasMerge: u32;
+var<workgroup> uSelLane: u32;
+var<workgroup> uMergeLeft: u32;
+var<workgroup> uMergeRight: u32;
+var<workgroup> uMergeSplit: u32;
+var<workgroup> uMergeFinal: u32;
+var<workgroup> uNumPrim: u32;
+var<workgroup> uValidCount: u32;
+var<workgroup> uActiveCount: u32;
+
+// Returns common prefix length (higher = more similar, lower = more divergent)
+fn delta(a: u32, b: u32) -> u32 {
+	let mcA = mortonCodes[a];
+	let mcB = mortonCodes[b];
+	let xorVal = mcA ^ mcB;
+	return select(countLeadingZeros(xorVal), 32u + countLeadingZeros(a ^ b), xorVal == 0u);
+}
+
+fn findParentId(left: u32, right: u32, primCount: u32) -> u32 {
+	if (left == 0u) { return right; }
+	if (right == primCount - 1u) { return left - 1u; }
+	let deltaRight = delta(right, right + 1u);
+	let deltaLeft = delta(left - 1u, left);
+	return select(left - 1u, right, deltaRight > deltaLeft);
+}
+
+fn aabbArea(boundsMin: vec3f, boundsMax: vec3f) -> f32 {
+	let extent = boundsMax - boundsMin;
+	return 2.0 * (extent.x * extent.y + extent.y * extent.z + extent.z * extent.x);
+}
+
+fn ballotCtz(ballot: vec4<u32>) -> u32 { return countTrailingZeros(ballot.x); }
+fn ballotAny(ballot: vec4<u32>) -> bool { return ballot.x != 0u; }
+fn ballotCount(ballot: vec4<u32>) -> u32 { return countOneBits(ballot.x); }
+
+@compute @workgroup_size(32)
+fn hplocBuildIndirect(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(subgroup_invocation_id) laneId: u32,
+	@builtin(subgroup_size) subgroupSize: u32
+) {
+	let localIdx = localId.x;
+	let threadIdx = globalId.x;
+
+	// Note: Runtime subgroup check removed - shader is only used when subgroup size is confirmed to be 32
+	// during pipeline selection. The check was causing intermittent failures.
+
+	// Read active count once per workgroup and broadcast (uniform value)
+	if (laneId == 0u) {
+		uActiveCount = atomicLoad(&activeCountIn);
+	}
+	let activeCount = workgroupUniformLoad(&uActiveCount);
+	var isOOB = threadIdx >= activeCount;
+
+	// Read primitive index from active list (key difference from direct dispatch)
+	var primIdx = 0u;
+	if (!isOOB) {
+		primIdx = activeListIn[threadIdx];
+		isOOB = primIdx >= uniforms.primCount;
+	}
+
+	// Load persistent state
+	var stateVec = vec4u(0u);
+	if (!isOOB) { stateVec = state[primIdx]; }
+	var left = stateVec.x;
+	var right = stateVec.y;
+	var split = stateVec.z;
+	var isActive = stateVec.w != 0u && !isOOB;
+
+	// ===== MULTI-STEP LBVH OPTIMIZATION =====
+	var rangeSize = right - left + 1u;
+
+	while (isActive) {
+		let parentId = findParentId(left, right, uniforms.primCount);
+		var previousId = INVALID_IDX;
+
+		if (parentId == right) {
+			previousId = atomicExchange(&parentIdx[right], left);
+			if (previousId != INVALID_IDX) { split = right + 1u; right = previousId; }
+		} else {
+			previousId = atomicExchange(&parentIdx[left - 1u], right);
+			if (previousId != INVALID_IDX) { split = left; left = previousId; }
+		}
+
+		if (previousId == INVALID_IDX) { isActive = false; break; }
+		rangeSize = right - left + 1u;
+		if (rangeSize > MERGING_THRESHOLD || rangeSize == uniforms.primCount) { break; }
+	}
+
+	let isFinal = isActive && (rangeSize == uniforms.primCount);
+	var needsMerge = isActive && ((rangeSize > MERGING_THRESHOLD) || isFinal);
+
+	// ===== BALLOT+CTZ MERGE SELECTION =====
+	for (var round = 0u; round < MAX_ROUNDS; round = round + 1u) {
+		let ballot = unsafeSubgroupBallot(needsMerge);
+
+		if (laneId == 0u) { uHasMerge = select(0u, 1u, ballotAny(ballot)); }
+		let hasMerge = workgroupUniformLoad(&uHasMerge) != 0u;
+		if (!hasMerge) { break; }
+
+		if (laneId == 0u) { uSelLane = ballotCtz(ballot); }
+		let selLane = workgroupUniformLoad(&uSelLane);
+
+		if (laneId == selLane) {
+			uMergeLeft = left;
+			uMergeRight = right;
+			uMergeSplit = split;
+			uMergeFinal = select(0u, 1u, (right - left + 1u) == uniforms.primCount);
+		}
+		let mergeLeft = workgroupUniformLoad(&uMergeLeft);
+		let mergeRight = workgroupUniformLoad(&uMergeRight);
+		let mergeSplit = workgroupUniformLoad(&uMergeSplit);
+		let mergeFinal = workgroupUniformLoad(&uMergeFinal) != 0u;
+
+		let totalLeft = mergeSplit - mergeLeft;
+		let totalRight = mergeRight - mergeSplit + 1u;
+		let halfWave = MERGING_THRESHOLD;
+		let leftCount = min(totalLeft, halfWave);
+		let rightCount = min(totalRight, halfWave);
+		let originalLoadedCount = leftCount + rightCount;
+		var numPrim = originalLoadedCount;
+		let threshold = select(MERGING_THRESHOLD, 1u, mergeFinal);
+
+		// Load cluster indices
+		var loadedIdx = INVALID_IDX;
+		if (laneId < numPrim) {
+			var loadIdx: u32;
+			if (laneId < leftCount) { loadIdx = mergeLeft + laneId; }
+			else { loadIdx = mergeSplit + (laneId - leftCount); }
+			loadedIdx = clusterIdx[loadIdx];
+		}
+		sharedClusterIdx[laneId] = loadedIdx;
+		workgroupBarrier();
+
+		// Compact valid clusters
+		let isValid = laneId < numPrim && loadedIdx != INVALID_IDX;
+		let validBallot = unsafeSubgroupBallot(isValid);
+		if (laneId == 0u) { uValidCount = ballotCount(validBallot); }
+		let validCount = workgroupUniformLoad(&uValidCount);
+		let validPrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, isValid));
+
+		if (isValid) { sharedTempIdx[validPrefix] = loadedIdx; }
+		workgroupBarrier();
+		numPrim = validCount;
+
+		// Load bounds
+		var myClusterIdx = INVALID_IDX;
+		var myBoundsMin = vec3f(0.0);
+		var myBoundsMax = vec3f(0.0);
+		if (laneId < numPrim) {
+			myClusterIdx = sharedTempIdx[laneId];
+			let node = bvh2Nodes[myClusterIdx];
+			myBoundsMin = node.boundsMin;
+			myBoundsMax = node.boundsMax;
+		}
+		sharedClusterIdx[laneId] = myClusterIdx;
+		sharedBoundsMin[laneId] = myBoundsMin;
+		sharedBoundsMax[laneId] = myBoundsMax;
+		workgroupBarrier();
+
+		// ===== PLOC merge loop =====
+		for (var mergeIter = 0u; mergeIter < MAX_MERGE_ITERS; mergeIter = mergeIter + 1u) {
+			if (laneId == 0u) { uNumPrim = numPrim; }
+			let uniformNumPrim = workgroupUniformLoad(&uNumPrim);
+			if (uniformNumPrim <= threshold) { break; }
+
+			// Find nearest neighbor
+			var nearestIdx = INVALID_IDX;
+			var nearestCost = 1e30f;
+			let laneActive = laneId < uniformNumPrim;
+			var myMin = vec3f(0.0);
+			var myMax = vec3f(0.0);
+			if (laneActive) { myMin = sharedBoundsMin[laneId]; myMax = sharedBoundsMax[laneId]; }
+
+			for (var r = 1u; r <= SEARCH_RADIUS; r = r + 1u) {
+				var costRight = 1e30f;
+				if (laneActive) {
+					let j = laneId + r;
+					if (j < uniformNumPrim) {
+						let mergedMin = min(myMin, sharedBoundsMin[j]);
+						let mergedMax = max(myMax, sharedBoundsMax[j]);
+						costRight = aabbArea(mergedMin, mergedMax);
+						if (costRight < nearestCost) { nearestCost = costRight; nearestIdx = j; }
+					}
+				}
+				var leftLane = 0u;
+				if (laneId >= r) { leftLane = laneId - r; }
+				let incomingCost = unsafeSubgroupShuffleF(costRight, leftLane);
+				if (laneActive && laneId >= r && incomingCost < nearestCost) {
+					nearestCost = incomingCost;
+					nearestIdx = leftLane;
+				}
+			}
+			sharedNearestNeighbor[laneId] = nearestIdx;
+			workgroupBarrier();
+
+			// Mutual nearest neighbor check
+			var shouldMerge = false;
+			if (laneId < numPrim && nearestIdx != INVALID_IDX && nearestIdx < numPrim) {
+				let theirNearest = sharedNearestNeighbor[nearestIdx];
+				if (theirNearest == laneId && laneId < nearestIdx) { shouldMerge = true; }
+			}
+
+			// Wave-aggregated node allocation
+			let mergeCount = unsafeSubgroupAdd(select(0u, 1u, shouldMerge));
+			let mergePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, shouldMerge));
+			var allocBase = 0u;
+			if (laneId == 0u && mergeCount > 0u) { allocBase = atomicAdd(&nodeCounter, mergeCount); }
+			allocBase = unsafeSubgroupShuffle(allocBase, 0u);
+
+			// Perform merges
+			let maxNodes = 2u * uniforms.primCount;
+			if (shouldMerge) {
+				let leftCluster = sharedClusterIdx[laneId];
+				let rightCluster = sharedClusterIdx[nearestIdx];
+				let mergedMin = min(sharedBoundsMin[laneId], sharedBoundsMin[nearestIdx]);
+				let mergedMax = max(sharedBoundsMax[laneId], sharedBoundsMax[nearestIdx]);
+				let newNodeIdx = allocBase + mergePrefix;
+				if (newNodeIdx < maxNodes) {
+					bvh2Nodes[newNodeIdx].boundsMin = mergedMin;
+					bvh2Nodes[newNodeIdx].boundsMax = mergedMax;
+					bvh2Nodes[newNodeIdx].leftChild = leftCluster;
+					bvh2Nodes[newNodeIdx].rightChild = rightCluster;
+					sharedClusterIdx[laneId] = newNodeIdx;
+					sharedBoundsMin[laneId] = mergedMin;
+					sharedBoundsMax[laneId] = mergedMax;
+				}
+			}
+			workgroupBarrier();
+
+			// Compaction
+			var survives = false;
+			if (laneId < uniformNumPrim) {
+				survives = true;
+				let myNearest = sharedNearestNeighbor[laneId];
+				if (myNearest != INVALID_IDX && myNearest < uniformNumPrim) {
+					let theirNearest = sharedNearestNeighbor[myNearest];
+					if (theirNearest == laneId && myNearest < laneId) { survives = false; }
+				}
+			}
+			// Compute subgroup sum BEFORE any conditional - subgroup ops must run on all lanes
+			let localSurviveCount = unsafeSubgroupAdd(select(0u, 1u, survives));
+			let survivePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, survives));
+			if (survives) {
+				sharedTempIdx[survivePrefix] = sharedClusterIdx[laneId];
+				sharedTempMin[survivePrefix] = sharedBoundsMin[laneId];
+				sharedTempMax[survivePrefix] = sharedBoundsMax[laneId];
+			}
+			if (laneId == 0u) { uNumPrim = localSurviveCount; }
+			let surviveCount = workgroupUniformLoad(&uNumPrim);
+			if (laneId < surviveCount) {
+				sharedClusterIdx[laneId] = sharedTempIdx[laneId];
+				sharedBoundsMin[laneId] = sharedTempMin[laneId];
+				sharedBoundsMax[laneId] = sharedTempMax[laneId];
+			}
+			workgroupBarrier();
+			numPrim = surviveCount;
+		}
+
+		if (laneId == 0u) { uNumPrim = numPrim; }
+		let finalNumPrim = workgroupUniformLoad(&uNumPrim);
+
+		// Write results back
+		if (laneId < originalLoadedCount) {
+			let outIdx = select(INVALID_IDX, sharedClusterIdx[laneId], laneId < finalNumPrim);
+			clusterIdx[mergeLeft + laneId] = outIdx;
+		}
+
+		if (laneId == selLane) {
+			needsMerge = false;
+			if (mergeFinal && finalNumPrim <= 1u) { isActive = false; }
+		}
+		workgroupBarrier();
+	}
+
+	// Save state
+	if (!isOOB) {
+		state[primIdx] = vec4u(left, right, split, select(0u, 1u, isActive));
+	}
+
+	// Subgroup-aggregated append: one global atomicAdd per workgroup (wave32 path).
+	let live = isActive && !isOOB;
+	let liveU = select(0u, 1u, live);
+	let liveCount = unsafeSubgroupAdd(liveU);
+	let livePrefix = unsafeSubgroupExclusiveAdd(liveU);
+
+	var activeBase = 0u;
+	if (laneId == 0u && liveCount > 0u) {
+		activeBase = atomicAdd(&activeCountOut, liveCount);
+	}
+	activeBase = unsafeSubgroupShuffle(activeBase, 0u);
+
+	if (live) {
+		activeListOut[activeBase + livePrefix] = primIdx;
+	}
+}
+`;
+
+/**
+ * H-PLOC Wave64 shader - 1-subgroup-per-workgroup design
+ *
+ * Optimized for GPUs with subgroup size 64 (AMD).
+ * Key optimizations:
+ * 1. @workgroup_size(64) = subgroup size, so entire workgroup is one subgroup
+ * 2. workgroupBarrier() is essentially free (no other subgroups to wait)
+ * 3. Shared memory sized to exactly 64 elements
+ * 4. MERGING_THRESHOLD = 32 (64/2) per paper's constraint
+ * 5. No subgroupId partitioning needed
+ * 6. Uses vec4 ballot masks for 64-bit lane support
+ */
+export const hplocShaderWave64 = /* wgsl */ `
+
+enable subgroups;
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupAdd(x: u32) -> u32 { return subgroupAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupExclusiveAdd(x: u32) -> u32 { return subgroupExclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupBallot(pred: bool) -> vec4<u32> { return subgroupBallot(pred); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffle(x: u32, lane: u32) -> u32 { return subgroupShuffle(x, lane); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffleF(x: f32, lane: u32) -> f32 { return subgroupShuffle(x, lane); }
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> mortonCodes: array<u32>;
+@group(0) @binding(2) var<storage, read_write> clusterIdx: array<u32>;
+@group(0) @binding(3) var<storage, read_write> parentIdx: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(5) var<storage, read_write> nodeCounter: atomic<u32>;
+@group(0) @binding(6) var<storage, read_write> state: array<vec4u>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = 64u;
+const SEARCH_RADIUS: u32 = 8u;
+// MERGING_THRESHOLD = WORKGROUP_SIZE/2 because two combining ranges could each
+// have up to MERGING_THRESHOLD clusters, and we can only load WORKGROUP_SIZE total
+const MERGING_THRESHOLD: u32 = 32u;
+const MAX_MERGE_ITERS: u32 = 32u;
+const MAX_ROUNDS: u32 = 64u;
+
+// Shared memory - sized to exactly WORKGROUP_SIZE (64)
+var<workgroup> sharedClusterIdx: array<u32, 64>;
+var<workgroup> sharedBoundsMin: array<vec3f, 64>;
+var<workgroup> sharedBoundsMax: array<vec3f, 64>;
+var<workgroup> sharedNearestNeighbor: array<u32, 64>;
+var<workgroup> sharedTempIdx: array<u32, 64>;
+var<workgroup> sharedTempMin: array<vec3f, 64>;
+var<workgroup> sharedTempMax: array<vec3f, 64>;
+
+// Broadcast variables (read via workgroupUniformLoad for uniform control flow)
+var<workgroup> uHasMerge: u32;
+var<workgroup> uSelLane: u32;
+var<workgroup> uMergeLeft: u32;
+var<workgroup> uMergeRight: u32;
+var<workgroup> uMergeSplit: u32;
+var<workgroup> uMergeFinal: u32;
+var<workgroup> uNumPrim: u32;
+var<workgroup> uValidCount: u32;
+
+// Returns common prefix length (higher = more similar, lower = more divergent)
+// Uses countLeadingZeros for canonical LBVH parent selection
+fn delta(a: u32, b: u32) -> u32 {
+	let mcA = mortonCodes[a];
+	let mcB = mortonCodes[b];
+	let xorVal = mcA ^ mcB;
+	// Equal morton codes: add 32 to ensure this is always > any CLZ(xorVal)
+	return select(countLeadingZeros(xorVal), 32u + countLeadingZeros(a ^ b), xorVal == 0u);
+}
+
+fn findParentId(left: u32, right: u32, primCount: u32) -> u32 {
+	if (left == 0u) { return right; }
+	if (right == primCount - 1u) { return left - 1u; }
+	let deltaRight = delta(right, right + 1u);
+	let deltaLeft = delta(left - 1u, left);
+	// With CLZ-based delta: higher = longer prefix = less divergent
+	// Return right when right boundary is LESS divergent (higher CLZ)
+	return select(left - 1u, right, deltaRight > deltaLeft);
+}
+
+fn aabbArea(boundsMin: vec3f, boundsMax: vec3f) -> f32 {
+	let extent = boundsMax - boundsMin;
+	return 2.0 * (extent.x * extent.y + extent.y * extent.z + extent.z * extent.x);
+}
+
+// 64-bit ballot helpers (uses .x and .y components)
+fn ballotCtz64(ballot: vec4<u32>) -> u32 {
+	if (ballot.x != 0u) { return countTrailingZeros(ballot.x); }
+	return 32u + countTrailingZeros(ballot.y);
+}
+
+fn ballotAny64(ballot: vec4<u32>) -> bool {
+	return (ballot.x | ballot.y) != 0u;
+}
+
+fn ballotCount64(ballot: vec4<u32>) -> u32 {
+	return countOneBits(ballot.x) + countOneBits(ballot.y);
+}
+
+@compute @workgroup_size(64)
+fn hplocBuild(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(subgroup_invocation_id) laneId: u32,
+	@builtin(subgroup_size) subgroupSize: u32
+) {
+	let localIdx = localId.x;
+	let primIdx = globalId.x;
+
+	// Runtime check: this shader requires subgroup size 64
+	if (subgroupSize != 64u) {
+		// Don't touch state - let fallback shader handle it
+		return;
+	}
+
+	let isOOB = primIdx >= uniforms.primCount;
+
+	// Load persistent state
+	var stateVec = vec4u(0u);
+	if (!isOOB) {
+		stateVec = state[primIdx];
+	}
+	var left = stateVec.x;
+	var right = stateVec.y;
+	var split = stateVec.z;
+	var isActive = stateVec.w != 0u && !isOOB;
+
+	// ===== MULTI-STEP LBVH OPTIMIZATION =====
+	var rangeSize = right - left + 1u;
+
+	while (isActive) {
+		let parentId = findParentId(left, right, uniforms.primCount);
+		var previousId = INVALID_IDX;
+
+		if (parentId == right) {
+			previousId = atomicExchange(&parentIdx[right], left);
+			if (previousId != INVALID_IDX) {
+				split = right + 1u;
+				right = previousId;
+			}
+		} else {
+			previousId = atomicExchange(&parentIdx[left - 1u], right);
+			if (previousId != INVALID_IDX) {
+				split = left;
+				left = previousId;
+			}
+		}
+
+		if (previousId == INVALID_IDX) {
+			isActive = false;
+			break;
+		}
+
+		rangeSize = right - left + 1u;
+
+		if (rangeSize > MERGING_THRESHOLD || rangeSize == uniforms.primCount) {
+			break;
+		}
+	}
+
+	// Determine if this thread needs a PLOC merge
+	let isFinal = isActive && (rangeSize == uniforms.primCount);
+	var needsMerge = isActive && ((rangeSize > MERGING_THRESHOLD) || isFinal);
+
+	// ===== BALLOT+CTZ MERGE SELECTION =====
+	// Use workgroupUniformLoad to satisfy WGSL uniform control flow requirements
+	for (var round = 0u; round < MAX_ROUNDS; round = round + 1u) {
+		let ballot = unsafeSubgroupBallot(needsMerge);
+
+		// Broadcast hasMerge via workgroup variable for uniform control flow
+		if (laneId == 0u) {
+			uHasMerge = select(0u, 1u, ballotAny64(ballot));
+		}
+		let hasMerge = workgroupUniformLoad(&uHasMerge) != 0u;
+
+		if (!hasMerge) {
+			break; // Uniform across entire workgroup
+		}
+
+		// Select first lane needing merge and broadcast via workgroup variables
+		if (laneId == 0u) {
+			let selLane = ballotCtz64(ballot);
+			uSelLane = selLane;
+		}
+		let selLane = workgroupUniformLoad(&uSelLane);
+
+		// Broadcast merge parameters
+		if (laneId == selLane) {
+			uMergeLeft = left;
+			uMergeRight = right;
+			uMergeSplit = split;
+			uMergeFinal = select(0u, 1u, (right - left + 1u) == uniforms.primCount);
+		}
+		let mergeLeft = workgroupUniformLoad(&uMergeLeft);
+		let mergeRight = workgroupUniformLoad(&uMergeRight);
+		let mergeSplit = workgroupUniformLoad(&uMergeSplit);
+		let mergeFinal = workgroupUniformLoad(&uMergeFinal) != 0u;
+
+		// Compute how many clusters to load from each side
+		let totalLeft = mergeSplit - mergeLeft;
+		let totalRight = mergeRight - mergeSplit + 1u;
+		let halfWave = MERGING_THRESHOLD; // 32
+		let leftCount = min(totalLeft, halfWave);
+		let rightCount = min(totalRight, halfWave);
+		let originalLoadedCount = leftCount + rightCount;
+		var numPrim = originalLoadedCount;
+
+		let threshold = select(MERGING_THRESHOLD, 1u, mergeFinal);
+
+		// ===== Load cluster indices =====
+		var loadedIdx = INVALID_IDX;
+		if (laneId < numPrim) {
+			var loadIdx: u32;
+			if (laneId < leftCount) {
+				loadIdx = mergeLeft + laneId;
+			} else {
+				loadIdx = mergeSplit + (laneId - leftCount);
+			}
+			loadedIdx = clusterIdx[loadIdx];
+		}
+		sharedClusterIdx[laneId] = loadedIdx;
+		workgroupBarrier();
+
+		// ===== Compact valid clusters (skip INVALID) =====
+		let isValid = laneId < numPrim && loadedIdx != INVALID_IDX;
+		let validBallot = unsafeSubgroupBallot(isValid);
+
+		// Broadcast valid count for uniform control flow
+		if (laneId == 0u) {
+			uValidCount = ballotCount64(validBallot);
+		}
+		let validCount = workgroupUniformLoad(&uValidCount);
+		let validPrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, isValid));
+
+		if (isValid) {
+			sharedTempIdx[validPrefix] = loadedIdx;
+		}
+		workgroupBarrier();
+
+		numPrim = validCount;
+
+		// Load bounds for compacted cluster list
+		var myClusterIdx = INVALID_IDX;
+		var myBoundsMin = vec3f(0.0);
+		var myBoundsMax = vec3f(0.0);
+
+		if (laneId < numPrim) {
+			myClusterIdx = sharedTempIdx[laneId];
+			let node = bvh2Nodes[myClusterIdx];
+			myBoundsMin = node.boundsMin;
+			myBoundsMax = node.boundsMax;
+		}
+
+		sharedClusterIdx[laneId] = myClusterIdx;
+		sharedBoundsMin[laneId] = myBoundsMin;
+		sharedBoundsMax[laneId] = myBoundsMax;
+		workgroupBarrier();
+
+		// ===== PLOC merge loop =====
+		for (var mergeIter = 0u; mergeIter < MAX_MERGE_ITERS; mergeIter = mergeIter + 1u) {
+			// Broadcast numPrim for uniform control flow
+			if (laneId == 0u) {
+				uNumPrim = numPrim;
+			}
+			let uniformNumPrim = workgroupUniformLoad(&uNumPrim);
+			if (uniformNumPrim <= threshold) {
+				break; // Uniform - entire workgroup breaks together
+			}
+
+			// Find nearest neighbor (right-only + propagate to left)
+			var nearestIdx = INVALID_IDX;
+			var nearestCost = 1e30f;
+
+			let laneActive = laneId < uniformNumPrim;
+			var myMin = vec3f(0.0);
+			var myMax = vec3f(0.0);
+			if (laneActive) {
+				myMin = sharedBoundsMin[laneId];
+				myMax = sharedBoundsMax[laneId];
+			}
+
+			for (var r = 1u; r <= SEARCH_RADIUS; r = r + 1u) {
+				var costRight = 1e30f;
+				if (laneActive) {
+					let j = laneId + r;
+					if (j < uniformNumPrim) {
+						let otherMin = sharedBoundsMin[j];
+						let otherMax = sharedBoundsMax[j];
+						let mergedMin = min(myMin, otherMin);
+						let mergedMax = max(myMax, otherMax);
+						costRight = aabbArea(mergedMin, mergedMax);
+
+						if (costRight < nearestCost) {
+							nearestCost = costRight;
+							nearestIdx = j;
+						}
+					}
+				}
+
+				var leftLane = 0u;
+				if (laneId >= r) {
+					leftLane = laneId - r;
+				}
+				let incomingCost = unsafeSubgroupShuffleF(costRight, leftLane);
+
+				if (laneActive && laneId >= r && incomingCost < nearestCost) {
+					nearestCost = incomingCost;
+					nearestIdx = leftLane;
+				}
+			}
+			sharedNearestNeighbor[laneId] = nearestIdx;
+			workgroupBarrier();
+
+			// Determine mutual nearest neighbor pairs (lower index merges)
+			var shouldMerge = false;
+			if (laneId < uniformNumPrim && nearestIdx != INVALID_IDX && nearestIdx < uniformNumPrim) {
+				let theirNearest = sharedNearestNeighbor[nearestIdx];
+				if (theirNearest == laneId && laneId < nearestIdx) {
+					shouldMerge = true;
+				}
+			}
+
+			// Wave-aggregated node allocation
+			let mergeCount = unsafeSubgroupAdd(select(0u, 1u, shouldMerge));
+			let mergePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, shouldMerge));
+
+			var allocBase = 0u;
+			if (laneId == 0u && mergeCount > 0u) {
+				allocBase = atomicAdd(&nodeCounter, mergeCount);
+			}
+			allocBase = unsafeSubgroupShuffle(allocBase, 0u);
+
+			// Perform merges
+			let maxNodes = 2u * uniforms.primCount;
+			if (shouldMerge) {
+				let leftCluster = sharedClusterIdx[laneId];
+				let rightCluster = sharedClusterIdx[nearestIdx];
+
+				let mergedMin = min(sharedBoundsMin[laneId], sharedBoundsMin[nearestIdx]);
+				let mergedMax = max(sharedBoundsMax[laneId], sharedBoundsMax[nearestIdx]);
+
+				let newNodeIdx = allocBase + mergePrefix;
+				if (newNodeIdx < maxNodes) {
+					bvh2Nodes[newNodeIdx].boundsMin = mergedMin;
+					bvh2Nodes[newNodeIdx].boundsMax = mergedMax;
+					bvh2Nodes[newNodeIdx].leftChild = leftCluster;
+					bvh2Nodes[newNodeIdx].rightChild = rightCluster;
+
+					sharedClusterIdx[laneId] = newNodeIdx;
+					sharedBoundsMin[laneId] = mergedMin;
+					sharedBoundsMax[laneId] = mergedMax;
+				}
+			}
+			workgroupBarrier();
+
+			// Compaction: determine who survives
+			var survives = false;
+			if (laneId < uniformNumPrim) {
+				survives = true;
+				let myNearest = sharedNearestNeighbor[laneId];
+				if (myNearest != INVALID_IDX && myNearest < uniformNumPrim) {
+					let theirNearest = sharedNearestNeighbor[myNearest];
+					if (theirNearest == laneId && myNearest < laneId) {
+						survives = false;
+					}
+				}
+			}
+
+			let localSurviveCount = unsafeSubgroupAdd(select(0u, 1u, survives));
+			let survivePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, survives));
+
+			if (survives) {
+				sharedTempIdx[survivePrefix] = sharedClusterIdx[laneId];
+				sharedTempMin[survivePrefix] = sharedBoundsMin[laneId];
+				sharedTempMax[survivePrefix] = sharedBoundsMax[laneId];
+			}
+
+			// Broadcast survive count for uniform control flow
+			if (laneId == 0u) {
+				uNumPrim = localSurviveCount;
+			}
+			let surviveCount = workgroupUniformLoad(&uNumPrim);
+
+			if (laneId < surviveCount) {
+				sharedClusterIdx[laneId] = sharedTempIdx[laneId];
+				sharedBoundsMin[laneId] = sharedTempMin[laneId];
+				sharedBoundsMax[laneId] = sharedTempMax[laneId];
+			}
+			workgroupBarrier();
+
+			numPrim = surviveCount;
+		}
+
+		// Broadcast final numPrim for uniform control flow
+		if (laneId == 0u) {
+			uNumPrim = numPrim;
+		}
+		let finalNumPrim = workgroupUniformLoad(&uNumPrim);
+
+		// ===== Write results back to global clusterIdx =====
+		if (laneId < originalLoadedCount) {
+			let outIdx = select(INVALID_IDX, sharedClusterIdx[laneId], laneId < finalNumPrim);
+			clusterIdx[mergeLeft + laneId] = outIdx;
+		}
+
+		// Only the selected lane clears its needsMerge and updates isActive
+		if (laneId == selLane) {
+			needsMerge = false;
+			if (mergeFinal && finalNumPrim <= 1u) {
+				isActive = false;
+			}
+		}
+
+		workgroupBarrier();
+	}
+
+	// Save state
+	if (!isOOB) {
+		state[primIdx] = vec4u(left, right, split, select(0u, 1u, isActive));
+	}
+}
+`;
+
+/**
+ * H-PLOC Wave64 Indirect shader - single-pass indirect dispatch version
+ *
+ * Same as wave64 but with active list input/output for reduced workgroup launches.
+ */
+export const hplocShaderWave64Indirect = /* wgsl */ `
+
+enable subgroups;
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupAdd(x: u32) -> u32 { return subgroupAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupExclusiveAdd(x: u32) -> u32 { return subgroupExclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupBallot(pred: bool) -> vec4<u32> { return subgroupBallot(pred); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffle(x: u32, lane: u32) -> u32 { return subgroupShuffle(x, lane); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffleF(x: f32, lane: u32) -> f32 { return subgroupShuffle(x, lane); }
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> mortonCodes: array<u32>;
+@group(0) @binding(2) var<storage, read_write> clusterIdx: array<u32>;
+@group(0) @binding(3) var<storage, read_write> parentIdx: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(5) var<storage, read_write> nodeCounter: atomic<u32>;
+@group(0) @binding(6) var<storage, read_write> state: array<vec4u>;
+// Indirect dispatch active list bindings
+@group(0) @binding(7) var<storage, read> activeListIn: array<u32>;
+@group(0) @binding(8) var<storage, read_write> activeListOut: array<u32>;
+@group(0) @binding(9) var<storage, read_write> activeCountOut: atomic<u32>;
+@group(0) @binding(10) var<storage, read_write> activeCountIn: atomic<u32>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = 64u;
+const SEARCH_RADIUS: u32 = 8u;
+const MERGING_THRESHOLD: u32 = 32u;
+const MAX_MERGE_ITERS: u32 = 32u;
+const MAX_ROUNDS: u32 = 64u;  // Must match wave64 direct (was 32, caused slow convergence)
+
+var<workgroup> sharedClusterIdx: array<u32, 64>;
+var<workgroup> sharedBoundsMin: array<vec3f, 64>;
+var<workgroup> sharedBoundsMax: array<vec3f, 64>;
+var<workgroup> sharedNearestNeighbor: array<u32, 64>;
+var<workgroup> sharedTempIdx: array<u32, 64>;
+var<workgroup> sharedTempMin: array<vec3f, 64>;
+var<workgroup> sharedTempMax: array<vec3f, 64>;
+
+var<workgroup> uHasMerge: u32;
+var<workgroup> uSelLane: u32;
+var<workgroup> uMergeLeft: u32;
+var<workgroup> uMergeRight: u32;
+var<workgroup> uMergeSplit: u32;
+var<workgroup> uMergeFinal: u32;
+var<workgroup> uNumPrim: u32;
+var<workgroup> uValidCount: u32;
+var<workgroup> uActiveCount: u32;
+
+fn delta(a: u32, b: u32) -> u32 {
+	let mcA = mortonCodes[a];
+	let mcB = mortonCodes[b];
+	let xorVal = mcA ^ mcB;
+	return select(countLeadingZeros(xorVal), 32u + countLeadingZeros(a ^ b), xorVal == 0u);
+}
+
+fn findParentId(left: u32, right: u32, primCount: u32) -> u32 {
+	if (left == 0u) { return right; }
+	if (right == primCount - 1u) { return left - 1u; }
+	let deltaRight = delta(right, right + 1u);
+	let deltaLeft = delta(left - 1u, left);
+	return select(left - 1u, right, deltaRight > deltaLeft);
+}
+
+fn aabbArea(boundsMin: vec3f, boundsMax: vec3f) -> f32 {
+	let extent = boundsMax - boundsMin;
+	return 2.0 * (extent.x * extent.y + extent.y * extent.z + extent.z * extent.x);
+}
+
+// 64-bit ballot helpers
+fn ballot64Ctz(ballot: vec4<u32>) -> u32 {
+	if (ballot.x != 0u) { return countTrailingZeros(ballot.x); }
+	return 32u + countTrailingZeros(ballot.y);
+}
+fn ballot64Any(ballot: vec4<u32>) -> bool { return (ballot.x | ballot.y) != 0u; }
+fn ballot64Count(ballot: vec4<u32>) -> u32 { return countOneBits(ballot.x) + countOneBits(ballot.y); }
+
+@compute @workgroup_size(64)
+fn hplocBuildIndirect(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(subgroup_invocation_id) laneId: u32,
+	@builtin(subgroup_size) subgroupSize: u32
+) {
+	let localIdx = localId.x;
+	let threadIdx = globalId.x;
+
+	if (subgroupSize != 64u) { return; }
+
+	// Read active count once per workgroup and broadcast (uniform value)
+	if (laneId == 0u) {
+		uActiveCount = atomicLoad(&activeCountIn);
+	}
+	let activeCount = workgroupUniformLoad(&uActiveCount);
+	var isOOB = threadIdx >= activeCount;
+
+	var primIdx = 0u;
+	if (!isOOB) {
+		primIdx = activeListIn[threadIdx];
+		isOOB = primIdx >= uniforms.primCount;
+	}
+
+	var stateVec = vec4u(0u);
+	if (!isOOB) { stateVec = state[primIdx]; }
+	var left = stateVec.x;
+	var right = stateVec.y;
+	var split = stateVec.z;
+	var isActive = stateVec.w != 0u && !isOOB;
+
+	var rangeSize = right - left + 1u;
+
+	while (isActive) {
+		let parentId = findParentId(left, right, uniforms.primCount);
+		var previousId = INVALID_IDX;
+
+		if (parentId == right) {
+			previousId = atomicExchange(&parentIdx[right], left);
+			if (previousId != INVALID_IDX) { split = right + 1u; right = previousId; }
+		} else {
+			previousId = atomicExchange(&parentIdx[left - 1u], right);
+			if (previousId != INVALID_IDX) { split = left; left = previousId; }
+		}
+
+		if (previousId == INVALID_IDX) { isActive = false; break; }
+		rangeSize = right - left + 1u;
+		if (rangeSize > MERGING_THRESHOLD || rangeSize == uniforms.primCount) { break; }
+	}
+
+	let isFinal = isActive && (rangeSize == uniforms.primCount);
+	var needsMerge = isActive && ((rangeSize > MERGING_THRESHOLD) || isFinal);
+
+	for (var round = 0u; round < MAX_ROUNDS; round = round + 1u) {
+		let ballot = unsafeSubgroupBallot(needsMerge);
+
+		if (laneId == 0u) { uHasMerge = select(0u, 1u, ballot64Any(ballot)); }
+		let hasMerge = workgroupUniformLoad(&uHasMerge) != 0u;
+		if (!hasMerge) { break; }
+
+		if (laneId == 0u) { uSelLane = ballot64Ctz(ballot); }
+		let selLane = workgroupUniformLoad(&uSelLane);
+
+		if (laneId == selLane) {
+			uMergeLeft = left;
+			uMergeRight = right;
+			uMergeSplit = split;
+			uMergeFinal = select(0u, 1u, (right - left + 1u) == uniforms.primCount);
+		}
+		let mergeLeft = workgroupUniformLoad(&uMergeLeft);
+		let mergeRight = workgroupUniformLoad(&uMergeRight);
+		let mergeSplit = workgroupUniformLoad(&uMergeSplit);
+		let mergeFinal = workgroupUniformLoad(&uMergeFinal) != 0u;
+
+		let totalLeft = mergeSplit - mergeLeft;
+		let totalRight = mergeRight - mergeSplit + 1u;
+		let halfWave = MERGING_THRESHOLD;
+		let leftCount = min(totalLeft, halfWave);
+		let rightCount = min(totalRight, halfWave);
+		let originalLoadedCount = leftCount + rightCount;
+		var numPrim = originalLoadedCount;
+		let threshold = select(MERGING_THRESHOLD, 1u, mergeFinal);
+
+		var loadedIdx = INVALID_IDX;
+		if (laneId < numPrim) {
+			var loadIdx: u32;
+			if (laneId < leftCount) { loadIdx = mergeLeft + laneId; }
+			else { loadIdx = mergeSplit + (laneId - leftCount); }
+			loadedIdx = clusterIdx[loadIdx];
+		}
+		sharedClusterIdx[laneId] = loadedIdx;
+		workgroupBarrier();
+
+		let isValid = laneId < numPrim && loadedIdx != INVALID_IDX;
+		let validBallot = unsafeSubgroupBallot(isValid);
+		if (laneId == 0u) { uValidCount = ballot64Count(validBallot); }
+		let validCount = workgroupUniformLoad(&uValidCount);
+		let validPrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, isValid));
+
+		if (isValid) { sharedTempIdx[validPrefix] = loadedIdx; }
+		workgroupBarrier();
+		numPrim = validCount;
+
+		var myClusterIdx = INVALID_IDX;
+		var myBoundsMin = vec3f(0.0);
+		var myBoundsMax = vec3f(0.0);
+		if (laneId < numPrim) {
+			myClusterIdx = sharedTempIdx[laneId];
+			let node = bvh2Nodes[myClusterIdx];
+			myBoundsMin = node.boundsMin;
+			myBoundsMax = node.boundsMax;
+		}
+		sharedClusterIdx[laneId] = myClusterIdx;
+		sharedBoundsMin[laneId] = myBoundsMin;
+		sharedBoundsMax[laneId] = myBoundsMax;
+		workgroupBarrier();
+
+		for (var mergeIter = 0u; mergeIter < MAX_MERGE_ITERS; mergeIter = mergeIter + 1u) {
+			if (laneId == 0u) { uNumPrim = numPrim; }
+			let uniformNumPrim = workgroupUniformLoad(&uNumPrim);
+			if (uniformNumPrim <= threshold) { break; }
+
+			var nearestIdx = INVALID_IDX;
+			var nearestCost = 1e30f;
+			let laneActive = laneId < uniformNumPrim;
+			var myMin = vec3f(0.0);
+			var myMax = vec3f(0.0);
+			if (laneActive) { myMin = sharedBoundsMin[laneId]; myMax = sharedBoundsMax[laneId]; }
+
+			for (var r = 1u; r <= SEARCH_RADIUS; r = r + 1u) {
+				var costRight = 1e30f;
+				if (laneActive) {
+					let j = laneId + r;
+					if (j < uniformNumPrim) {
+						let mergedMin = min(myMin, sharedBoundsMin[j]);
+						let mergedMax = max(myMax, sharedBoundsMax[j]);
+						costRight = aabbArea(mergedMin, mergedMax);
+						if (costRight < nearestCost) { nearestCost = costRight; nearestIdx = j; }
+					}
+				}
+				var leftLane = 0u;
+				if (laneId >= r) { leftLane = laneId - r; }
+				let incomingCost = unsafeSubgroupShuffleF(costRight, leftLane);
+				if (laneActive && laneId >= r && incomingCost < nearestCost) {
+					nearestCost = incomingCost;
+					nearestIdx = leftLane;
+				}
+			}
+			sharedNearestNeighbor[laneId] = nearestIdx;
+			workgroupBarrier();
+
+			var shouldMerge = false;
+			if (laneId < numPrim && nearestIdx != INVALID_IDX && nearestIdx < numPrim) {
+				let theirNearest = sharedNearestNeighbor[nearestIdx];
+				if (theirNearest == laneId && laneId < nearestIdx) { shouldMerge = true; }
+			}
+
+			let mergeCount = unsafeSubgroupAdd(select(0u, 1u, shouldMerge));
+			let mergePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, shouldMerge));
+			var allocBase = 0u;
+			if (laneId == 0u && mergeCount > 0u) { allocBase = atomicAdd(&nodeCounter, mergeCount); }
+			allocBase = unsafeSubgroupShuffle(allocBase, 0u);
+
+			let maxNodes = 2u * uniforms.primCount;
+			if (shouldMerge) {
+				let leftCluster = sharedClusterIdx[laneId];
+				let rightCluster = sharedClusterIdx[nearestIdx];
+				let mergedMin = min(sharedBoundsMin[laneId], sharedBoundsMin[nearestIdx]);
+				let mergedMax = max(sharedBoundsMax[laneId], sharedBoundsMax[nearestIdx]);
+				let newNodeIdx = allocBase + mergePrefix;
+				if (newNodeIdx < maxNodes) {
+					bvh2Nodes[newNodeIdx].boundsMin = mergedMin;
+					bvh2Nodes[newNodeIdx].boundsMax = mergedMax;
+					bvh2Nodes[newNodeIdx].leftChild = leftCluster;
+					bvh2Nodes[newNodeIdx].rightChild = rightCluster;
+					sharedClusterIdx[laneId] = newNodeIdx;
+					sharedBoundsMin[laneId] = mergedMin;
+					sharedBoundsMax[laneId] = mergedMax;
+				}
+			}
+			workgroupBarrier();
+
+			var survives = false;
+			if (laneId < uniformNumPrim) {
+				survives = true;
+				let myNearest = sharedNearestNeighbor[laneId];
+				if (myNearest != INVALID_IDX && myNearest < uniformNumPrim) {
+					let theirNearest = sharedNearestNeighbor[myNearest];
+					if (theirNearest == laneId && myNearest < laneId) { survives = false; }
+				}
+			}
+			// Compute subgroup sum BEFORE any conditional - subgroup ops must run on all lanes
+			let localSurviveCount = unsafeSubgroupAdd(select(0u, 1u, survives));
+			let survivePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, survives));
+			if (survives) {
+				sharedTempIdx[survivePrefix] = sharedClusterIdx[laneId];
+				sharedTempMin[survivePrefix] = sharedBoundsMin[laneId];
+				sharedTempMax[survivePrefix] = sharedBoundsMax[laneId];
+			}
+			if (laneId == 0u) { uNumPrim = localSurviveCount; }
+			let surviveCount = workgroupUniformLoad(&uNumPrim);
+			if (laneId < surviveCount) {
+				sharedClusterIdx[laneId] = sharedTempIdx[laneId];
+				sharedBoundsMin[laneId] = sharedTempMin[laneId];
+				sharedBoundsMax[laneId] = sharedTempMax[laneId];
+			}
+			workgroupBarrier();
+			numPrim = surviveCount;
+		}
+
+		if (laneId == 0u) { uNumPrim = numPrim; }
+		let finalNumPrim = workgroupUniformLoad(&uNumPrim);
+
+		if (laneId < originalLoadedCount) {
+			let outIdx = select(INVALID_IDX, sharedClusterIdx[laneId], laneId < finalNumPrim);
+			clusterIdx[mergeLeft + laneId] = outIdx;
+		}
+
+		if (laneId == selLane) {
+			needsMerge = false;
+			if (mergeFinal && finalNumPrim <= 1u) { isActive = false; }
+		}
+		workgroupBarrier();
+	}
+
+	if (!isOOB) {
+		state[primIdx] = vec4u(left, right, split, select(0u, 1u, isActive));
+	}
+
+	// Subgroup-aggregated append: one global atomicAdd per workgroup (wave64 path).
+	let live = isActive && !isOOB;
+	let liveU = select(0u, 1u, live);
+	let liveCount = unsafeSubgroupAdd(liveU);
+	let livePrefix = unsafeSubgroupExclusiveAdd(liveU);
+
+	var activeBase = 0u;
+	if (laneId == 0u && liveCount > 0u) {
+		activeBase = atomicAdd(&activeCountOut, liveCount);
+	}
+	activeBase = unsafeSubgroupShuffle(activeBase, 0u);
+
+	if (live) {
+		activeListOut[activeBase + livePrefix] = primIdx;
+	}
+}
+`;
+
+export const hplocShaderSubgroup = /* wgsl */ `
+
+enable subgroups;
+
+// Subgroup helper functions
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupOr(x: u32) -> u32 { return subgroupOr(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupAdd(x: u32) -> u32 { return subgroupAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupExclusiveAdd(x: u32) -> u32 { return subgroupExclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupBallot(pred: bool) -> vec4<u32> { return subgroupBallot(pred); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffle(x: u32, lane: u32) -> u32 { return subgroupShuffle(x, lane); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffleF(x: f32, lane: u32) -> f32 { return subgroupShuffle(x, lane); }
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> mortonCodes: array<u32>;
+@group(0) @binding(2) var<storage, read_write> clusterIdx: array<u32>;
+@group(0) @binding(3) var<storage, read_write> parentIdx: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(5) var<storage, read_write> nodeCounter: atomic<u32>;
+@group(0) @binding(6) var<storage, read_write> state: array<vec4u>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = 128u;
+const SEARCH_RADIUS: u32 = 8u;
+const MAX_MERGE_ITERS: u32 = 32u;
+// Upper bound on "one merge per lane" selection rounds.
+// Theoretical max is subgroupSize (each round processes one merge per subgroup).
+// 64 covers all practical subgroup sizes (NVIDIA=32, AMD=64, Apple=32).
+const MAX_ROUNDS: u32 = 64u;
+
+// Shared memory partitioned by subgroup (segment [waveBase .. waveBase+subgroupSize))
+var<workgroup> sharedClusterIdx: array<u32, 128>;
+var<workgroup> sharedBoundsMin: array<vec3f, 128>;
+var<workgroup> sharedBoundsMax: array<vec3f, 128>;
+var<workgroup> sharedNearestNeighbor: array<u32, 128>;
+
+var<workgroup> sharedTempIdx: array<u32, 128>;
+var<workgroup> sharedTempMin: array<vec3f, 128>;
+var<workgroup> sharedTempMax: array<vec3f, 128>;
+
+// One entry per possible subgroupId (worst case: subgroupSize=1 => subgroupId in [0..127])
+var<workgroup> sharedSubgroupHasMerge: array<u32, 128>;
+var<workgroup> uAnyMerge: u32;
+
+// Returns common prefix length (higher = more similar, lower = more divergent)
+// Uses countLeadingZeros for canonical LBVH parent selection
+fn delta(a: u32, b: u32) -> u32 {
+	let mcA = mortonCodes[a];
+	let mcB = mortonCodes[b];
+	let xorVal = mcA ^ mcB;
+	// Equal morton codes: add 32 to ensure this is always > any CLZ(xorVal)
+	return select(countLeadingZeros(xorVal), 32u + countLeadingZeros(a ^ b), xorVal == 0u);
+}
+
+fn findParentId(left: u32, right: u32, primCount: u32) -> u32 {
+	if (left == 0u) { return right; }
+	if (right == primCount - 1u) { return left - 1u; }
+	let deltaRight = delta(right, right + 1u);
+	let deltaLeft = delta(left - 1u, left);
+	// With CLZ-based delta: higher = longer prefix = less divergent
+	// Return right when right boundary is LESS divergent (higher CLZ)
+	return select(left - 1u, right, deltaRight > deltaLeft);
+}
+
+fn aabbArea(boundsMin: vec3f, boundsMax: vec3f) -> f32 {
+	let extent = boundsMax - boundsMin;
+	return 2.0 * (extent.x * extent.y + extent.y * extent.z + extent.z * extent.x);
+}
+
+// Count trailing zeros in ballot (find first active lane)
+fn ballotCtz(ballot: vec4<u32>) -> u32 {
+	if (ballot.x != 0u) { return countTrailingZeros(ballot.x); }
+	if (ballot.y != 0u) { return 32u + countTrailingZeros(ballot.y); }
+	if (ballot.z != 0u) { return 64u + countTrailingZeros(ballot.z); }
+	if (ballot.w != 0u) { return 96u + countTrailingZeros(ballot.w); }
+	return 128u; // No bits set
+}
+
+// Check if ballot has any bits set
+fn ballotAny(ballot: vec4<u32>) -> bool {
+	return (ballot.x | ballot.y | ballot.z | ballot.w) != 0u;
+}
+
+// Count bits in ballot (all 4 components for subgroupSize up to 128)
+fn ballotCount(ballot: vec4<u32>) -> u32 {
+	return countOneBits(ballot.x) + countOneBits(ballot.y) + countOneBits(ballot.z) + countOneBits(ballot.w);
+}
+
+@compute @workgroup_size(128)
+fn hplocBuild(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(subgroup_invocation_id) laneId: u32,
+	@builtin(subgroup_size) subgroupSize: u32
+) {
+	let localIdx = localId.x;
+	let primIdx = globalId.x;
+
+	// OOB guard: threads beyond primCount are inactive and don't access state
+	// IMPORTANT: Don't use select() for OOB guard - WGSL may evaluate both arguments
+	let isOOB = primIdx >= uniforms.primCount;
+
+	// Load persistent state
+	var stateVec = vec4u(0u);
+	if (!isOOB) {
+		stateVec = state[primIdx];
+	}
+	var left = stateVec.x;
+	var right = stateVec.y;
+	var split = stateVec.z;
+	var isActive = stateVec.w != 0u && !isOOB;
+
+	// Subgroup partition indices
+	// NOTE: This assumes local_invocation_id.x is assigned contiguously to lanes (same assumption as OneSweep).
+	let subgroupId = localIdx / subgroupSize;
+	let waveBase = subgroupId * subgroupSize;
+
+	// FIX: Guard against unsupported subgroup layouts that would index shared arrays out of bounds.
+	// This is uniform across the workgroup because subgroupSize is uniform.
+	if ((WORKGROUP_SIZE % subgroupSize) != 0u || subgroupSize == 0u || subgroupSize > WORKGROUP_SIZE) {
+		if (!isOOB) {
+			// Save state unchanged (still valid), but skip subgroup-merge path.
+			state[primIdx] = vec4u(left, right, split, select(0u, 1u, isActive));
+		}
+		return;
+	}
+
+	// Dynamic threshold based on subgroup size
+	// Must be <= subgroupSize/2 because two combining ranges could each have
+	// up to mergeThreshold clusters, and we can only load subgroupSize total.
+	// Clamp to at least 1 to avoid threshold=0 on tiny subgroup sizes.
+	let mergeThreshold = max(1u, subgroupSize / 2u);
+
+	// ===== MULTI-STEP LBVH OPTIMIZATION =====
+	var rangeSize = right - left + 1u;
+
+	while (isActive) {
+		let parentId = findParentId(left, right, uniforms.primCount);
+		var previousId = INVALID_IDX;
+
+		if (parentId == right) {
+			previousId = atomicExchange(&parentIdx[right], left);
+			if (previousId != INVALID_IDX) {
+				split = right + 1u;
+				right = previousId;
+			}
+		} else {
+			previousId = atomicExchange(&parentIdx[left - 1u], right);
+			if (previousId != INVALID_IDX) {
+				split = left;
+				left = previousId;
+			}
+		}
+
+		if (previousId == INVALID_IDX) {
+			isActive = false;
+			break;
+		}
+
+		rangeSize = right - left + 1u;
+
+		if (rangeSize > mergeThreshold || rangeSize == uniforms.primCount) {
+			break;
+		}
+	}
+
+	// Determine if this thread needs a PLOC merge
+	let isFinal = isActive && (rangeSize == uniforms.primCount);
+	var needsMerge = isActive && ((rangeSize > mergeThreshold) || isFinal);
+
+	// ===== PER-SUBGROUP BALLOT+CTZ MERGE SELECTION =====
+	// Each subgroup repeatedly selects one lane needing merge, performs the merge, then clears that lane's flag.
+	// We synchronize at workgroup scope because WGSL only provides workgroupBarrier().
+
+	let numSubgroups = WORKGROUP_SIZE / subgroupSize;
+
+	for (var round = 0u; round < MAX_ROUNDS; round = round + 1u) {
+		// Subgroup ballot of "needsMerge"
+		let ballot = unsafeSubgroupBallot(needsMerge);
+		let hasMerge = ballotAny(ballot); // uniform within subgroup
+
+		// Publish per-subgroup activity (one lane per subgroup)
+		if (laneId == 0u) {
+			sharedSubgroupHasMerge[subgroupId] = select(0u, 1u, hasMerge);
+		}
+		workgroupBarrier();
+
+		// Workgroup-wide OR to decide if any subgroup still has work (uniform break)
+		if (localIdx == 0u) {
+			var any = 0u;
+			for (var s = 0u; s < numSubgroups; s = s + 1u) {
+				any = any | sharedSubgroupHasMerge[s];
+			}
+			uAnyMerge = any;
+		}
+		let anyMergeAll = workgroupUniformLoad(&uAnyMerge);
+
+		if (anyMergeAll == 0u) {
+			break; // Uniform across the workgroup (safe with barriers)
+		}
+
+		// If this subgroup has no pending merge, it still must participate in the barrier pattern below.
+		let doMerge = hasMerge;
+
+		// Selected lane (valid only if doMerge==true)
+		var selLane: u32 = 0u;
+		var mergeLeft: u32 = 0u;
+		var mergeRight: u32 = 0u;
+		var mergeSplit: u32 = 0u;
+		var mergeFinal: bool = false;
+
+		// FIX: Only compute/broadcast merge parameters when doMerge is true.
+		// Otherwise mergeSplit-mergeLeft could underflow and cause out-of-bounds loads.
+		if (doMerge) {
+			selLane = ballotCtz(ballot); // < subgroupSize because hasMerge==true
+			mergeLeft = unsafeSubgroupShuffle(left, selLane);
+			mergeRight = unsafeSubgroupShuffle(right, selLane);
+			mergeSplit = unsafeSubgroupShuffle(split, selLane);
+			mergeFinal = (mergeRight - mergeLeft + 1u) == uniforms.primCount;
+		}
+
+		// Compute how many clusters to load from each side
+		var leftCount: u32 = 0u;
+		var rightCount: u32 = 0u;
+		var originalLoadedCount: u32 = 0u;
+		var numPrim: u32 = 0u;
+		var threshold: u32 = mergeThreshold;
+
+		if (doMerge) {
+			let totalLeft = mergeSplit - mergeLeft;
+			let totalRight = mergeRight - mergeSplit + 1u;
+			let halfWave = mergeThreshold; // subgroupSize/2
+			leftCount = min(totalLeft, halfWave);
+			rightCount = min(totalRight, halfWave);
+			originalLoadedCount = leftCount + rightCount;
+			numPrim = originalLoadedCount;
+
+			// Merge down to 1 only for the final/root range
+			threshold = select(mergeThreshold, 1u, mergeFinal);
+		}
+
+		// ===== Load cluster indices into subgroup-local shared segment =====
+		var loadedIdx = INVALID_IDX;
+		if (laneId < numPrim) {
+			var loadIdx: u32;
+			if (laneId < leftCount) {
+				loadIdx = mergeLeft + laneId;
+			} else {
+				loadIdx = mergeSplit + (laneId - leftCount);
+			}
+			loadedIdx = clusterIdx[loadIdx];
+		}
+		sharedClusterIdx[waveBase + laneId] = loadedIdx;
+		workgroupBarrier();
+
+		// ===== Compact valid clusters (skip INVALID) =====
+		let isValid = laneId < numPrim && loadedIdx != INVALID_IDX;
+		let validBallot = unsafeSubgroupBallot(isValid);
+		let validCount = ballotCount(validBallot);
+		let validPrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, isValid));
+
+		if (isValid) {
+			sharedTempIdx[waveBase + validPrefix] = loadedIdx;
+		}
+		workgroupBarrier();
+
+		// Updated numPrim after compaction
+		numPrim = validCount;
+
+		// Load bounds for compacted cluster list
+		var myClusterIdx = INVALID_IDX;
+		var myBoundsMin = vec3f(0.0);
+		var myBoundsMax = vec3f(0.0);
+
+		if (laneId < numPrim) {
+			myClusterIdx = sharedTempIdx[waveBase + laneId];
+			let node = bvh2Nodes[myClusterIdx];
+			myBoundsMin = node.boundsMin;
+			myBoundsMax = node.boundsMax;
+		}
+
+		sharedClusterIdx[waveBase + laneId] = myClusterIdx;
+		sharedBoundsMin[waveBase + laneId] = myBoundsMin;
+		sharedBoundsMax[waveBase + laneId] = myBoundsMax;
+		workgroupBarrier();
+
+		// ===== PLOC merge loop with workgroup-uniform early exit =====
+		// PLOC typically converges in 3-5 iterations. Without early exit, we'd run
+		// MAX_MERGE_ITERS=32 iterations with 4 barriers each = 128 barriers.
+		// Early exit saves ~100+ barriers when merging converges quickly.
+		for (var mergeIter = 0u; mergeIter < MAX_MERGE_ITERS; mergeIter = mergeIter + 1u) {
+			let doIter = doMerge && (numPrim > threshold);
+
+			// Early exit check: if no subgroup needs more iterations, break uniformly
+			if (laneId == 0u) {
+				sharedSubgroupHasMerge[subgroupId] = select(0u, 1u, doIter);
+			}
+			workgroupBarrier();
+			if (localIdx == 0u) {
+				var anyIter = 0u;
+				for (var s = 0u; s < numSubgroups; s = s + 1u) {
+					anyIter = anyIter | sharedSubgroupHasMerge[s];
+				}
+				uAnyMerge = anyIter;
+			}
+			let stillMerging = workgroupUniformLoad(&uAnyMerge);
+			if (stillMerging == 0u) {
+				break; // Uniform across workgroup - safe with barriers
+			}
+
+			// Find nearest neighbor
+			var nearestIdx = INVALID_IDX;
+			var nearestCost = 1e30f;
+
+			if (doIter && laneId < numPrim) {
+				let myMin = sharedBoundsMin[waveBase + laneId];
+				let myMax = sharedBoundsMax[waveBase + laneId];
+
+				let searchStart = select(0u, laneId - SEARCH_RADIUS, laneId >= SEARCH_RADIUS);
+				let searchEnd = min(laneId + SEARCH_RADIUS + 1u, numPrim);
+
+				for (var j = searchStart; j < searchEnd; j = j + 1u) {
+					if (j != laneId) {
+						let otherMin = sharedBoundsMin[waveBase + j];
+						let otherMax = sharedBoundsMax[waveBase + j];
+						let mergedMin = min(myMin, otherMin);
+						let mergedMax = max(myMax, otherMax);
+						let cost = aabbArea(mergedMin, mergedMax);
+
+						if (cost < nearestCost) {
+							nearestCost = cost;
+							nearestIdx = j;
+						}
+					}
+				}
+				sharedNearestNeighbor[waveBase + laneId] = nearestIdx;
+			} else if (doIter) {
+				// Keep data defined for lanes >= numPrim
+				sharedNearestNeighbor[waveBase + laneId] = INVALID_IDX;
+			}
+			workgroupBarrier();
+
+			// Determine mutual nearest neighbor pairs (lower index merges)
+			var shouldMerge = false;
+			if (doIter && laneId < numPrim && nearestIdx != INVALID_IDX && nearestIdx < numPrim) {
+				let theirNearest = sharedNearestNeighbor[waveBase + nearestIdx];
+				if (theirNearest == laneId && laneId < nearestIdx) {
+					shouldMerge = true;
+				}
+			}
+
+			// Wave-aggregated node allocation (single atomic per subgroup per iteration)
+			let mergeCount = unsafeSubgroupAdd(select(0u, 1u, shouldMerge));
+			let mergePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, shouldMerge));
+
+			var allocBase = 0u;
+			if (doIter && laneId == 0u && mergeCount > 0u) {
+				allocBase = atomicAdd(&nodeCounter, mergeCount);
+			}
+			allocBase = unsafeSubgroupShuffle(allocBase, 0u);
+
+			// Perform merges
+			let maxNodes = 2u * uniforms.primCount;
+			if (doIter && shouldMerge) {
+				let leftCluster = sharedClusterIdx[waveBase + laneId];
+				let rightCluster = sharedClusterIdx[waveBase + nearestIdx];
+
+				let mergedMin = min(sharedBoundsMin[waveBase + laneId], sharedBoundsMin[waveBase + nearestIdx]);
+				let mergedMax = max(sharedBoundsMax[waveBase + laneId], sharedBoundsMax[waveBase + nearestIdx]);
+
+				let newNodeIdx = allocBase + mergePrefix;
+				if (newNodeIdx < maxNodes) {
+					bvh2Nodes[newNodeIdx].boundsMin = mergedMin;
+					bvh2Nodes[newNodeIdx].boundsMax = mergedMax;
+					bvh2Nodes[newNodeIdx].leftChild = leftCluster;
+					bvh2Nodes[newNodeIdx].rightChild = rightCluster;
+
+					sharedClusterIdx[waveBase + laneId] = newNodeIdx;
+					sharedBoundsMin[waveBase + laneId] = mergedMin;
+					sharedBoundsMax[waveBase + laneId] = mergedMax;
+				}
+			}
+			workgroupBarrier();
+
+			// Compaction: determine who survives
+			var survives = false;
+			if (doIter && laneId < numPrim) {
+				survives = true;
+				let myNearest = sharedNearestNeighbor[waveBase + laneId];
+				if (myNearest != INVALID_IDX && myNearest < numPrim) {
+					let theirNearest = sharedNearestNeighbor[waveBase + myNearest];
+					// I was merged INTO if they chose me AND they have lower index
+					if (theirNearest == laneId && myNearest < laneId) {
+						survives = false;
+					}
+				}
+			}
+
+			let surviveCount = unsafeSubgroupAdd(select(0u, 1u, survives));
+			let survivePrefix = unsafeSubgroupExclusiveAdd(select(0u, 1u, survives));
+
+			if (doIter && survives) {
+				sharedTempIdx[waveBase + survivePrefix] = sharedClusterIdx[waveBase + laneId];
+				sharedTempMin[waveBase + survivePrefix] = sharedBoundsMin[waveBase + laneId];
+				sharedTempMax[waveBase + survivePrefix] = sharedBoundsMax[waveBase + laneId];
+			}
+			workgroupBarrier();
+
+			if (doIter && laneId < surviveCount) {
+				sharedClusterIdx[waveBase + laneId] = sharedTempIdx[waveBase + laneId];
+				sharedBoundsMin[waveBase + laneId] = sharedTempMin[waveBase + laneId];
+				sharedBoundsMax[waveBase + laneId] = sharedTempMax[waveBase + laneId];
+			}
+			workgroupBarrier();
+
+			if (doIter) {
+				numPrim = surviveCount;
+			}
+		}
+
+		// ===== Write results back to global clusterIdx =====
+		if (doMerge && laneId < originalLoadedCount) {
+			let outIdx = select(INVALID_IDX, sharedClusterIdx[waveBase + laneId], laneId < numPrim);
+			clusterIdx[mergeLeft + laneId] = outIdx;
+		}
+
+		// FIX: Only the selected lane clears its own needsMerge and updates its own isActive.
+		if (doMerge && laneId == selLane) {
+			needsMerge = false;
+
+			// Deactivate only when final merge reached a single root cluster
+			if (mergeFinal && numPrim <= 1u) {
+				isActive = false;
+			}
+		}
+
+		// End-of-round sync so barriers remain ordered across the workgroup.
+		workgroupBarrier();
+	}
+
+	// Save state
+	if (!isOOB) {
+		state[primIdx] = vec4u(left, right, split, select(0u, 1u, isActive));
+	}
+}
+`;

--- a/src/gpu/shaders/radix_sort.wgsl.js
+++ b/src/gpu/shaders/radix_sort.wgsl.js
@@ -1,0 +1,231 @@
+/**
+ * Radix sort shaders for sorting Morton codes with associated values.
+ * Uses 8-bit digits (4 passes for 32-bit keys).
+ *
+ * Stable radix sort (required for LSD radix correctness):
+ * 1. Histogram: Count per-workgroup digits, store counts, accumulate totals
+ * 2. Workgroup Scan: Compute exclusive prefix sum across workgroups for each digit
+ * 3. Digit Scan: Simple 256-element prefix sum for digit base offsets
+ * 4. Scatter: Use workgroup offset + digit base + local rank
+ *
+ * Stability is achieved by deterministic workgroup-order prefix sum,
+ * ensuring workgroup 0's elements always come before workgroup 1's within each digit.
+ */
+
+// Histogram shader: Count digit occurrences per workgroup
+export const histogramShader = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	workgroupCount: u32,
+	pad1: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> keys: array<u32>;
+@group(0) @binding(2) var<storage, read_write> groupCounts: array<u32>;
+@group(0) @binding(3) var<storage, read_write> globalDigitCount: array<atomic<u32>>;
+
+const WORKGROUP_SIZE: u32 = 256u;
+const RADIX_SIZE: u32 = 256u;
+
+var<workgroup> localHistogram: array<atomic<u32>, RADIX_SIZE>;
+
+@compute @workgroup_size(256)
+fn computeHistogram(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(workgroup_id) workgroupId: vec3u
+) {
+	let idx = globalId.x;
+	let localIdx = localId.x;
+
+	// Initialize local histogram
+	if (localIdx < RADIX_SIZE) {
+		atomicStore(&localHistogram[localIdx], 0u);
+	}
+
+	workgroupBarrier();
+
+	// Count local occurrences
+	if (idx < uniforms.primCount) {
+		let key = keys[idx];
+		let digit = (key >> uniforms.bitOffset) & 0xFFu;
+		atomicAdd(&localHistogram[digit], 1u);
+	}
+
+	workgroupBarrier();
+
+	// Store per-workgroup counts (not reservations - that was non-deterministic!)
+	// Also accumulate global totals for digit base offset calculation
+	if (localIdx < RADIX_SIZE) {
+		let count = atomicLoad(&localHistogram[localIdx]);
+		// Store count for workgroup scan to process in deterministic order
+		groupCounts[workgroupId.x * RADIX_SIZE + localIdx] = count;
+		// Accumulate global total for this digit
+		atomicAdd(&globalDigitCount[localIdx], count);
+	}
+}
+`;
+
+// Workgroup scan shader: Compute exclusive prefix sum across workgroups for each digit
+// This ensures stability: workgroup 0's elements come before workgroup 1's within each digit
+export const workgroupScanShader = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	workgroupCount: u32,
+	pad1: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> groupCounts: array<u32>;
+@group(0) @binding(2) var<storage, read_write> groupPrefix: array<u32>;
+
+const RADIX_SIZE: u32 = 256u;
+
+@compute @workgroup_size(256)
+fn workgroupScan(
+	@builtin(local_invocation_id) localId: vec3u
+) {
+	let digit = localId.x;  // Each thread handles one digit (256 threads = 256 digits)
+
+	// Compute exclusive prefix sum across all workgroups for this digit
+	// This is O(workgroupCount) per thread, but ensures deterministic ordering
+	var sum = 0u;
+	for (var wg = 0u; wg < uniforms.workgroupCount; wg++) {
+		let count = groupCounts[wg * RADIX_SIZE + digit];
+		groupPrefix[wg * RADIX_SIZE + digit] = sum;  // Exclusive prefix
+		sum += count;
+	}
+}
+`;
+
+// Scan shader: Simple 256-element prefix sum for digit base offsets
+export const scanShader = /* wgsl */ `
+
+@group(0) @binding(1) var<storage, read> globalDigitCount: array<u32>;
+@group(0) @binding(2) var<storage, read_write> digitOffsets: array<u32>;
+
+const RADIX_SIZE: u32 = 256u;
+
+var<workgroup> sharedScan: array<u32, RADIX_SIZE>;
+
+@compute @workgroup_size(256)
+fn prefixScan(
+	@builtin(local_invocation_id) localId: vec3u
+) {
+	let idx = localId.x;
+
+	// Load digit counts
+	sharedScan[idx] = globalDigitCount[idx];
+	workgroupBarrier();
+
+	// Hillis-Steele inclusive prefix sum (log2(256) = 8 iterations)
+	for (var stride = 1u; stride < RADIX_SIZE; stride = stride * 2u) {
+		var addVal = 0u;
+		if (idx >= stride) {
+			addVal = sharedScan[idx - stride];
+		}
+		workgroupBarrier();
+		sharedScan[idx] = sharedScan[idx] + addVal;
+		workgroupBarrier();
+	}
+
+	// Convert inclusive to exclusive prefix sum and store
+	if (idx == 0u) {
+		digitOffsets[0] = 0u;
+	} else {
+		digitOffsets[idx] = sharedScan[idx - 1u];
+	}
+}
+`;
+
+// Scatter shader: Reorder keys and values based on prefix sums
+export const scatterShader = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	bitOffset: u32,
+	workgroupCount: u32,
+	pad1: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> keysIn: array<u32>;
+@group(0) @binding(2) var<storage, read_write> keysOut: array<u32>;
+@group(0) @binding(3) var<storage, read> valsIn: array<u32>;
+@group(0) @binding(4) var<storage, read_write> valsOut: array<u32>;
+@group(0) @binding(5) var<storage, read> groupPrefix: array<u32>;
+@group(0) @binding(6) var<storage, read> digitOffsets: array<u32>;
+
+const WORKGROUP_SIZE: u32 = 256u;
+const RADIX_SIZE: u32 = 256u;
+
+var<workgroup> sharedDigits: array<u32, WORKGROUP_SIZE>;
+var<workgroup> sharedRanks: array<u32, WORKGROUP_SIZE>;
+var<workgroup> digitCounts: array<u32, RADIX_SIZE>;
+
+@compute @workgroup_size(256)
+fn scatter(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(workgroup_id) workgroupId: vec3u
+) {
+	let idx = globalId.x;
+	let localIdx = localId.x;
+	let valid = idx < uniforms.primCount;
+
+	var digit = 0xFFFFFFFFu;
+	if (valid) {
+		let key = keysIn[idx];
+		digit = (key >> uniforms.bitOffset) & 0xFFu;
+	}
+
+	sharedDigits[localIdx] = digit;
+	workgroupBarrier();
+
+	// Thread 0 computes all ranks in single O(n) pass
+	// This maintains stability: threads are processed in order
+	if (localIdx == 0u) {
+		// Zero digit counts
+		for (var d = 0u; d < RADIX_SIZE; d = d + 1u) {
+			digitCounts[d] = 0u;
+		}
+		// Assign ranks in thread order (stable)
+		for (var i = 0u; i < WORKGROUP_SIZE; i = i + 1u) {
+			let d = sharedDigits[i];
+			if (d < RADIX_SIZE) {
+				sharedRanks[i] = digitCounts[d];
+				digitCounts[d] = digitCounts[d] + 1u;
+			} else {
+				sharedRanks[i] = 0u;
+			}
+		}
+	}
+	workgroupBarrier();
+
+	if (!valid) {
+		return;
+	}
+
+	let localRank = sharedRanks[localIdx];
+	let key = keysIn[idx];
+	let val = valsIn[idx];
+	let groupOffset = groupPrefix[workgroupId.x * RADIX_SIZE + digit];
+	let baseOffset = digitOffsets[digit];
+	let destIdx = baseOffset + groupOffset + localRank;
+
+	keysOut[destIdx] = key;
+	valsOut[destIdx] = val;
+}
+`;
+
+export const radixSortShaders = {
+	histogram: histogramShader,
+	workgroupScan: workgroupScanShader,
+	scan: scanShader,
+	scatter: scatterShader,
+};

--- a/src/gpu/shaders/refit.wgsl.js
+++ b/src/gpu/shaders/refit.wgsl.js
@@ -1,0 +1,263 @@
+/**
+ * Refit shaders for GPU BVH2:
+ * 1) buildParentMap: derive parent index for every node from child pointers.
+ * 2) refitLeaves: update all leaf bounds and append ready parents.
+ * 3) refitInternalWave: process ready internal nodes and append next-wave parents.
+ *
+ * Topology remains fixed. Only node bounds are updated.
+ */
+
+export const refitBuildParentsShader = /* wgsl */ `
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+@group(0) @binding(0) var<storage, read> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(1) var<storage, read_write> nodeCounter: atomic<u32>;
+@group(0) @binding(2) var<storage, read_write> parentIdx: array<u32>;
+@group(0) @binding(3) var<storage, read> clusterIdx: array<u32>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+
+@compute @workgroup_size(256)
+fn buildParentMap(
+	@builtin(global_invocation_id) globalId: vec3u
+) {
+	let nodeIdx = globalId.x;
+	let nodeCount = atomicLoad(&nodeCounter);
+	if (nodeIdx >= nodeCount) {
+		return;
+	}
+
+	let node = bvh2Nodes[nodeIdx];
+	if (node.leftChild != INVALID_IDX) {
+		parentIdx[node.leftChild] = nodeIdx;
+		parentIdx[node.rightChild] = nodeIdx;
+	}
+
+	// Mark root as self-parent so refit traversal has a stable termination condition.
+	if (nodeIdx == 0u) {
+		let rootIdx = clusterIdx[0];
+		parentIdx[rootIdx] = rootIdx;
+	}
+}
+`;
+
+export const refitBVHLeavesShader = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	positionStride: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+struct Bounds {
+	min: vec3f,
+	max: vec3f,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> positions: array<f32>;
+@group(0) @binding(2) var<storage, read> indices: array<u32>;
+@group(0) @binding(3) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(4) var<storage, read> parentIdx: array<u32>;
+@group(0) @binding(5) var<storage, read_write> visitCount: array<atomic<u32>>;
+@group(0) @binding(6) var<storage, read_write> activeListOut: array<u32>;
+@group(0) @binding(7) var<storage, read_write> activeCountOut: atomic<u32>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = 256u;
+
+var<workgroup> sharedPrefix: array<u32, 256>;
+var<workgroup> uReadyCount: u32;
+var<workgroup> uActiveListBase: u32;
+
+fn loadPosition(vertexIdx: u32) -> vec3f {
+	let base = vertexIdx * uniforms.positionStride;
+	return vec3f(positions[base], positions[base + 1u], positions[base + 2u]);
+}
+
+fn computeTriangleBounds(primIdx: u32) -> Bounds {
+	let base = primIdx * 3u;
+	let i0 = indices[base];
+	let i1 = indices[base + 1u];
+	let i2 = indices[base + 2u];
+
+	let v0 = loadPosition(i0);
+	let v1 = loadPosition(i1);
+	let v2 = loadPosition(i2);
+
+	var bounds: Bounds;
+	bounds.min = min(min(v0, v1), v2);
+	bounds.max = max(max(v0, v1), v2);
+	return bounds;
+}
+
+@compute @workgroup_size(256)
+fn refitLeaves(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u
+) {
+	let primIdx = globalId.x;
+	let localIdx = localId.x;
+
+	var readyParent = INVALID_IDX;
+	var isReady = false;
+
+	if (primIdx < uniforms.primCount) {
+		// 1) Update leaf bounds
+		let leafBounds = computeTriangleBounds(primIdx);
+		bvh2Nodes[primIdx].boundsMin = leafBounds.min;
+		bvh2Nodes[primIdx].boundsMax = leafBounds.max;
+
+		// 2) Signal parent and mark ready on second arrival
+		let p = parentIdx[primIdx];
+		if (p != primIdx && p != INVALID_IDX) {
+			let old = atomicAdd(&visitCount[p], 1u);
+			if (old == 1u) {
+				isReady = true;
+				readyParent = p;
+			}
+		}
+	}
+
+	// Workgroup-aggregated append: one global atomicAdd per workgroup.
+	sharedPrefix[localIdx] = select(0u, 1u, isReady);
+	workgroupBarrier();
+
+	for (var stride = 1u; stride < WORKGROUP_SIZE; stride = stride * 2u) {
+		var addVal = 0u;
+		if (localIdx >= stride) {
+			addVal = sharedPrefix[localIdx - stride];
+		}
+		workgroupBarrier();
+		sharedPrefix[localIdx] = sharedPrefix[localIdx] + addVal;
+		workgroupBarrier();
+	}
+
+	if (localIdx == 0u) {
+		uReadyCount = sharedPrefix[WORKGROUP_SIZE - 1u];
+		var base = 0u;
+		if (uReadyCount > 0u) {
+			base = atomicAdd(&activeCountOut, uReadyCount);
+		}
+		uActiveListBase = base;
+	}
+
+	let readyCount = workgroupUniformLoad(&uReadyCount);
+	let activeBase = workgroupUniformLoad(&uActiveListBase);
+	if (isReady && readyCount > 0u) {
+		let outIdx = activeBase + (sharedPrefix[localIdx] - 1u);
+		activeListOut[outIdx] = readyParent;
+	}
+}
+`;
+
+export function getRefitBVHInternalShader( workgroupSize = 256 ) {
+
+	const wgSize = Math.max( 1, Math.floor( workgroupSize ) );
+	return /* wgsl */ `
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+@group(0) @binding(0) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(1) var<storage, read> parentIdx: array<u32>;
+@group(0) @binding(2) var<storage, read_write> visitCount: array<atomic<u32>>;
+@group(0) @binding(3) var<storage, read> activeListIn: array<u32>;
+@group(0) @binding(4) var<storage, read_write> activeListOut: array<u32>;
+@group(0) @binding(5) var<storage, read_write> activeCountIn: atomic<u32>;
+@group(0) @binding(6) var<storage, read_write> activeCountOut: atomic<u32>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = ${wgSize}u;
+
+var<workgroup> sharedPrefix: array<u32, ${wgSize}>;
+var<workgroup> uReadyCount: u32;
+var<workgroup> uActiveListBase: u32;
+
+@compute @workgroup_size(${wgSize})
+fn refitInternalWave(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u
+) {
+	let threadIdx = globalId.x;
+	let localIdx = localId.x;
+	let activeCount = atomicLoad(&activeCountIn);
+
+	var readyParent = INVALID_IDX;
+	var isReady = false;
+
+	if (threadIdx < activeCount) {
+		let nodeIdx = activeListIn[threadIdx];
+		if (nodeIdx != INVALID_IDX) {
+			let node = bvh2Nodes[nodeIdx];
+			let c0 = node.leftChild;
+			let c1 = node.rightChild;
+			if (c0 != INVALID_IDX && c1 != INVALID_IDX) {
+				let mergedMin = min(bvh2Nodes[c0].boundsMin, bvh2Nodes[c1].boundsMin);
+				let mergedMax = max(bvh2Nodes[c0].boundsMax, bvh2Nodes[c1].boundsMax);
+				bvh2Nodes[nodeIdx].boundsMin = mergedMin;
+				bvh2Nodes[nodeIdx].boundsMax = mergedMax;
+
+				let p = parentIdx[nodeIdx];
+				if (p != nodeIdx && p != INVALID_IDX) {
+					let old = atomicAdd(&visitCount[p], 1u);
+					if (old == 1u) {
+						isReady = true;
+						readyParent = p;
+					}
+				}
+			}
+		}
+	}
+
+	// Workgroup-aggregated append: one global atomicAdd per workgroup.
+	sharedPrefix[localIdx] = select(0u, 1u, isReady);
+	workgroupBarrier();
+
+	for (var stride = 1u; stride < WORKGROUP_SIZE; stride = stride * 2u) {
+		var addVal = 0u;
+		if (localIdx >= stride) {
+			addVal = sharedPrefix[localIdx - stride];
+		}
+		workgroupBarrier();
+		sharedPrefix[localIdx] = sharedPrefix[localIdx] + addVal;
+		workgroupBarrier();
+	}
+
+	if (localIdx == 0u) {
+		uReadyCount = sharedPrefix[WORKGROUP_SIZE - 1u];
+		var base = 0u;
+		if (uReadyCount > 0u) {
+			base = atomicAdd(&activeCountOut, uReadyCount);
+		}
+		uActiveListBase = base;
+	}
+
+	let readyCount = workgroupUniformLoad(&uReadyCount);
+	let activeBase = workgroupUniformLoad(&uActiveListBase);
+	if (isReady && readyCount > 0u) {
+		let outIdx = activeBase + (sharedPrefix[localIdx] - 1u);
+		activeListOut[outIdx] = readyParent;
+	}
+}
+`;
+
+}

--- a/src/gpu/shaders/setup.wgsl.js
+++ b/src/gpu/shaders/setup.wgsl.js
@@ -1,0 +1,541 @@
+/**
+ * Setup shaders: Two passes
+ * Pass 1: Compute primitive bounds, initialize nodes, atomic reduce to scene bounds
+ * Pass 2: Compute Morton codes using scene bounds
+ *
+ * Optimization: Uses lock-free integer atomics for scene bounds - eliminates reduction passes
+ */
+
+// Pass 1: Compute bounds, initialize state, atomic update scene bounds
+export const computeBoundsShader = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	workgroupCount: u32,
+	positionStride: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+struct Bounds {
+	min: vec3f,
+	max: vec3f,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+// Zero-copy: read packed f32/u32 arrays directly (no vec4 padding)
+@group(0) @binding(1) var<storage, read> positions: array<f32>;
+@group(0) @binding(2) var<storage, read> indices: array<u32>;
+@group(0) @binding(3) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+// Phase 1 optimization: plain u32 instead of atomic - no contention on initial write
+@group(0) @binding(4) var<storage, read_write> clusterIdx: array<u32>;
+// Atomic scene bounds in sortable-u32 format:
+// [minX, minY, minZ, maxX, maxY, maxZ]
+@group(0) @binding(5) var<storage, read_write> atomicSceneBounds: array<atomic<u32>, 6>;
+// GPU-side initialization: moved from CPU
+@group(0) @binding(6) var<storage, read_write> parentIdx: array<u32>;
+@group(0) @binding(7) var<storage, read_write> hplocState: array<vec4u>;
+@group(0) @binding(8) var<storage, read_write> activeList: array<u32>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = 256u;
+
+var<workgroup> sharedMin: array<vec3f, WORKGROUP_SIZE>;
+var<workgroup> sharedMax: array<vec3f, WORKGROUP_SIZE>;
+
+// Map f32 to sortable u32 so unsigned integer order matches float order.
+// Negative values: invert all bits. Non-negative values: set sign bit.
+fn f32ToOrderedU32(val: f32) -> u32 {
+	let bits = bitcast<u32>(val);
+	return select(bits | 0x80000000u, ~bits, (bits & 0x80000000u) != 0u);
+}
+
+// Atomic min for f32 via native atomicMin on sortable-u32
+fn atomicMinF32(idx: u32, val: f32) {
+	atomicMin(&atomicSceneBounds[idx], f32ToOrderedU32(val));
+}
+
+// Atomic max for f32 via native atomicMax on sortable-u32
+fn atomicMaxF32(idx: u32, val: f32) {
+	atomicMax(&atomicSceneBounds[idx], f32ToOrderedU32(val));
+}
+
+// Load position from packed f32 array (configurable stride: 3 for vec3, 4 for vec4)
+fn loadPosition(vertexIdx: u32) -> vec3f {
+	let base = vertexIdx * uniforms.positionStride;
+	return vec3f(positions[base], positions[base + 1u], positions[base + 2u]);
+}
+
+fn computeTriangleBounds(primIdx: u32) -> Bounds {
+	// Load indices from packed u32 array (stride 3)
+	let base = primIdx * 3u;
+	let i0 = indices[base];
+	let i1 = indices[base + 1u];
+	let i2 = indices[base + 2u];
+
+	let v0 = loadPosition(i0);
+	let v1 = loadPosition(i1);
+	let v2 = loadPosition(i2);
+
+	var bounds: Bounds;
+	bounds.min = min(min(v0, v1), v2);
+	bounds.max = max(max(v0, v1), v2);
+	return bounds;
+}
+
+@compute @workgroup_size(256)
+fn computeBounds(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(workgroup_id) workgroupId: vec3u
+) {
+	let primIdx = globalId.x;
+	let localIdx = localId.x;
+
+	var localMin = vec3f(1e30);
+	var localMax = vec3f(-1e30);
+
+	if (primIdx < uniforms.primCount) {
+		let bounds = computeTriangleBounds(primIdx);
+
+		// Store as leaf node
+		var node: BVH2Node;
+		node.boundsMin = bounds.min;
+		node.boundsMax = bounds.max;
+		node.leftChild = INVALID_IDX;
+		node.rightChild = primIdx;
+		bvh2Nodes[primIdx] = node;
+
+		// Initialize cluster index (plain store - no atomic needed)
+		clusterIdx[primIdx] = primIdx;
+
+		// GPU-side initialization (moved from CPU)
+		parentIdx[primIdx] = INVALID_IDX;
+
+		// hplocState: vec4u(left, right, split, active) - single vectorized write
+		hplocState[primIdx] = vec4u(primIdx, primIdx, 0u, 1u);
+
+		// Initialize active list (folded from separate initActiveList dispatch)
+		activeList[primIdx] = primIdx;
+
+		localMin = bounds.min;
+		localMax = bounds.max;
+	}
+
+	sharedMin[localIdx] = localMin;
+	sharedMax[localIdx] = localMax;
+
+	workgroupBarrier();
+
+	// Workgroup reduction
+	for (var stride = WORKGROUP_SIZE / 2u; stride > 0u; stride = stride >> 1u) {
+		if (localIdx < stride) {
+			sharedMin[localIdx] = min(sharedMin[localIdx], sharedMin[localIdx + stride]);
+			sharedMax[localIdx] = max(sharedMax[localIdx], sharedMax[localIdx + stride]);
+		}
+		workgroupBarrier();
+	}
+
+	// Thread 0 atomically updates global scene bounds (eliminates reduction passes!)
+	if (localIdx == 0u) {
+		let wgMin = sharedMin[0];
+		let wgMax = sharedMax[0];
+
+		// Atomic min for each component of min bounds
+		atomicMinF32(0u, wgMin.x);
+		atomicMinF32(1u, wgMin.y);
+		atomicMinF32(2u, wgMin.z);
+
+		// Atomic max for each component of max bounds
+		atomicMaxF32(3u, wgMax.x);
+		atomicMaxF32(4u, wgMax.y);
+		atomicMaxF32(5u, wgMax.z);
+	}
+}
+`;
+
+// Pass 1b: Final reduction of partial bounds to single scene bounds
+export const reduceBoundsShader = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	workgroupCount: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct SceneBounds {
+	min: vec3f,
+	pad0: f32,
+	max: vec3f,
+	pad1: f32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> partialBoundsMin: array<vec4f>;
+@group(0) @binding(2) var<storage, read> partialBoundsMax: array<vec4f>;
+@group(0) @binding(3) var<storage, read_write> sceneBounds: SceneBounds;
+
+const WORKGROUP_SIZE: u32 = 256u;
+
+var<workgroup> sharedMin: array<vec3f, WORKGROUP_SIZE>;
+var<workgroup> sharedMax: array<vec3f, WORKGROUP_SIZE>;
+
+@compute @workgroup_size(256)
+fn reduceBounds(
+	@builtin(local_invocation_id) localId: vec3u
+) {
+	let localIdx = localId.x;
+
+	var localMin = vec3f(1e30);
+	var localMax = vec3f(-1e30);
+
+	// Load partial results
+	if (localIdx < uniforms.workgroupCount) {
+		localMin = partialBoundsMin[localIdx].xyz;
+		localMax = partialBoundsMax[localIdx].xyz;
+	}
+
+	sharedMin[localIdx] = localMin;
+	sharedMax[localIdx] = localMax;
+
+	workgroupBarrier();
+
+	// Reduction
+	for (var stride = WORKGROUP_SIZE / 2u; stride > 0u; stride = stride >> 1u) {
+		if (localIdx < stride) {
+			sharedMin[localIdx] = min(sharedMin[localIdx], sharedMin[localIdx + stride]);
+			sharedMax[localIdx] = max(sharedMax[localIdx], sharedMax[localIdx + stride]);
+		}
+		workgroupBarrier();
+	}
+
+	// Write final result
+	if (localIdx == 0u) {
+		sceneBounds.min = sharedMin[0];
+		sceneBounds.max = sharedMax[0];
+	}
+}
+`;
+
+// Pass 1b (multi-pass): Reduce partial bounds into a smaller partial set
+export const reduceBoundsToPartialShader = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	workgroupCount: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> partialBoundsMinIn: array<vec4f>;
+@group(0) @binding(2) var<storage, read> partialBoundsMaxIn: array<vec4f>;
+@group(0) @binding(3) var<storage, read_write> partialBoundsMinOut: array<vec4f>;
+@group(0) @binding(4) var<storage, read_write> partialBoundsMaxOut: array<vec4f>;
+
+const WORKGROUP_SIZE: u32 = 256u;
+
+var<workgroup> sharedMin: array<vec3f, WORKGROUP_SIZE>;
+var<workgroup> sharedMax: array<vec3f, WORKGROUP_SIZE>;
+
+@compute @workgroup_size(256)
+fn reduceBoundsToPartial(
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(workgroup_id) workgroupId: vec3u
+) {
+	let localIdx = localId.x;
+	let base = workgroupId.x * WORKGROUP_SIZE;
+	let idx = base + localIdx;
+
+	var localMin = vec3f(1e30);
+	var localMax = vec3f(-1e30);
+
+	// Load partial results
+	if (idx < uniforms.workgroupCount) {
+		localMin = partialBoundsMinIn[idx].xyz;
+		localMax = partialBoundsMaxIn[idx].xyz;
+	}
+
+	sharedMin[localIdx] = localMin;
+	sharedMax[localIdx] = localMax;
+
+	workgroupBarrier();
+
+	// Reduction
+	for (var stride = WORKGROUP_SIZE / 2u; stride > 0u; stride = stride >> 1u) {
+		if (localIdx < stride) {
+			sharedMin[localIdx] = min(sharedMin[localIdx], sharedMin[localIdx + stride]);
+			sharedMax[localIdx] = max(sharedMax[localIdx], sharedMax[localIdx + stride]);
+		}
+		workgroupBarrier();
+	}
+
+	// Write reduced result
+	if (localIdx == 0u) {
+		partialBoundsMinOut[workgroupId.x] = vec4f(sharedMin[0], 0.0);
+		partialBoundsMaxOut[workgroupId.x] = vec4f(sharedMax[0], 0.0);
+	}
+}
+`;
+
+// Pass 2: Compute Morton codes
+export const computeMortonShader = /* wgsl */ `
+
+struct Uniforms {
+	primCount: u32,
+	workgroupCount: u32,
+	pad0: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> bvh2Nodes: array<BVH2Node>;
+// Atomic scene bounds in sortable-u32 format:
+// [minX, minY, minZ, maxX, maxY, maxZ]
+@group(0) @binding(2) var<storage, read> atomicSceneBounds: array<u32, 6>;
+@group(0) @binding(3) var<storage, read_write> mortonCodes: array<u32>;
+
+fn orderedU32ToF32(key: u32) -> f32 {
+	let bits = select(key & 0x7FFFFFFFu, ~key, (key & 0x80000000u) == 0u);
+	return bitcast<f32>(bits);
+}
+
+fn expandBits(v: u32) -> u32 {
+	var x = v & 0x3FFu;
+	x = (x | (x << 16u)) & 0x030000FFu;
+	x = (x | (x << 8u)) & 0x0300F00Fu;
+	x = (x | (x << 4u)) & 0x030C30C3u;
+	x = (x | (x << 2u)) & 0x09249249u;
+	return x;
+}
+
+fn computeMortonCode(normalizedPos: vec3f) -> u32 {
+	let clamped = clamp(normalizedPos, vec3f(0.0), vec3f(1.0));
+	let scaled = vec3u(clamped * 1023.0);
+
+	let xx = expandBits(scaled.x);
+	let yy = expandBits(scaled.y);
+	let zz = expandBits(scaled.z);
+
+	return (xx << 2u) | (yy << 1u) | zz;
+}
+
+@compute @workgroup_size(256)
+fn computeMorton(
+	@builtin(global_invocation_id) globalId: vec3u
+) {
+	let primIdx = globalId.x;
+
+	if (primIdx >= uniforms.primCount) {
+		return;
+	}
+
+	let node = bvh2Nodes[primIdx];
+	let centroid = (node.boundsMin + node.boundsMax) * 0.5;
+
+	// Decode scene bounds from sortable-u32 format.
+	let sceneMin = vec3f(
+		orderedU32ToF32(atomicSceneBounds[0]),
+		orderedU32ToF32(atomicSceneBounds[1]),
+		orderedU32ToF32(atomicSceneBounds[2])
+	);
+	let sceneMax = vec3f(
+		orderedU32ToF32(atomicSceneBounds[3]),
+		orderedU32ToF32(atomicSceneBounds[4]),
+		orderedU32ToF32(atomicSceneBounds[5])
+	);
+
+	let sceneExtent = sceneMax - sceneMin;
+	let safeExtent = select(sceneExtent, vec3f(1.0), sceneExtent == vec3f(0.0));
+
+	let normalized = (centroid - sceneMin) / safeExtent;
+	mortonCodes[primIdx] = computeMortonCode(normalized);
+}
+`;
+
+// Subgroup-optimized version: uses subgroupMin/Max to reduce within subgroups first
+// This reduces workgroup barriers from 8 to ~3 (for subgroup_size=32)
+export const computeBoundsSubgroupShader = /* wgsl */ `
+enable subgroups;
+
+struct Uniforms {
+	primCount: u32,
+	workgroupCount: u32,
+	positionStride: u32,
+	pad1: u32,
+};
+
+struct BVH2Node {
+	boundsMin: vec3f,
+	leftChild: u32,
+	boundsMax: vec3f,
+	rightChild: u32,
+};
+
+struct Bounds {
+	min: vec3f,
+	max: vec3f,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(1) var<storage, read> positions: array<f32>;
+@group(0) @binding(2) var<storage, read> indices: array<u32>;
+@group(0) @binding(3) var<storage, read_write> bvh2Nodes: array<BVH2Node>;
+@group(0) @binding(4) var<storage, read_write> clusterIdx: array<u32>;
+@group(0) @binding(5) var<storage, read_write> atomicSceneBounds: array<atomic<u32>, 6>;
+@group(0) @binding(6) var<storage, read_write> parentIdx: array<u32>;
+@group(0) @binding(7) var<storage, read_write> hplocState: array<vec4u>;
+@group(0) @binding(8) var<storage, read_write> activeList: array<u32>;
+
+const INVALID_IDX: u32 = 0xFFFFFFFFu;
+const WORKGROUP_SIZE: u32 = 256u;
+
+// Shared memory sized for worst case (subgroupSize=1 means 256 subgroups)
+// Most GPUs have subgroupSize=32, so only 8 slots used, but we need to be safe
+var<workgroup> sharedMin: array<vec3f, WORKGROUP_SIZE>;
+var<workgroup> sharedMax: array<vec3f, WORKGROUP_SIZE>;
+
+fn f32ToOrderedU32(val: f32) -> u32 {
+	let bits = bitcast<u32>(val);
+	return select(bits | 0x80000000u, ~bits, (bits & 0x80000000u) != 0u);
+}
+
+fn atomicMinF32(idx: u32, val: f32) {
+	atomicMin(&atomicSceneBounds[idx], f32ToOrderedU32(val));
+}
+
+fn atomicMaxF32(idx: u32, val: f32) {
+	atomicMax(&atomicSceneBounds[idx], f32ToOrderedU32(val));
+}
+
+fn loadPosition(vertexIdx: u32) -> vec3f {
+	let base = vertexIdx * uniforms.positionStride;
+	return vec3f(positions[base], positions[base + 1u], positions[base + 2u]);
+}
+
+fn computeTriangleBounds(primIdx: u32) -> Bounds {
+	let base = primIdx * 3u;
+	let i0 = indices[base];
+	let i1 = indices[base + 1u];
+	let i2 = indices[base + 2u];
+
+	let v0 = loadPosition(i0);
+	let v1 = loadPosition(i1);
+	let v2 = loadPosition(i2);
+
+	var bounds: Bounds;
+	bounds.min = min(min(v0, v1), v2);
+	bounds.max = max(max(v0, v1), v2);
+	return bounds;
+}
+
+@compute @workgroup_size(256)
+fn computeBounds(
+	@builtin(global_invocation_id) globalId: vec3u,
+	@builtin(local_invocation_id) localId: vec3u,
+	@builtin(subgroup_invocation_id) subgroupInvocationId: u32,
+	@builtin(subgroup_size) subgroupSize: u32
+) {
+	let primIdx = globalId.x;
+	let localIdx = localId.x;
+	let subgroupIdx = localIdx / subgroupSize;
+
+	var localMin = vec3f(1e30);
+	var localMax = vec3f(-1e30);
+
+	if (primIdx < uniforms.primCount) {
+		let bounds = computeTriangleBounds(primIdx);
+
+		// Store as leaf node
+		var node: BVH2Node;
+		node.boundsMin = bounds.min;
+		node.boundsMax = bounds.max;
+		node.leftChild = INVALID_IDX;
+		node.rightChild = primIdx;
+		bvh2Nodes[primIdx] = node;
+
+		// Initialize cluster index
+		clusterIdx[primIdx] = primIdx;
+
+		// GPU-side initialization
+		parentIdx[primIdx] = INVALID_IDX;
+
+		// hplocState: vec4u(left, right, split, active) - single vectorized write
+		hplocState[primIdx] = vec4u(primIdx, primIdx, 0u, 1u);
+
+		// Initialize active list (folded from separate initActiveList dispatch)
+		activeList[primIdx] = primIdx;
+
+		localMin = bounds.min;
+		localMax = bounds.max;
+	}
+
+	// Subgroup reduction - no barrier needed, hardware handles it
+	let sgMinX = subgroupMin(localMin.x);
+	let sgMinY = subgroupMin(localMin.y);
+	let sgMinZ = subgroupMin(localMin.z);
+	let sgMaxX = subgroupMax(localMax.x);
+	let sgMaxY = subgroupMax(localMax.y);
+	let sgMaxZ = subgroupMax(localMax.z);
+
+	// subgroupSize is uniform within workgroup, so this is uniform (no barrier needed)
+	let subgroupCount = WORKGROUP_SIZE / subgroupSize;
+
+	// First thread of each subgroup writes to shared memory
+	if (subgroupInvocationId == 0u) {
+		sharedMin[subgroupIdx] = vec3f(sgMinX, sgMinY, sgMinZ);
+		sharedMax[subgroupIdx] = vec3f(sgMaxX, sgMaxY, sgMaxZ);
+	}
+
+	workgroupBarrier();
+
+	// Final reduction: tree reduction across subgroup results
+	// Use fixed iteration count for uniform control flow (8 iterations covers up to 256 subgroups)
+	// Each iteration halves the active range until only element 0 remains
+	for (var s = 128u; s > 0u; s = s >> 1u) {
+		// Only reduce if this stride is within our subgroup count
+		if (s < subgroupCount && localIdx < s) {
+			sharedMin[localIdx] = min(sharedMin[localIdx], sharedMin[localIdx + s]);
+			sharedMax[localIdx] = max(sharedMax[localIdx], sharedMax[localIdx + s]);
+		}
+		workgroupBarrier();
+	}
+
+	// Thread 0 atomically updates global scene bounds
+	if (localIdx == 0u) {
+		let wgMin = sharedMin[0];
+		let wgMax = sharedMax[0];
+		atomicMinF32(0u, wgMin.x);
+		atomicMinF32(1u, wgMin.y);
+		atomicMinF32(2u, wgMin.z);
+		atomicMaxF32(3u, wgMax.x);
+		atomicMaxF32(4u, wgMax.y);
+		atomicMaxF32(5u, wgMax.z);
+	}
+}
+`;
+
+// Combined export for backwards compatibility
+export const setupShader = computeBoundsShader;
+
+export const setupShaders = {
+	computeBounds: computeBoundsShader,
+	computeBoundsSubgroup: computeBoundsSubgroupShader,
+	reduceBounds: reduceBoundsShader,
+	reduceBoundsToPartial: reduceBoundsToPartialShader,
+	computeMorton: computeMortonShader,
+};

--- a/src/gpu/sorting/BaseSorter.js
+++ b/src/gpu/sorting/BaseSorter.js
@@ -1,0 +1,66 @@
+/**
+ * Base class for GPU sorting implementations.
+ * All sorters must implement this interface.
+ */
+export class BaseSorter {
+
+	constructor( device ) {
+
+		this.device = device;
+		this.name = 'BaseSorter';
+		this._initialized = false;
+
+	}
+
+	/**
+	 * Initialize the sorter (create pipelines, allocate buffers)
+	 * @param {number} maxKeys - Maximum number of keys to sort
+	 * @returns {Promise<void>}
+	 */
+	async init( _maxKeys ) {
+
+		void _maxKeys;
+		throw new Error( 'BaseSorter.init() must be implemented by subclass' );
+
+	}
+
+	/**
+	 * Sort keys and values in place (or into output buffers)
+	 * @param {Object} params
+	 * @param {GPUCommandEncoder} params.commandEncoder - Command encoder to record commands to
+	 * @param {GPUBuffer} params.keysIn - Input keys buffer
+	 * @param {GPUBuffer} params.keysOut - Output keys buffer (may be same as keysIn)
+	 * @param {GPUBuffer} params.valsIn - Input values buffer
+	 * @param {GPUBuffer} params.valsOut - Output values buffer (may be same as valsIn)
+	 * @param {number} params.count - Number of elements to sort
+	 * @param {GPUBuffer} [params.uniforms] - Optional uniforms buffer
+	 * @param {number} [params.uniformOffset] - Offset into uniforms buffer
+	 * @returns {Object} - { keysResult, valsResult } - buffers containing sorted results
+	 */
+	sort( _params ) {
+
+		void _params;
+		throw new Error( 'BaseSorter.sort() must be implemented by subclass' );
+
+	}
+
+	/**
+	 * Dispose of GPU resources
+	 */
+	dispose() {
+
+		// Override in subclass
+
+	}
+
+	/**
+	 * Get timing information from last sort (if available)
+	 * @returns {Object|null}
+	 */
+	getTimings() {
+
+		return null;
+
+	}
+
+}

--- a/src/gpu/sorting/OneSweepSorter.js
+++ b/src/gpu/sorting/OneSweepSorter.js
@@ -1,0 +1,467 @@
+/**
+ * OneSweep Radix Sort - High-performance GPU sorting
+ * Based on Thomas Smith's GPUSorting library
+ * https://github.com/b0nes164/GPUSorting
+ *
+ * Adapted for three-mesh-bvh by following the webgpu-sorting port.
+ * Uses subgroup operations for maximum performance.
+ */
+import { BaseSorter } from './BaseSorter.js';
+import {
+	oneSweep16Shader,
+	oneSweep32Shader,
+	oneSweep64Shader,
+	subgroupDetectShader,
+} from './shaders/onesweep.wgsl.js';
+
+const SORT_PASSES = 4;
+const BLOCK_DIM = 256;
+const RADIX = 256;
+const RADIX_LOG = 8;
+const KEYS_PER_THREAD = 15;
+const REDUCE_BLOCK_DIM = 128;
+const REDUCE_KEYS_PER_THREAD = 30;
+const STATUS_LENGTH = 4; // 0=global_hist, 1=scan, 2=pass, 3=lane_count
+
+export class OneSweepSorter extends BaseSorter {
+
+	constructor( device ) {
+
+		super( device );
+		this.name = 'OneSweep';
+		this._pipelines = null;
+		this._buffers = null;
+		this._bindGroupLayout = null;
+		this._maxKeys = 0;
+		this._subgroupSize = 0;
+		this._shaderVariantLabel = '';
+
+		this.blockDim = BLOCK_DIM;
+		this.reduceBlockDim = REDUCE_BLOCK_DIM;
+		this.partSize = this.blockDim * KEYS_PER_THREAD;
+		this.reducePartSize = this.reduceBlockDim * REDUCE_KEYS_PER_THREAD;
+
+		// Pre-allocate small buffer for FLAG_INCLUSIVE initialization (256 u32s)
+		// Avoids large allocation every sort() call
+		const FLAG_INCLUSIVE = 2;
+		this._flagInclusiveBlock = new Uint32Array( RADIX );
+		this._flagInclusiveBlock.fill( FLAG_INCLUSIVE );
+
+		// Pre-allocate buffer for pass info uploads (4 passes × 4 u32s)
+		this._infoUploadData = new Uint32Array( SORT_PASSES * 4 );
+
+	}
+
+	async init( maxKeys ) {
+
+		this._maxKeys = maxKeys;
+		const device = this.device;
+
+		// Detect subgroup size
+		const subgroupSize = await this._detectSubgroupSize();
+		const { shaderSource, label } = this._selectShaderVariant( subgroupSize );
+		this._shaderVariantLabel = label;
+
+		// Create shader module
+		const shaderModule = device.createShaderModule( {
+			label: `OneSweep Shader (${label})`,
+			code: shaderSource,
+		} );
+
+		// Check for compilation errors
+		const compilationInfo = await shaderModule.getCompilationInfo();
+		for ( const msg of compilationInfo.messages ) {
+
+			if ( msg.type === 'error' ) {
+
+				throw new Error( `OneSweep shader compilation error: ${msg.message} at line ${msg.lineNum}` );
+
+			}
+
+		}
+
+		// Create bind group layout
+		this._bindGroupLayout = device.createBindGroupLayout( {
+			entries: [
+				{ binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+				{ binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+				{ binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+				{ binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+				{ binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+				{ binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+				{ binding: 6, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+				{ binding: 7, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+				{ binding: 8, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+			],
+		} );
+
+		const pipelineLayout = device.createPipelineLayout( {
+			bindGroupLayouts: [ this._bindGroupLayout ],
+		} );
+
+		// Create pipelines
+		this._pipelines = {
+			globalHist: device.createComputePipeline( {
+				layout: pipelineLayout,
+				compute: { module: shaderModule, entryPoint: 'global_hist' },
+			} ),
+			scan: device.createComputePipeline( {
+				layout: pipelineLayout,
+				compute: { module: shaderModule, entryPoint: 'onesweep_scan' },
+			} ),
+			pass: device.createComputePipeline( {
+				layout: pipelineLayout,
+				compute: { module: shaderModule, entryPoint: 'onesweep_pass' },
+			} ),
+		};
+
+		// Create internal buffers
+		this._createBuffers( maxKeys );
+
+		this._initialized = true;
+
+	}
+
+	_createBuffers( maxKeys ) {
+
+		const device = this.device;
+		const threadBlocks = Math.ceil( maxKeys / this.partSize );
+
+		// Destroy old buffers if present
+		if ( this._buffers ) {
+
+			for ( const key in this._buffers ) {
+
+				this._buffers[ key ]?.destroy();
+
+			}
+
+		}
+
+		this._buffers = {
+			// Internal alt buffers for ping-pong
+			altKeys: device.createBuffer( {
+				size: Math.max( 16, maxKeys * 4 ),
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+			} ),
+			altVals: device.createBuffer( {
+				size: Math.max( 16, maxKeys * 4 ),
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+			} ),
+
+			// Bump counter for workgroup scheduling
+			bump: device.createBuffer( {
+				size: ( SORT_PASSES + 1 ) * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Global histogram
+			hist: device.createBuffer( {
+				size: RADIX * SORT_PASSES * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Per-block histograms for decoupled lookback
+			passHist: device.createBuffer( {
+				size: threadBlocks * RADIX * SORT_PASSES * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Status/error buffer
+			status: device.createBuffer( {
+				size: STATUS_LENGTH * 4,
+				usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Uniforms
+			info: device.createBuffer( {
+				size: 16,
+				usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Upload buffer for info data (all 4 passes)
+			infoUpload: device.createBuffer( {
+				size: 16 * SORT_PASSES,
+				usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+			} ),
+
+			// Staging buffer for FLAG_INCLUSIVE initialization (256 u32s per pass = 1024 u32s total)
+			// Used to avoid race between writeBuffer (immediate) and clearBuffer (recorded)
+			flagInclusiveStaging: device.createBuffer( {
+				size: RADIX * SORT_PASSES * 4,
+				usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+			} ),
+		};
+
+	}
+
+	/**
+	 * Sort using command encoder (records commands, doesn't submit)
+	 */
+	sort( params ) {
+
+		const { commandEncoder, keysIn, valsIn, count } = params;
+		const device = this.device;
+
+		// Reallocate if needed
+		if ( count > this._maxKeys ) {
+
+			this._maxKeys = count;
+			this._createBuffers( count );
+
+		}
+
+		const threadBlocks = Math.ceil( count / this.partSize );
+
+		// Initialize bump counters
+		commandEncoder.clearBuffer( this._buffers.bump );
+
+		// Initialize hist
+		commandEncoder.clearBuffer( this._buffers.hist );
+
+		// Initialize status
+		commandEncoder.clearBuffer( this._buffers.status );
+
+		// Initialize passHist: clear to 0, then set FLAG_INCLUSIVE for first block of each pass
+		// This avoids allocating/uploading a huge array every build (was ~324KB for 300k tris)
+		commandEncoder.clearBuffer( this._buffers.passHist );
+
+		// Write FLAG_INCLUSIVE (256 u32s) at the start of each pass's section
+		// Use staging buffer + copyBufferToBuffer to avoid race condition:
+		// writeBuffer is IMMEDIATE while clearBuffer is RECORDED, so direct writeBuffer
+		// would be wiped by the clearBuffer when the command encoder executes.
+		// By using copyBufferToBuffer (recorded), FLAG_INCLUSIVE copies happen AFTER the clear.
+		const passHistStrideBytes = threadBlocks * RADIX * 4;
+		const stagingStrideBytes = RADIX * 4; // 256 * 4 = 1024 bytes per pass
+
+		// Upload FLAG_INCLUSIVE data to staging buffer (immediate, but to staging not passHist)
+		for ( let pass = 0; pass < SORT_PASSES; pass ++ ) {
+
+			device.queue.writeBuffer(
+				this._buffers.flagInclusiveStaging,
+				pass * stagingStrideBytes,
+				this._flagInclusiveBlock
+			);
+
+		}
+
+		// Copy from staging to passHist (recorded, executes AFTER clearBuffer)
+		for ( let pass = 0; pass < SORT_PASSES; pass ++ ) {
+
+			commandEncoder.copyBufferToBuffer(
+				this._buffers.flagInclusiveStaging, pass * stagingStrideBytes,
+				this._buffers.passHist, pass * passHistStrideBytes,
+				stagingStrideBytes
+			);
+
+		}
+
+		// Pre-upload all pass info (using pre-allocated buffer to avoid GC pressure)
+		for ( let pass = 0; pass < SORT_PASSES; pass ++ ) {
+
+			const offset = pass * 4;
+			this._infoUploadData[ offset + 0 ] = count;
+			this._infoUploadData[ offset + 1 ] = pass * RADIX_LOG; // shift
+			this._infoUploadData[ offset + 2 ] = threadBlocks;
+			this._infoUploadData[ offset + 3 ] = 0;
+
+		}
+
+		device.queue.writeBuffer( this._buffers.infoUpload, 0, this._infoUploadData );
+
+		// Execute passes
+		// Buffer ping-pong: even passes read from keysIn/valsIn, write to alt
+		// odd passes read from alt, write to keysIn/valsIn
+		for ( let pass = 0; pass < SORT_PASSES; pass ++ ) {
+
+			// Copy info for this pass
+			commandEncoder.copyBufferToBuffer(
+				this._buffers.infoUpload, pass * 16,
+				this._buffers.info, 0, 16
+			);
+
+			const isEven = pass % 2 === 0;
+			const sortIn = isEven ? keysIn : this._buffers.altKeys;
+			const sortOut = isEven ? this._buffers.altKeys : keysIn;
+			const payloadIn = isEven ? valsIn : this._buffers.altVals;
+			const payloadOut = isEven ? this._buffers.altVals : valsIn;
+
+			const bindGroup = device.createBindGroup( {
+				layout: this._bindGroupLayout,
+				entries: [
+					{ binding: 0, resource: { buffer: this._buffers.info } },
+					{ binding: 1, resource: { buffer: this._buffers.bump } },
+					{ binding: 2, resource: { buffer: sortIn } },
+					{ binding: 3, resource: { buffer: sortOut } },
+					{ binding: 4, resource: { buffer: payloadIn } },
+					{ binding: 5, resource: { buffer: payloadOut } },
+					{ binding: 6, resource: { buffer: this._buffers.hist } },
+					{ binding: 7, resource: { buffer: this._buffers.passHist } },
+					{ binding: 8, resource: { buffer: this._buffers.status } },
+				],
+			} );
+
+			// Global histogram (only on first pass)
+			if ( pass === 0 ) {
+
+				const passEncoder = commandEncoder.beginComputePass();
+				passEncoder.setPipeline( this._pipelines.globalHist );
+				passEncoder.setBindGroup( 0, bindGroup );
+				const globalHistBlocks = Math.ceil( count / this.reducePartSize );
+				passEncoder.dispatchWorkgroups( globalHistBlocks );
+				passEncoder.end();
+
+			}
+
+			// Scan
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				passEncoder.setPipeline( this._pipelines.scan );
+				passEncoder.setBindGroup( 0, bindGroup );
+				passEncoder.dispatchWorkgroups( 1 );
+				passEncoder.end();
+
+			}
+
+			// OneSweep pass
+			{
+
+				const passEncoder = commandEncoder.beginComputePass();
+				passEncoder.setPipeline( this._pipelines.pass );
+				passEncoder.setBindGroup( 0, bindGroup );
+				passEncoder.dispatchWorkgroups( threadBlocks );
+				passEncoder.end();
+
+			}
+
+		}
+
+		// After 4 passes (even number), result is back in keysIn/valsIn
+		return { keysResult: keysIn, valsResult: valsIn };
+
+	}
+
+	async _detectSubgroupSize() {
+
+		if ( this._subgroupSize > 0 ) {
+
+			return this._subgroupSize;
+
+		}
+
+		const device = this.device;
+
+		const module = device.createShaderModule( {
+			label: 'Subgroup Probe',
+			code: subgroupDetectShader,
+		} );
+
+		const pipeline = device.createComputePipeline( {
+			layout: 'auto',
+			compute: { module, entryPoint: 'main' },
+		} );
+
+		const outputBuffer = device.createBuffer( {
+			size: 4,
+			usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+		} );
+
+		const stagingBuffer = device.createBuffer( {
+			size: 4,
+			usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+		} );
+
+		const bindGroup = device.createBindGroup( {
+			layout: pipeline.getBindGroupLayout( 0 ),
+			entries: [ { binding: 0, resource: { buffer: outputBuffer } } ],
+		} );
+
+		const encoder = device.createCommandEncoder();
+		const pass = encoder.beginComputePass();
+		pass.setPipeline( pipeline );
+		pass.setBindGroup( 0, bindGroup );
+		pass.dispatchWorkgroups( 1 );
+		pass.end();
+		encoder.copyBufferToBuffer( outputBuffer, 0, stagingBuffer, 0, 4 );
+		device.queue.submit( [ encoder.finish() ] );
+
+		await device.queue.onSubmittedWorkDone();
+
+		try {
+
+			await stagingBuffer.mapAsync( GPUMapMode.READ );
+			const detected = new Uint32Array( stagingBuffer.getMappedRange() )[ 0 ];
+			stagingBuffer.unmap();
+			this._subgroupSize = detected !== 0 ? detected : 16;
+
+		} finally {
+
+			stagingBuffer.destroy();
+			outputBuffer.destroy();
+
+		}
+
+		return this._subgroupSize;
+
+	}
+
+	_selectShaderVariant( size ) {
+
+		// Strict shader selection based on subgroup size:
+		// - wave64: uses vec4 masks, works for any size > 32
+		// - wave32: requires exactly 32 (MIN_SUBGROUP_SIZE = 32 in shader)
+		// - wave16: works for 16-32 (MIN_SUBGROUP_SIZE = 16 in shader)
+		if ( size > 32 ) {
+
+			return { shaderSource: oneSweep64Shader, label: 'wave64' };
+
+		}
+
+		if ( size === 32 ) {
+
+			return { shaderSource: oneSweep32Shader, label: 'wave32' };
+
+		}
+
+		if ( size >= 16 ) {
+
+			return { shaderSource: oneSweep16Shader, label: 'wave16' };
+
+		}
+
+		console.warn( `OneSweepSorter: detected subgroup size ${size}, below minimum (16). Forcing wave16.` );
+		return { shaderSource: oneSweep16Shader, label: 'wave16 (forced)' };
+
+	}
+
+	dispose() {
+
+		if ( this._buffers ) {
+
+			for ( const key in this._buffers ) {
+
+				this._buffers[ key ]?.destroy();
+
+			}
+
+			this._buffers = null;
+
+		}
+
+	}
+
+	// Minimal validation getters (added for debugging)
+	get subgroupSize() {
+
+		return this._subgroupSize;
+
+	}
+
+	get shaderVariant() {
+
+		return this._shaderVariantLabel;
+
+	}
+
+}

--- a/src/gpu/sorting/index.js
+++ b/src/gpu/sorting/index.js
@@ -1,0 +1,16 @@
+/**
+ * GPU Sorting Module
+ *
+ * Provides GPU radix sort implementations.
+ * - OneSweepSorter: High-performance implementation (15 elements/thread, subgroup ops)
+ */
+
+export { BaseSorter } from './BaseSorter.js';
+export { OneSweepSorter } from './OneSweepSorter.js';
+
+/**
+ * Available sorter types for configuration
+ */
+export const SorterType = {
+	ONESWEEP: 'onesweep',
+};

--- a/src/gpu/sorting/shaders/onesweep.wgsl.js
+++ b/src/gpu/sorting/shaders/onesweep.wgsl.js
@@ -1,0 +1,1461 @@
+export const oneSweep16Shader = `
+//****************************************************************************
+// GPUSorting
+// OneSweep - WaveSize 16-32 variant
+//
+// SPDX-License-Identifier: MIT
+// Copyright Thomas Smith 12/7/2024
+// https://github.com/b0nes164/GPUSorting
+//
+// Modified for WGSL compatibility and variable subgroup sizes by Dino Metarapi, 2025
+// Based on original work by Thomas Smith
+//
+// NOTE: This shader uses ballot.x (32 bits) for peer masks, so it only works
+// for lane_count <= 32. For lane_count > 32, use the wave64 variant.
+//****************************************************************************
+
+enable subgroups;
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupInclusiveAdd(x: u32) -> u32 { return subgroupInclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupExclusiveAdd(x: u32) -> u32 { return subgroupExclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffle(x: u32, source: u32) -> u32 { return subgroupShuffle(x, source); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupBallot(pred: bool) -> vec4<u32> { return subgroupBallot(pred); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupAdd(x: u32) -> u32 { return subgroupAdd(x); }
+
+struct InfoStruct
+{
+    size: u32,
+    shift: u32,
+    thread_blocks: u32,
+    seed: u32,
+};
+
+@group(0) @binding(0)
+var<uniform> info : InfoStruct;
+
+@group(0) @binding(1)
+var<storage, read_write> bump: array<atomic<u32>>;
+
+@group(0) @binding(2)
+var<storage, read_write> sort: array<u32>;
+
+@group(0) @binding(3)
+var<storage, read_write> alt: array<u32>;
+
+@group(0) @binding(4)
+var<storage, read_write> payload: array<u32>;
+
+@group(0) @binding(5)
+var<storage, read_write> alt_payload: array<u32>;
+
+@group(0) @binding(6)
+var<storage, read_write> hist: array<atomic<u32>>;
+
+@group(0) @binding(7)
+var<storage, read_write> pass_hist: array<atomic<u32>>;
+
+@group(0) @binding(8)
+var<storage, read_write> status: array<u32>;
+
+const SORT_PASSES = 4u;
+const BLOCK_DIM = 256u;
+const MIN_SUBGROUP_SIZE = 16u;
+const MAX_SUBGROUP_SIZE_W16 = 32u;  // ballot.x is only 32 bits - wave16 max
+const MAX_REDUCE_SIZE = BLOCK_DIM / MIN_SUBGROUP_SIZE;
+
+const STATUS_ERR_GLOBAL_HIST = 0u;
+const STATUS_ERR_SCAN = 1u;
+const STATUS_ERR_PASS = 2u;
+const STATUS_ERR_LANE_COUNT = 3u;
+
+const FLAG_NOT_READY = 0u;
+const FLAG_REDUCTION = 1u;
+const FLAG_INCLUSIVE = 2u;
+const FLAG_MASK = 3u;
+
+const RADIX = 256u;
+const ALL_RADIX = RADIX * SORT_PASSES;
+const RADIX_MASK = 255u;
+const RADIX_LOG = 8u;
+
+const KEYS_PER_THREAD = 15u;
+const PART_SIZE = KEYS_PER_THREAD * BLOCK_DIM;
+
+const REDUCE_BLOCK_DIM = 128u;
+const REDUCE_KEYS_PER_THREAD = 30u;
+const REDUCE_HIST_SIZE = REDUCE_BLOCK_DIM / MIN_SUBGROUP_SIZE * ALL_RADIX;
+const REDUCE_PART_SIZE = REDUCE_KEYS_PER_THREAD * REDUCE_BLOCK_DIM;
+
+const MAX_SUBGROUPS_PER_BLOCK = BLOCK_DIM / MIN_SUBGROUP_SIZE;
+const WARP_HIST_CAPACITY = MAX_SUBGROUPS_PER_BLOCK * RADIX;
+
+var<workgroup> wg_globalHist: array<atomic<u32>, REDUCE_HIST_SIZE>;
+
+@compute @workgroup_size(REDUCE_BLOCK_DIM, 1, 1)
+fn global_hist(
+    @builtin(local_invocation_id) threadid: vec3<u32>,
+    @builtin(subgroup_invocation_id) laneid: u32,
+    @builtin(subgroup_size) lane_count: u32,
+    @builtin(workgroup_id) wgid: vec3<u32>) {
+
+    if (lane_count < MIN_SUBGROUP_SIZE || (REDUCE_BLOCK_DIM % lane_count) != 0u) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_GLOBAL_HIST] = 0xDEAD0001u;
+        }
+        return;
+    }
+
+    let sid = threadid.x / lane_count;
+
+    //Clear shared memory
+    for (var i = threadid.x; i < REDUCE_HIST_SIZE; i += REDUCE_BLOCK_DIM) {
+        atomicStore(&wg_globalHist[i], 0u);
+    }
+    workgroupBarrier();
+
+    let radix_shift = info.shift;
+    let hist_offset = sid * ALL_RADIX;
+    {
+        var i = threadid.x + wgid.x * REDUCE_PART_SIZE;
+        if(wgid.x < info.thread_blocks - 1) {
+            for (var k = 0u; k < REDUCE_KEYS_PER_THREAD; k += 1u) {
+                let key = sort[i];
+                atomicAdd(&wg_globalHist[(key & RADIX_MASK) + hist_offset], 1u);
+                atomicAdd(&wg_globalHist[((key >> 8u) & RADIX_MASK) + hist_offset + 256u], 1u);
+                atomicAdd(&wg_globalHist[((key >> 16u) & RADIX_MASK) + hist_offset + 512u], 1u);
+                atomicAdd(&wg_globalHist[((key >> 24u) & RADIX_MASK) + hist_offset + 768u], 1u);
+                i += REDUCE_BLOCK_DIM;
+            }
+        }
+
+        if(wgid.x == info.thread_blocks - 1) {
+            for (var k = 0u; k < REDUCE_KEYS_PER_THREAD; k += 1u) {
+                if (i < info.size) {
+                    let key = sort[i];
+                    atomicAdd(&wg_globalHist[(key & RADIX_MASK) + hist_offset], 1u);
+                    atomicAdd(&wg_globalHist[((key >> 8u) & RADIX_MASK) + hist_offset + 256u], 1u);
+                    atomicAdd(&wg_globalHist[((key >> 16u) & RADIX_MASK) + hist_offset + 512u], 1u);
+                    atomicAdd(&wg_globalHist[((key >> 24u) & RADIX_MASK) + hist_offset + 768u], 1u);
+                }
+                i += REDUCE_BLOCK_DIM;
+            }
+        }
+    }
+    workgroupBarrier();
+
+    // Merge subgroup histograms
+    let subgroup_histograms = REDUCE_BLOCK_DIM / lane_count;
+    for(var i = threadid.x; i < RADIX; i += REDUCE_BLOCK_DIM) {
+        var reduction0 = atomicLoad(&wg_globalHist[i]);
+        var reduction1 = atomicLoad(&wg_globalHist[i + 256u]);
+        var reduction2 = atomicLoad(&wg_globalHist[i + 512u]);
+        var reduction3 = atomicLoad(&wg_globalHist[i + 768u]);
+
+        for (var h = 1u; h < subgroup_histograms; h += 1u) {
+            let idx = h * ALL_RADIX;
+            reduction0 += atomicLoad(&wg_globalHist[i + idx]);
+            reduction1 += atomicLoad(&wg_globalHist[i + 256u + idx]);
+            reduction2 += atomicLoad(&wg_globalHist[i + 512u + idx]);
+            reduction3 += atomicLoad(&wg_globalHist[i + 768u + idx]);
+        }
+
+        atomicAdd(&hist[i], reduction0);
+        atomicAdd(&hist[i + 256u], reduction1);
+        atomicAdd(&hist[i + 512u], reduction2);
+        atomicAdd(&hist[i + 768u], reduction3);
+    }
+}
+
+//Assumes block dim 256
+const SCAN_MEM_SIZE = RADIX / MIN_SUBGROUP_SIZE;
+var<workgroup> wg_scan: array<u32, SCAN_MEM_SIZE>;
+@compute @workgroup_size(BLOCK_DIM, 1, 1)
+fn onesweep_scan(
+    @builtin(local_invocation_id) threadid: vec3<u32>,
+    @builtin(subgroup_invocation_id) laneid: u32,
+    @builtin(subgroup_size) lane_count: u32,
+    @builtin(workgroup_id) wgid: vec3<u32>) {
+
+    if (lane_count < MIN_SUBGROUP_SIZE || (BLOCK_DIM % lane_count) != 0u) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_SCAN] = 0xDEAD0002u;
+        }
+        return;
+    }
+
+    let sid = threadid.x / lane_count;
+    let pass_plane = info.shift >> 3u;
+    let hist_index = threadid.x + pass_plane * RADIX;
+    let scan = atomicLoad(&hist[hist_index]);
+    let red = unsafeSubgroupAdd(scan);
+    if(laneid == 0u){
+        wg_scan[sid] = red;
+    }
+    workgroupBarrier();
+
+    //Non-divergent subgroup agnostic inclusive scan across subgroup reductions
+    {
+        var offset0 = 0u;
+        var offset1 = 0u;
+        let lane_log = u32(countTrailingZeros(lane_count));
+        let spine_size = BLOCK_DIM >> lane_log;
+        let aligned_size = 1u << ((u32(countTrailingZeros(spine_size)) + lane_log - 1u) / lane_log * lane_log);
+        for(var j = lane_count; j <= aligned_size; j <<= lane_log){
+            let i0 = ((threadid.x + offset0) << offset1) - select(0u, 1u, j != lane_count);
+            let pred0 = i0 < spine_size;
+            let t0 = unsafeSubgroupInclusiveAdd(select(0u, wg_scan[i0], pred0));
+            if(pred0){
+                wg_scan[i0] = t0;
+            }
+            workgroupBarrier();
+
+            if(j != lane_count){
+                let rshift = j >> lane_log;
+                let i1 = threadid.x + rshift;
+                if ((i1 & (j - 1u)) >= rshift){
+                    let pred1 = i1 < spine_size;
+                    let t1 = select(0u, wg_scan[((i1 >> offset1) << offset1) - 1u], pred1);
+                    if(pred1 && ((i1 + 1u) & (rshift - 1u)) != 0u){
+                        wg_scan[i1] += t1;
+                    }
+                }
+            } else {
+                offset0 += 1u;
+            }
+            offset1 += lane_log;
+        }
+    }
+    workgroupBarrier();
+
+    if (wgid.x != 0u) {
+        return;
+    }
+
+    let plane_stride = info.thread_blocks * RADIX;
+    let pass_index = threadid.x + pass_plane * plane_stride;
+    let subgroup_prefix = unsafeSubgroupExclusiveAdd(scan);
+    var spine_prefix = 0u;
+    if (sid > 0u) {
+        spine_prefix = wg_scan[sid - 1u];
+    }
+    atomicStore(&pass_hist[pass_index], ((subgroup_prefix + spine_prefix) << 2u) | FLAG_INCLUSIVE);
+}
+
+var<workgroup> wg_subgroupHist: array<atomic<u32>, WARP_HIST_CAPACITY>;
+var<workgroup> wg_localHist: array<u32, RADIX>;
+var<workgroup> wg_broadcast: u32;
+
+// Wave16 WLMS: uses ballot.x (32 bits) - only valid for lane_count <= 32
+fn WLMS(key: u32, shift: u32, laneid: u32, lane_count: u32, lane_mask_lt: u32, s_offset: u32, key_valid: bool) -> u32 {
+    // FIX: Compute valid_mask FIRST to exclude invalid lanes from peer groups.
+    // Without this, invalid lanes (key_valid=false) look like "bit=0" lanes during ballot,
+    // allowing them to join peer groups with valid keys. If an invalid lane becomes
+    // highest_rank_peer, the atomicAdd is skipped (gated by key_valid), causing missing
+    // histogram increments → offset collisions → duplicates/missing elements.
+    let valid_mask = unsafeSubgroupBallot(key_valid).x;
+
+    var eq_mask = 0xffffffffu;
+    for (var k = 0u; k < RADIX_LOG; k += 1u) {
+        let curr_bit = 1u << (k + shift);
+        let pred = key_valid && ((key & curr_bit) != 0u);
+        let ballot = unsafeSubgroupBallot(pred);
+        eq_mask &= select(~ballot.x, ballot.x, pred);
+    }
+
+    // Remove invalid lanes from the peer group (critical fix for partial last partitions)
+    eq_mask &= valid_mask;
+
+    var subgroup_mask = 0xffffffffu;
+    if (lane_count != 32u) {
+        subgroup_mask = (1u << lane_count) - 1u;
+    }
+    eq_mask &= subgroup_mask;
+
+    if (!key_valid) {
+        eq_mask = 0u;
+    }
+    var out = countOneBits(eq_mask & lane_mask_lt);
+    let highest_rank_peer = select(lane_count - 1u, 31u - countLeadingZeros(eq_mask), eq_mask != 0u);
+    var pre_inc = 0u;
+    if (key_valid && eq_mask != 0u && laneid == highest_rank_peer) {
+        pre_inc = atomicAdd(&wg_subgroupHist[((key >> shift) & RADIX_MASK) + s_offset], out + 1u);
+    }
+    workgroupBarrier();
+    // Call shuffle unconditionally to maintain uniform control flow across subgroup.
+    // Divergent subgroup ops (when some lanes skip due to keyValid=false) cause undefined behavior.
+    let bcast = unsafeSubgroupShuffle(pre_inc, highest_rank_peer);
+    // Only apply it for real keys / real peer groups
+    out += select(0u, bcast, eq_mask != 0u);
+    return select(0u, out, key_valid);
+}
+
+fn fake_wlms(key: u32, shift: u32, laneid: u32, lane_count: u32, lane_mask_lt: u32, s_offset: u32) -> u32 {
+    return 0u;
+}
+
+@compute @workgroup_size(BLOCK_DIM, 1, 1)
+fn onesweep_pass(
+    @builtin(local_invocation_id) threadid: vec3<u32>,
+    @builtin(subgroup_invocation_id) laneid: u32,
+    @builtin(subgroup_size) lane_count: u32) {
+
+    let shift = info.shift;
+    let sid = threadid.x / lane_count;
+
+    // CRITICAL: This wave16 shader uses ballot.x (32 bits only) for peer masks.
+    // If lane_count > 32, the ballot mask would miss lanes 32+, causing corruption.
+    // Also lane_mask_lt = (1u << laneid) - 1u overflows for laneid >= 32.
+    if (lane_count > MAX_SUBGROUP_SIZE_W16) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_LANE_COUNT] = 0xDEAD0016u | (lane_count << 16u);
+        }
+        return;
+    }
+
+    let subgroup_hist_size = (BLOCK_DIM / lane_count) * RADIX;
+    if (subgroup_hist_size > WARP_HIST_CAPACITY) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_PASS] = 0xDEAD0004u;
+        }
+        return;
+    }
+
+    for (var i = threadid.x; i < subgroup_hist_size; i += BLOCK_DIM) {
+        atomicStore(&wg_subgroupHist[i], 0u);
+    }
+    workgroupBarrier();
+
+    if (threadid.x == 0u) {
+        wg_broadcast = atomicAdd(&bump[shift >> 3u], 1u);
+    }
+    // Explicit barrier to ensure wg_broadcast is visible to all threads
+    workgroupBarrier();
+    let partid = wg_broadcast;
+
+    var keys = array<u32, KEYS_PER_THREAD>();
+    var values = array<u32, KEYS_PER_THREAD>();
+    var keyValid = array<bool, KEYS_PER_THREAD>();
+    {
+        let dev_offset = partid * PART_SIZE;
+        let lane_stride = sid * lane_count * KEYS_PER_THREAD;
+        var idx = laneid + lane_stride + dev_offset;
+        if (partid < info.thread_blocks - 1u) {
+            for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+                keys[k] = sort[idx];
+                values[k] = payload[idx];
+                keyValid[k] = true;
+                idx += lane_count;
+            }
+        } else {
+            for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+                if (idx < info.size) {
+                    keys[k] = sort[idx];
+                    values[k] = payload[idx];
+                    keyValid[k] = true;
+                } else {
+                    keys[k] = 0xffffffffu;
+                    values[k] = 0xffffffffu;
+                    keyValid[k] = false;
+                }
+                idx += lane_count;
+            }
+        }
+    }
+
+    var offsets = array<u32, KEYS_PER_THREAD>();
+    {
+        let lane_mask_lt = (1u << laneid) - 1u;
+        let hist_offset = sid * RADIX;
+        for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+            offsets[k] = WLMS(keys[k], shift, laneid, lane_count, lane_mask_lt, hist_offset, keyValid[k]);
+        }
+    }
+    workgroupBarrier();
+
+    var local_reduction = 0u;
+    if (threadid.x < RADIX) {
+        local_reduction = atomicLoad(&wg_subgroupHist[threadid.x]);
+        var subtotal = local_reduction;
+        for (var i = threadid.x + RADIX; i < subgroup_hist_size; i += RADIX) {
+            let current = atomicLoad(&wg_subgroupHist[i]);
+            atomicStore(&wg_subgroupHist[i], subtotal);
+            subtotal += current;
+        }
+        local_reduction = subtotal;
+
+        if (partid < info.thread_blocks - 1u) {
+            let pass_plane = shift >> 3u;
+            let pass_index = threadid.x + pass_plane * info.thread_blocks * RADIX + (partid + 1u) * RADIX;
+            atomicStore(&pass_hist[pass_index], (local_reduction << 2u) | FLAG_REDUCTION);
+        }
+
+        let lane_mask = lane_count - 1u;
+        let circular_lane_shift = (laneid + lane_mask) & lane_mask;
+        let t = unsafeSubgroupInclusiveAdd(local_reduction);
+        wg_localHist[threadid.x] = unsafeSubgroupShuffle(t, circular_lane_shift);
+    }
+    workgroupBarrier();
+
+    if (threadid.x < lane_count) {
+        let pred = threadid.x < RADIX / lane_count;
+        let t = unsafeSubgroupExclusiveAdd(select(0u, wg_localHist[threadid.x * lane_count], pred));
+        if (pred) {
+            wg_localHist[threadid.x * lane_count] = t;
+        }
+    }
+    workgroupBarrier();
+
+    if (threadid.x < RADIX && laneid != 0u) {
+        wg_localHist[threadid.x] += wg_localHist[(threadid.x / lane_count) * lane_count];
+    }
+    workgroupBarrier();
+
+    for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+        if (keyValid[k]) {
+            let digit = (keys[k] >> shift) & RADIX_MASK;
+            let block_prefix = wg_localHist[digit];
+            if (sid == 0u) {
+                offsets[k] += block_prefix;
+            } else {
+                let subgroup_prefix = atomicLoad(&wg_subgroupHist[digit + sid * RADIX]);
+                offsets[k] += block_prefix + subgroup_prefix;
+            }
+        }
+    }
+    workgroupBarrier();
+
+    if (threadid.x < RADIX) {
+        let pass_plane = shift >> 3u;
+        let base_plane = pass_plane * info.thread_blocks * RADIX;
+        let bin = threadid.x;
+        let block_prefix = wg_localHist[bin];
+        var prev_reduction = 0u;
+        var lookbackid = partid;
+        loop {
+            let flag_payload = atomicLoad(&pass_hist[bin + base_plane + lookbackid * RADIX]);
+            if ((flag_payload & FLAG_MASK) > FLAG_NOT_READY) {
+                prev_reduction += flag_payload >> 2u;
+                if ((flag_payload & FLAG_MASK) == FLAG_INCLUSIVE) {
+                    if (partid < info.thread_blocks - 1u) {
+                        let next_idx = bin + base_plane + (partid + 1u) * RADIX;
+                        atomicStore(&pass_hist[next_idx], ((prev_reduction + local_reduction) << 2u) | FLAG_INCLUSIVE);
+                    }
+                    wg_localHist[bin] = prev_reduction - block_prefix;
+                    break;
+                } else {
+                    lookbackid -= 1u;
+                }
+            }
+        }
+    }
+    workgroupBarrier();
+
+    for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+        if (keyValid[k]) {
+            let digit = (keys[k] >> shift) & RADIX_MASK;
+            let global_offset = wg_localHist[digit] + offsets[k];
+            if (global_offset < info.size) {
+                alt[global_offset] = keys[k];
+                alt_payload[global_offset] = values[k];
+            }
+        }
+    }
+}
+`;
+
+export const oneSweep32Shader = `
+//****************************************************************************
+// GPUSorting
+// OneSweep - WaveSize 32 variant
+//
+// SPDX-License-Identifier: MIT
+// Copyright Thomas Smith 12/7/2024
+// https://github.com/b0nes164/GPUSorting
+//
+// Modified for WGSL compatibility and variable subgroup sizes by Dino Metarapi, 2025
+// Based on original work by Thomas Smith
+//****************************************************************************
+
+enable subgroups;
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupInclusiveAdd(x: u32) -> u32 { return subgroupInclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupExclusiveAdd(x: u32) -> u32 { return subgroupExclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffle(x: u32, source: u32) -> u32 { return subgroupShuffle(x, source); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupBallot(pred: bool) -> vec4<u32> { return subgroupBallot(pred); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupAdd(x: u32) -> u32 { return subgroupAdd(x); }
+
+struct InfoStruct
+{
+    size: u32,
+    shift: u32,
+    thread_blocks: u32,
+    seed: u32,
+};
+
+@group(0) @binding(0)
+var<uniform> info : InfoStruct;
+
+@group(0) @binding(1)
+var<storage, read_write> bump: array<atomic<u32>>;
+
+@group(0) @binding(2)
+var<storage, read_write> sort: array<u32>;
+
+@group(0) @binding(3)
+var<storage, read_write> alt: array<u32>;
+
+@group(0) @binding(4)
+var<storage, read_write> payload: array<u32>;
+
+@group(0) @binding(5)
+var<storage, read_write> alt_payload: array<u32>;
+
+@group(0) @binding(6)
+var<storage, read_write> hist: array<atomic<u32>>;
+
+@group(0) @binding(7)
+var<storage, read_write> pass_hist: array<atomic<u32>>;
+
+@group(0) @binding(8)
+var<storage, read_write> status: array<u32>;
+
+const SORT_PASSES = 4u;
+const BLOCK_DIM = 256u;
+const MIN_SUBGROUP_SIZE = 32u;
+const MAX_SUBGROUP_SIZE_W32 = 32u;  // ballot.x is only 32 bits - wave32 max
+const MAX_REDUCE_SIZE = BLOCK_DIM / MIN_SUBGROUP_SIZE;
+
+const STATUS_ERR_GLOBAL_HIST = 0u;
+const STATUS_ERR_SCAN = 1u;
+const STATUS_ERR_PASS = 2u;
+const STATUS_ERR_LANE_COUNT = 3u;
+
+const FLAG_NOT_READY = 0u;
+const FLAG_REDUCTION = 1u;
+const FLAG_INCLUSIVE = 2u;
+const FLAG_MASK = 3u;
+
+const RADIX = 256u;
+const ALL_RADIX = RADIX * SORT_PASSES;
+const RADIX_MASK = 255u;
+const RADIX_LOG = 8u;
+
+const KEYS_PER_THREAD = 15u;
+const PART_SIZE = KEYS_PER_THREAD * BLOCK_DIM;
+
+const REDUCE_BLOCK_DIM = 128u;
+const REDUCE_KEYS_PER_THREAD = 30u;
+const REDUCE_HIST_SIZE = REDUCE_BLOCK_DIM / MIN_SUBGROUP_SIZE * ALL_RADIX;
+const REDUCE_PART_SIZE = REDUCE_KEYS_PER_THREAD * REDUCE_BLOCK_DIM;
+
+const MAX_SUBGROUPS_PER_BLOCK = BLOCK_DIM / MIN_SUBGROUP_SIZE;
+const WARP_HIST_CAPACITY = MAX_SUBGROUPS_PER_BLOCK * RADIX;
+
+var<workgroup> wg_globalHist: array<atomic<u32>, REDUCE_HIST_SIZE>;
+
+@compute @workgroup_size(REDUCE_BLOCK_DIM, 1, 1)
+fn global_hist(
+    @builtin(local_invocation_id) threadid: vec3<u32>,
+    @builtin(subgroup_invocation_id) laneid: u32,
+    @builtin(subgroup_size) lane_count: u32,
+    @builtin(workgroup_id) wgid: vec3<u32>) {
+
+    if (lane_count < MIN_SUBGROUP_SIZE || (REDUCE_BLOCK_DIM % lane_count) != 0u) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_GLOBAL_HIST] = 0xDEAD0001u;
+        }
+        return;
+    }
+
+    let sid = threadid.x / lane_count;
+
+    //Clear shared memory
+    for (var i = threadid.x; i < REDUCE_HIST_SIZE; i += REDUCE_BLOCK_DIM) {
+        atomicStore(&wg_globalHist[i], 0u);
+    }
+    workgroupBarrier();
+
+    let radix_shift = info.shift;
+    let hist_offset = sid * ALL_RADIX;
+    {
+        var i = threadid.x + wgid.x * REDUCE_PART_SIZE;
+        if(wgid.x < info.thread_blocks - 1) {
+            for (var k = 0u; k < REDUCE_KEYS_PER_THREAD; k += 1u) {
+                let key = sort[i];
+                atomicAdd(&wg_globalHist[(key & RADIX_MASK) + hist_offset], 1u);
+                atomicAdd(&wg_globalHist[((key >> 8u) & RADIX_MASK) + hist_offset + 256u], 1u);
+                atomicAdd(&wg_globalHist[((key >> 16u) & RADIX_MASK) + hist_offset + 512u], 1u);
+                atomicAdd(&wg_globalHist[((key >> 24u) & RADIX_MASK) + hist_offset + 768u], 1u);
+                i += REDUCE_BLOCK_DIM;
+            }
+        }
+
+        if(wgid.x == info.thread_blocks - 1) {
+            for (var k = 0u; k < REDUCE_KEYS_PER_THREAD; k += 1u) {
+                if (i < info.size) {
+                    let key = sort[i];
+                    atomicAdd(&wg_globalHist[(key & RADIX_MASK) + hist_offset], 1u);
+                    atomicAdd(&wg_globalHist[((key >> 8u) & RADIX_MASK) + hist_offset + 256u], 1u);
+                    atomicAdd(&wg_globalHist[((key >> 16u) & RADIX_MASK) + hist_offset + 512u], 1u);
+                    atomicAdd(&wg_globalHist[((key >> 24u) & RADIX_MASK) + hist_offset + 768u], 1u);
+                }
+                i += REDUCE_BLOCK_DIM;
+            }
+        }
+    }
+    workgroupBarrier();
+
+    // Merge subgroup histograms
+    let subgroup_histograms = REDUCE_BLOCK_DIM / lane_count;
+    for(var i = threadid.x; i < RADIX; i += REDUCE_BLOCK_DIM) {
+        var reduction0 = atomicLoad(&wg_globalHist[i]);
+        var reduction1 = atomicLoad(&wg_globalHist[i + 256u]);
+        var reduction2 = atomicLoad(&wg_globalHist[i + 512u]);
+        var reduction3 = atomicLoad(&wg_globalHist[i + 768u]);
+
+        for (var h = 1u; h < subgroup_histograms; h += 1u) {
+            let idx = h * ALL_RADIX;
+            reduction0 += atomicLoad(&wg_globalHist[i + idx]);
+            reduction1 += atomicLoad(&wg_globalHist[i + 256u + idx]);
+            reduction2 += atomicLoad(&wg_globalHist[i + 512u + idx]);
+            reduction3 += atomicLoad(&wg_globalHist[i + 768u + idx]);
+        }
+
+        atomicAdd(&hist[i], reduction0);
+        atomicAdd(&hist[i + 256u], reduction1);
+        atomicAdd(&hist[i + 512u], reduction2);
+        atomicAdd(&hist[i + 768u], reduction3);
+    }
+}
+
+//Assumes block dim 256
+const SCAN_MEM_SIZE = RADIX / MIN_SUBGROUP_SIZE;
+var<workgroup> wg_scan: array<u32, SCAN_MEM_SIZE>;
+@compute @workgroup_size(BLOCK_DIM, 1, 1)
+fn onesweep_scan(
+    @builtin(local_invocation_id) threadid: vec3<u32>,
+    @builtin(subgroup_invocation_id) laneid: u32,
+    @builtin(subgroup_size) lane_count: u32,
+    @builtin(workgroup_id) wgid: vec3<u32>) {
+
+    if (lane_count < MIN_SUBGROUP_SIZE || (BLOCK_DIM % lane_count) != 0u) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_SCAN] = 0xDEAD0002u;
+        }
+        return;
+    }
+
+    let sid = threadid.x / lane_count;
+    let pass_plane = info.shift >> 3u;
+    let hist_index = threadid.x + pass_plane * RADIX;
+    let scan = atomicLoad(&hist[hist_index]);
+    let red = unsafeSubgroupAdd(scan);
+    if(laneid == 0u){
+        wg_scan[sid] = red;
+    }
+    workgroupBarrier();
+
+    //Non-divergent subgroup agnostic inclusive scan across subgroup reductions
+    {
+        var offset0 = 0u;
+        var offset1 = 0u;
+        let lane_log = u32(countTrailingZeros(lane_count));
+        let spine_size = BLOCK_DIM >> lane_log;
+        let aligned_size = 1u << ((u32(countTrailingZeros(spine_size)) + lane_log - 1u) / lane_log * lane_log);
+        for(var j = lane_count; j <= aligned_size; j <<= lane_log){
+            let i0 = ((threadid.x + offset0) << offset1) - select(0u, 1u, j != lane_count);
+            let pred0 = i0 < spine_size;
+            let t0 = unsafeSubgroupInclusiveAdd(select(0u, wg_scan[i0], pred0));
+            if(pred0){
+                wg_scan[i0] = t0;
+            }
+            workgroupBarrier();
+
+            if(j != lane_count){
+                let rshift = j >> lane_log;
+                let i1 = threadid.x + rshift;
+                if ((i1 & (j - 1u)) >= rshift){
+                    let pred1 = i1 < spine_size;
+                    let t1 = select(0u, wg_scan[((i1 >> offset1) << offset1) - 1u], pred1);
+                    if(pred1 && ((i1 + 1u) & (rshift - 1u)) != 0u){
+                        wg_scan[i1] += t1;
+                    }
+                }
+            } else {
+                offset0 += 1u;
+            }
+            offset1 += lane_log;
+        }
+    }
+    workgroupBarrier();
+
+    if (wgid.x != 0u) {
+        return;
+    }
+
+    let plane_stride = info.thread_blocks * RADIX;
+    let pass_index = threadid.x + pass_plane * plane_stride;
+    let subgroup_prefix = unsafeSubgroupExclusiveAdd(scan);
+    var spine_prefix = 0u;
+    if (sid > 0u) {
+        spine_prefix = wg_scan[sid - 1u];
+    }
+    atomicStore(&pass_hist[pass_index], ((subgroup_prefix + spine_prefix) << 2u) | FLAG_INCLUSIVE);
+}
+
+var<workgroup> wg_subgroupHist: array<atomic<u32>, WARP_HIST_CAPACITY>;
+var<workgroup> wg_localHist: array<u32, RADIX>;
+var<workgroup> wg_broadcast: u32;
+
+// Wave32 WLMS: uses ballot.x (32 bits) - only valid for lane_count <= 32
+fn WLMS(key: u32, shift: u32, laneid: u32, lane_count: u32, lane_mask_lt: u32, s_offset: u32, key_valid: bool) -> u32 {
+    // FIX: Compute valid_mask FIRST to exclude invalid lanes from peer groups.
+    // Without this, invalid lanes (key_valid=false) look like "bit=0" lanes during ballot,
+    // allowing them to join peer groups with valid keys. If an invalid lane becomes
+    // highest_rank_peer, the atomicAdd is skipped (gated by key_valid), causing missing
+    // histogram increments → offset collisions → duplicates/missing elements.
+    let valid_mask = unsafeSubgroupBallot(key_valid).x;
+
+    var eq_mask = 0xffffffffu;
+    for (var k = 0u; k < RADIX_LOG; k += 1u) {
+        let curr_bit = 1u << (k + shift);
+        let pred = key_valid && ((key & curr_bit) != 0u);
+        let ballot = unsafeSubgroupBallot(pred);
+        eq_mask &= select(~ballot.x, ballot.x, pred);
+    }
+
+    // Remove invalid lanes from the peer group (critical fix for partial last partitions)
+    eq_mask &= valid_mask;
+
+    var subgroup_mask = 0xffffffffu;
+    if (lane_count != 32u) {
+        subgroup_mask = (1u << lane_count) - 1u;
+    }
+    eq_mask &= subgroup_mask;
+
+    if (!key_valid) {
+        eq_mask = 0u;
+    }
+    var out = countOneBits(eq_mask & lane_mask_lt);
+    let highest_rank_peer = select(lane_count - 1u, 31u - countLeadingZeros(eq_mask), eq_mask != 0u);
+    var pre_inc = 0u;
+    if (key_valid && eq_mask != 0u && laneid == highest_rank_peer) {
+        pre_inc = atomicAdd(&wg_subgroupHist[((key >> shift) & RADIX_MASK) + s_offset], out + 1u);
+    }
+    workgroupBarrier();
+    // Call shuffle unconditionally to maintain uniform control flow across subgroup.
+    // Divergent subgroup ops (when some lanes skip due to keyValid=false) cause undefined behavior.
+    let bcast = unsafeSubgroupShuffle(pre_inc, highest_rank_peer);
+    // Only apply it for real keys / real peer groups
+    out += select(0u, bcast, eq_mask != 0u);
+    return select(0u, out, key_valid);
+}
+
+fn fake_wlms(key: u32, shift: u32, laneid: u32, lane_count: u32, lane_mask_lt: u32, s_offset: u32) -> u32 {
+    return 0u;
+}
+
+@compute @workgroup_size(BLOCK_DIM, 1, 1)
+fn onesweep_pass(
+    @builtin(local_invocation_id) threadid: vec3<u32>,
+    @builtin(subgroup_invocation_id) laneid: u32,
+    @builtin(subgroup_size) lane_count: u32) {
+
+    let shift = info.shift;
+    let sid = threadid.x / lane_count;
+
+    // CRITICAL: This wave32 shader uses ballot.x (32 bits only) for peer masks.
+    // If lane_count > 32, the ballot mask would miss lanes 32+, causing corruption.
+    // Also lane_mask_lt = (1u << laneid) - 1u overflows for laneid >= 32.
+    if (lane_count > MAX_SUBGROUP_SIZE_W32) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_LANE_COUNT] = 0xDEAD0032u | (lane_count << 16u);
+        }
+        return;
+    }
+
+    let subgroup_hist_size = (BLOCK_DIM / lane_count) * RADIX;
+    if (subgroup_hist_size > WARP_HIST_CAPACITY) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_PASS] = 0xDEAD0004u;
+        }
+        return;
+    }
+
+    for (var i = threadid.x; i < subgroup_hist_size; i += BLOCK_DIM) {
+        atomicStore(&wg_subgroupHist[i], 0u);
+    }
+    workgroupBarrier();
+
+    if (threadid.x == 0u) {
+        wg_broadcast = atomicAdd(&bump[shift >> 3u], 1u);
+    }
+    // Explicit barrier to ensure wg_broadcast is visible to all threads
+    workgroupBarrier();
+    let partid = wg_broadcast;
+
+    var keys = array<u32, KEYS_PER_THREAD>();
+    var values = array<u32, KEYS_PER_THREAD>();
+    var keyValid = array<bool, KEYS_PER_THREAD>();
+    {
+        let dev_offset = partid * PART_SIZE;
+        let lane_stride = sid * lane_count * KEYS_PER_THREAD;
+        var idx = laneid + lane_stride + dev_offset;
+        if (partid < info.thread_blocks - 1u) {
+            for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+                keys[k] = sort[idx];
+                values[k] = payload[idx];
+                keyValid[k] = true;
+                idx += lane_count;
+            }
+        } else {
+            for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+                if (idx < info.size) {
+                    keys[k] = sort[idx];
+                    values[k] = payload[idx];
+                    keyValid[k] = true;
+                } else {
+                    keys[k] = 0xffffffffu;
+                    values[k] = 0xffffffffu;
+                    keyValid[k] = false;
+                }
+                idx += lane_count;
+            }
+        }
+    }
+
+    var offsets = array<u32, KEYS_PER_THREAD>();
+    {
+        let lane_mask_lt = (1u << laneid) - 1u;
+        let hist_offset = sid * RADIX;
+        for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+            offsets[k] = WLMS(keys[k], shift, laneid, lane_count, lane_mask_lt, hist_offset, keyValid[k]);
+        }
+    }
+    workgroupBarrier();
+
+    var local_reduction = 0u;
+    if (threadid.x < RADIX) {
+        local_reduction = atomicLoad(&wg_subgroupHist[threadid.x]);
+        var subtotal = local_reduction;
+        for (var i = threadid.x + RADIX; i < subgroup_hist_size; i += RADIX) {
+            let current = atomicLoad(&wg_subgroupHist[i]);
+            atomicStore(&wg_subgroupHist[i], subtotal);
+            subtotal += current;
+        }
+        local_reduction = subtotal;
+
+        if (partid < info.thread_blocks - 1u) {
+            let pass_plane = shift >> 3u;
+            let pass_index = threadid.x + pass_plane * info.thread_blocks * RADIX + (partid + 1u) * RADIX;
+            atomicStore(&pass_hist[pass_index], (local_reduction << 2u) | FLAG_REDUCTION);
+        }
+
+        let lane_mask = lane_count - 1u;
+        let circular_lane_shift = (laneid + lane_mask) & lane_mask;
+        let t = unsafeSubgroupInclusiveAdd(local_reduction);
+        wg_localHist[threadid.x] = unsafeSubgroupShuffle(t, circular_lane_shift);
+    }
+    workgroupBarrier();
+
+    if (threadid.x < lane_count) {
+        let pred = threadid.x < RADIX / lane_count;
+        let t = unsafeSubgroupExclusiveAdd(select(0u, wg_localHist[threadid.x * lane_count], pred));
+        if (pred) {
+            wg_localHist[threadid.x * lane_count] = t;
+        }
+    }
+    workgroupBarrier();
+
+    if (threadid.x < RADIX && laneid != 0u) {
+        wg_localHist[threadid.x] += wg_localHist[(threadid.x / lane_count) * lane_count];
+    }
+    workgroupBarrier();
+
+    for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+        if (keyValid[k]) {
+            let digit = (keys[k] >> shift) & RADIX_MASK;
+            let block_prefix = wg_localHist[digit];
+            if (sid == 0u) {
+                offsets[k] += block_prefix;
+            } else {
+                let subgroup_prefix = atomicLoad(&wg_subgroupHist[digit + sid * RADIX]);
+                offsets[k] += block_prefix + subgroup_prefix;
+            }
+        }
+    }
+    workgroupBarrier();
+
+    if (threadid.x < RADIX) {
+        let pass_plane = shift >> 3u;
+        let base_plane = pass_plane * info.thread_blocks * RADIX;
+        let bin = threadid.x;
+        let block_prefix = wg_localHist[bin];
+        var prev_reduction = 0u;
+        var lookbackid = partid;
+        loop {
+            let flag_payload = atomicLoad(&pass_hist[bin + base_plane + lookbackid * RADIX]);
+            if ((flag_payload & FLAG_MASK) > FLAG_NOT_READY) {
+                prev_reduction += flag_payload >> 2u;
+                if ((flag_payload & FLAG_MASK) == FLAG_INCLUSIVE) {
+                    if (partid < info.thread_blocks - 1u) {
+                        let next_idx = bin + base_plane + (partid + 1u) * RADIX;
+                        atomicStore(&pass_hist[next_idx], ((prev_reduction + local_reduction) << 2u) | FLAG_INCLUSIVE);
+                    }
+                    wg_localHist[bin] = prev_reduction - block_prefix;
+                    break;
+                } else {
+                    lookbackid -= 1u;
+                }
+            }
+        }
+    }
+    workgroupBarrier();
+
+    for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+        if (keyValid[k]) {
+            let digit = (keys[k] >> shift) & RADIX_MASK;
+            let global_offset = wg_localHist[digit] + offsets[k];
+            if (global_offset < info.size) {
+                alt[global_offset] = keys[k];
+                alt_payload[global_offset] = values[k];
+            }
+        }
+    }
+}
+`;
+
+export const oneSweep64Shader = `
+//****************************************************************************
+// GPUSorting
+// OneSweep - WaveSize 64 variant
+//
+// SPDX-License-Identifier: MIT
+// Copyright Thomas Smith 12/7/2024
+// https://github.com/b0nes164/GPUSorting
+//
+// Modified for WGSL compatibility and variable subgroup sizes by Dino Metarapi, 2025
+// Based on original work by Thomas Smith
+//****************************************************************************
+
+enable subgroups;
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupInclusiveAdd(x: u32) -> u32 { return subgroupInclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupExclusiveAdd(x: u32) -> u32 { return subgroupExclusiveAdd(x); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupShuffle(x: u32, source: u32) -> u32 { return subgroupShuffle(x, source); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupBallot(pred: bool) -> vec4<u32> { return subgroupBallot(pred); }
+
+@diagnostic(off, subgroup_uniformity)
+fn unsafeSubgroupAdd(x: u32) -> u32 { return subgroupAdd(x); }
+
+struct InfoStruct
+{
+    size: u32,
+    shift: u32,
+    thread_blocks: u32,
+    seed: u32,
+};
+
+@group(0) @binding(0)
+var<uniform> info : InfoStruct;
+
+@group(0) @binding(1)
+var<storage, read_write> bump: array<atomic<u32>>;
+
+@group(0) @binding(2)
+var<storage, read_write> sort: array<u32>;
+
+@group(0) @binding(3)
+var<storage, read_write> alt: array<u32>;
+
+@group(0) @binding(4)
+var<storage, read_write> payload: array<u32>;
+
+@group(0) @binding(5)
+var<storage, read_write> alt_payload: array<u32>;
+
+@group(0) @binding(6)
+var<storage, read_write> hist: array<atomic<u32>>;
+
+@group(0) @binding(7)
+var<storage, read_write> pass_hist: array<atomic<u32>>;
+
+@group(0) @binding(8)
+var<storage, read_write> status: array<u32>;
+
+const SORT_PASSES = 4u;
+const BLOCK_DIM = 256u;
+const MIN_SUBGROUP_SIZE = 64u;
+const MAX_REDUCE_SIZE = BLOCK_DIM / MIN_SUBGROUP_SIZE;
+
+const STATUS_ERR_GLOBAL_HIST = 0u;
+const STATUS_ERR_SCAN = 1u;
+const STATUS_ERR_PASS = 2u;
+
+const FLAG_NOT_READY = 0u;
+const FLAG_REDUCTION = 1u;
+const FLAG_INCLUSIVE = 2u;
+const FLAG_MASK = 3u;
+
+const RADIX = 256u;
+const ALL_RADIX = RADIX * SORT_PASSES;
+const RADIX_MASK = 255u;
+const RADIX_LOG = 8u;
+
+const KEYS_PER_THREAD = 15u;
+const PART_SIZE = KEYS_PER_THREAD * BLOCK_DIM;
+
+const REDUCE_BLOCK_DIM = 128u;
+const REDUCE_KEYS_PER_THREAD = 30u;
+const REDUCE_HIST_SIZE = REDUCE_BLOCK_DIM / MIN_SUBGROUP_SIZE * ALL_RADIX;
+const REDUCE_PART_SIZE = REDUCE_KEYS_PER_THREAD * REDUCE_BLOCK_DIM;
+
+const MAX_SUBGROUPS_PER_BLOCK = BLOCK_DIM / MIN_SUBGROUP_SIZE;
+const WARP_HIST_CAPACITY = MAX_SUBGROUPS_PER_BLOCK * RADIX;
+
+var<workgroup> wg_globalHist: array<atomic<u32>, REDUCE_HIST_SIZE>;
+
+@compute @workgroup_size(REDUCE_BLOCK_DIM, 1, 1)
+fn global_hist(
+    @builtin(local_invocation_id) threadid: vec3<u32>,
+    @builtin(subgroup_invocation_id) laneid: u32,
+    @builtin(subgroup_size) lane_count: u32,
+    @builtin(workgroup_id) wgid: vec3<u32>) {
+
+    if (lane_count < MIN_SUBGROUP_SIZE || (REDUCE_BLOCK_DIM % lane_count) != 0u) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_GLOBAL_HIST] = 0xDEAD0001u;
+        }
+        return;
+    }
+
+    let sid = threadid.x / lane_count;
+
+    //Clear shared memory
+    for (var i = threadid.x; i < REDUCE_HIST_SIZE; i += REDUCE_BLOCK_DIM) {
+        atomicStore(&wg_globalHist[i], 0u);
+    }
+    workgroupBarrier();
+
+    let radix_shift = info.shift;
+    let hist_offset = sid * ALL_RADIX;
+    {
+        var i = threadid.x + wgid.x * REDUCE_PART_SIZE;
+        if(wgid.x < info.thread_blocks - 1u) {
+            for (var k = 0u; k < REDUCE_KEYS_PER_THREAD; k += 1u) {
+                let key = sort[i];
+                atomicAdd(&wg_globalHist[(key & RADIX_MASK) + hist_offset], 1u);
+                atomicAdd(&wg_globalHist[((key >> 8u) & RADIX_MASK) + hist_offset + 256u], 1u);
+                atomicAdd(&wg_globalHist[((key >> 16u) & RADIX_MASK) + hist_offset + 512u], 1u);
+                atomicAdd(&wg_globalHist[((key >> 24u) & RADIX_MASK) + hist_offset + 768u], 1u);
+                i += REDUCE_BLOCK_DIM;
+            }
+        }
+
+        if(wgid.x == info.thread_blocks - 1u) {
+            for (var k = 0u; k < REDUCE_KEYS_PER_THREAD; k += 1u) {
+                if (i < info.size) {
+                    let key = sort[i];
+                    atomicAdd(&wg_globalHist[(key & RADIX_MASK) + hist_offset], 1u);
+                    atomicAdd(&wg_globalHist[((key >> 8u) & RADIX_MASK) + hist_offset + 256u], 1u);
+                    atomicAdd(&wg_globalHist[((key >> 16u) & RADIX_MASK) + hist_offset + 512u], 1u);
+                    atomicAdd(&wg_globalHist[((key >> 24u) & RADIX_MASK) + hist_offset + 768u], 1u);
+                }
+                i += REDUCE_BLOCK_DIM;
+            }
+        }
+    }
+    workgroupBarrier();
+
+    // Merge subgroup histograms
+    let subgroup_histograms = REDUCE_BLOCK_DIM / lane_count;
+    for(var i = threadid.x; i < RADIX; i += REDUCE_BLOCK_DIM) {
+        var reduction0 = atomicLoad(&wg_globalHist[i]);
+        var reduction1 = atomicLoad(&wg_globalHist[i + 256u]);
+        var reduction2 = atomicLoad(&wg_globalHist[i + 512u]);
+        var reduction3 = atomicLoad(&wg_globalHist[i + 768u]);
+
+        for (var h = 1u; h < subgroup_histograms; h += 1u) {
+            let idx = h * ALL_RADIX;
+            reduction0 += atomicLoad(&wg_globalHist[i + idx]);
+            reduction1 += atomicLoad(&wg_globalHist[i + 256u + idx]);
+            reduction2 += atomicLoad(&wg_globalHist[i + 512u + idx]);
+            reduction3 += atomicLoad(&wg_globalHist[i + 768u + idx]);
+        }
+
+        atomicAdd(&hist[i], reduction0);
+        atomicAdd(&hist[i + 256u], reduction1);
+        atomicAdd(&hist[i + 512u], reduction2);
+        atomicAdd(&hist[i + 768u], reduction3);
+    }
+}
+
+//Assumes block dim 256
+const SCAN_MEM_SIZE = RADIX / MIN_SUBGROUP_SIZE;
+var<workgroup> wg_scan: array<u32, SCAN_MEM_SIZE>;
+@compute @workgroup_size(BLOCK_DIM, 1, 1)
+fn onesweep_scan(
+    @builtin(local_invocation_id) threadid: vec3<u32>,
+    @builtin(subgroup_invocation_id) laneid: u32,
+    @builtin(subgroup_size) lane_count: u32,
+    @builtin(workgroup_id) wgid: vec3<u32>) {
+
+    if (lane_count < MIN_SUBGROUP_SIZE || (BLOCK_DIM % lane_count) != 0u) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_SCAN] = 0xDEAD0002u;
+        }
+        return;
+    }
+
+    let sid = threadid.x / lane_count;
+    let pass_plane = info.shift >> 3u;
+    let hist_index = threadid.x + pass_plane * RADIX;
+    let scan = atomicLoad(&hist[hist_index]);
+    let red = unsafeSubgroupAdd(scan);
+    if(laneid == 0u){
+        wg_scan[sid] = red;
+    }
+    workgroupBarrier();
+
+    //Non-divergent subgroup agnostic inclusive scan across subgroup reductions
+    {
+        var offset0 = 0u;
+        var offset1 = 0u;
+        let lane_log = u32(countTrailingZeros(lane_count));
+        let spine_size = BLOCK_DIM >> lane_log;
+        let aligned_size = 1u << ((u32(countTrailingZeros(spine_size)) + lane_log - 1u) / lane_log * lane_log);
+        for(var j = lane_count; j <= aligned_size; j <<= lane_log){
+            let i0 = ((threadid.x + offset0) << offset1) - select(0u, 1u, j != lane_count);
+            let pred0 = i0 < spine_size;
+            let t0 = unsafeSubgroupInclusiveAdd(select(0u, wg_scan[i0], pred0));
+            if(pred0){
+                wg_scan[i0] = t0;
+            }
+            workgroupBarrier();
+
+            if(j != lane_count){
+                let rshift = j >> lane_log;
+                let i1 = threadid.x + rshift;
+                if ((i1 & (j - 1u)) >= rshift){
+                    let pred1 = i1 < spine_size;
+                    let t1 = select(0u, wg_scan[((i1 >> offset1) << offset1) - 1u], pred1);
+                    if(pred1 && ((i1 + 1u) & (rshift - 1u)) != 0u){
+                        wg_scan[i1] += t1;
+                    }
+                }
+            } else {
+                offset0 += 1u;
+            }
+            offset1 += lane_log;
+        }
+    }
+    workgroupBarrier();
+
+    if (wgid.x != 0u) {
+        return;
+    }
+
+    let plane_stride = info.thread_blocks * RADIX;
+    let pass_index = threadid.x + pass_plane * plane_stride;
+    let subgroup_prefix = unsafeSubgroupExclusiveAdd(scan);
+    var spine_prefix = 0u;
+    if (sid > 0u) {
+        spine_prefix = wg_scan[sid - 1u];
+    }
+    atomicStore(&pass_hist[pass_index], ((subgroup_prefix + spine_prefix) << 2u) | FLAG_INCLUSIVE);
+}
+
+var<workgroup> wg_subgroupHist: array<atomic<u32>, WARP_HIST_CAPACITY>;
+var<workgroup> wg_localHist: array<u32, RADIX>;
+var<workgroup> wg_broadcast: u32;
+
+fn lowMask(bits: u32) -> u32 {
+    if (bits == 0u) {
+        return 0u;
+    }
+    if (bits >= 32u) {
+        return 0xffffffffu;
+    }
+    return (1u << bits) - 1u;
+}
+
+fn laneMaskLessThan(laneid: u32) -> vec4<u32> {
+    if (laneid >= 32u) {
+        return vec4<u32>(0xffffffffu, lowMask(laneid - 32u), 0u, 0u);
+    }
+    return vec4<u32>(lowMask(laneid), 0u, 0u, 0u);
+}
+
+fn subgroupMaskForSize(size: u32) -> vec4<u32> {
+    if (size <= 32u) {
+        return vec4<u32>(lowMask(size), 0u, 0u, 0u);
+    }
+    return vec4<u32>(0xffffffffu, lowMask(size - 32u), 0u, 0u);
+}
+
+fn maskAnd(a: vec4<u32>, b: vec4<u32>) -> vec4<u32> {
+    return vec4<u32>(a.x & b.x, a.y & b.y, 0u, 0u);
+}
+
+fn maskFilter(ballot: vec4<u32>, pred: bool) -> vec4<u32> {
+    let keep = vec4<u32>(ballot.x, ballot.y, 0u, 0u);
+    let reject = vec4<u32>(~ballot.x, ~ballot.y, 0u, 0u);
+    let cond = vec4<bool>(pred, pred, pred, pred);
+    return select(reject, keep, cond);
+}
+
+fn maskBitCount(mask: vec4<u32>) -> u32 {
+    return countOneBits(mask.x) + countOneBits(mask.y);
+}
+
+fn maskHasBits(mask: vec4<u32>) -> bool {
+    return (mask.x | mask.y) != 0u;
+}
+
+fn maskHighestLane(mask: vec4<u32>) -> u32 {
+    if (mask.y != 0u) {
+        return 32u + (31u - countLeadingZeros(mask.y));
+    }
+    return 31u - countLeadingZeros(mask.x);
+}
+
+fn WLMS(key: u32, shift: u32, laneid: u32, lane_count: u32, s_offset: u32, key_valid: bool) -> u32 {
+    // FIX: Compute valid_mask FIRST to exclude invalid lanes from peer groups.
+    // Without this, invalid lanes (key_valid=false) look like "bit=0" lanes during ballot,
+    // allowing them to join peer groups with valid keys. If an invalid lane becomes
+    // highest_rank_peer, the atomicAdd is skipped (gated by key_valid), causing missing
+    // histogram increments → offset collisions → duplicates/missing elements.
+    let valid_ballot = unsafeSubgroupBallot(key_valid);
+    let valid_mask = vec4<u32>(valid_ballot.x, valid_ballot.y, 0u, 0u);
+
+    var eq_mask = vec4<u32>(0xffffffffu, 0xffffffffu, 0u, 0u);
+    for (var k = 0u; k < RADIX_LOG; k += 1u) {
+        let curr_bit = 1u << (k + shift);
+        let pred = key_valid && ((key & curr_bit) != 0u);
+        let ballot = unsafeSubgroupBallot(pred);
+        eq_mask = maskAnd(eq_mask, maskFilter(ballot, pred));
+    }
+
+    // Remove invalid lanes from the peer group (critical fix for partial last partitions)
+    eq_mask = maskAnd(eq_mask, valid_mask);
+
+    if (!key_valid) {
+        eq_mask = vec4<u32>(0u);
+    }
+    eq_mask = maskAnd(eq_mask, subgroupMaskForSize(lane_count));
+    let lane_mask_lt = laneMaskLessThan(laneid);
+    var out = maskBitCount(maskAnd(eq_mask, lane_mask_lt));
+    let has_peers = maskHasBits(eq_mask);
+    let highest_rank_peer = select(lane_count - 1u, maskHighestLane(eq_mask), has_peers);
+    var pre_inc = 0u;
+    if (key_valid && has_peers && laneid == highest_rank_peer) {
+        pre_inc = atomicAdd(&wg_subgroupHist[((key >> shift) & RADIX_MASK) + s_offset], out + 1u);
+    }
+    workgroupBarrier();
+    // Call shuffle unconditionally to maintain uniform control flow across subgroup.
+    // Divergent subgroup ops (when some lanes skip due to keyValid=false) cause undefined behavior.
+    let bcast = unsafeSubgroupShuffle(pre_inc, highest_rank_peer);
+    // Only apply it for real keys / real peer groups
+    out += select(0u, bcast, has_peers);
+    return select(0u, out, key_valid);
+}
+
+fn fake_wlms(key: u32, shift: u32, laneid: u32, lane_count: u32, s_offset: u32) -> u32 {
+    return 0u;
+}
+
+@compute @workgroup_size(BLOCK_DIM, 1, 1)
+fn onesweep_pass(
+    @builtin(local_invocation_id) threadid: vec3<u32>,
+    @builtin(subgroup_invocation_id) laneid: u32,
+    @builtin(subgroup_size) lane_count: u32) {
+
+    let shift = info.shift;
+    let sid = threadid.x / lane_count;
+
+    let subgroup_hist_size = (BLOCK_DIM / lane_count) * RADIX;
+    if (subgroup_hist_size > WARP_HIST_CAPACITY) {
+        if (threadid.x == 0u) {
+            status[STATUS_ERR_PASS] = 0xDEAD0004u;
+        }
+        return;
+    }
+
+    for (var i = threadid.x; i < subgroup_hist_size; i += BLOCK_DIM) {
+        atomicStore(&wg_subgroupHist[i], 0u);
+    }
+    workgroupBarrier();
+
+    if (threadid.x == 0u) {
+        wg_broadcast = atomicAdd(&bump[shift >> 3u], 1u);
+    }
+    // Explicit barrier to ensure wg_broadcast is visible to all threads
+    workgroupBarrier();
+    let partid = wg_broadcast;
+
+    var keys = array<u32, KEYS_PER_THREAD>();
+    var values = array<u32, KEYS_PER_THREAD>();
+    var keyValid = array<bool, KEYS_PER_THREAD>();
+    {
+        let dev_offset = partid * PART_SIZE;
+        let lane_stride = sid * lane_count * KEYS_PER_THREAD;
+        var idx = laneid + lane_stride + dev_offset;
+        if (partid < info.thread_blocks - 1u) {
+            for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+                keys[k] = sort[idx];
+                values[k] = payload[idx];
+                keyValid[k] = true;
+                idx += lane_count;
+            }
+        } else {
+            for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+                if (idx < info.size) {
+                    keys[k] = sort[idx];
+                    values[k] = payload[idx];
+                    keyValid[k] = true;
+                } else {
+                    keys[k] = 0xffffffffu;
+                    values[k] = 0xffffffffu;
+                    keyValid[k] = false;
+                }
+                idx += lane_count;
+            }
+        }
+    }
+
+    var offsets = array<u32, KEYS_PER_THREAD>();
+    {
+        let hist_offset = sid * RADIX;
+        for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+            offsets[k] = WLMS(keys[k], shift, laneid, lane_count, hist_offset, keyValid[k]);
+        }
+    }
+    workgroupBarrier();
+
+    var local_reduction = 0u;
+    if (threadid.x < RADIX) {
+        local_reduction = atomicLoad(&wg_subgroupHist[threadid.x]);
+        var subtotal = local_reduction;
+        for (var i = threadid.x + RADIX; i < subgroup_hist_size; i += RADIX) {
+            let current = atomicLoad(&wg_subgroupHist[i]);
+            atomicStore(&wg_subgroupHist[i], subtotal);
+            subtotal += current;
+        }
+        local_reduction = subtotal;
+
+        if (partid < info.thread_blocks - 1u) {
+            let pass_plane = shift >> 3u;
+            let pass_index = threadid.x + pass_plane * info.thread_blocks * RADIX + (partid + 1u) * RADIX;
+            atomicStore(&pass_hist[pass_index], (local_reduction << 2u) | FLAG_REDUCTION);
+        }
+
+        let lane_mask = lane_count - 1u;
+        let circular_lane_shift = (laneid + lane_mask) & lane_mask;
+        let t = unsafeSubgroupInclusiveAdd(local_reduction);
+        wg_localHist[threadid.x] = unsafeSubgroupShuffle(t, circular_lane_shift);
+    }
+    workgroupBarrier();
+
+    if (threadid.x < lane_count) {
+        let pred = threadid.x < RADIX / lane_count;
+        let t = unsafeSubgroupExclusiveAdd(select(0u, wg_localHist[threadid.x * lane_count], pred));
+        if (pred) {
+            wg_localHist[threadid.x * lane_count] = t;
+        }
+    }
+    workgroupBarrier();
+
+    if (threadid.x < RADIX && laneid != 0u) {
+        wg_localHist[threadid.x] += wg_localHist[(threadid.x / lane_count) * lane_count];
+    }
+    workgroupBarrier();
+
+    for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+        if (keyValid[k]) {
+            let digit = (keys[k] >> shift) & RADIX_MASK;
+            let block_prefix = wg_localHist[digit];
+            if (sid == 0u) {
+                offsets[k] += block_prefix;
+            } else {
+                let subgroup_prefix = atomicLoad(&wg_subgroupHist[digit + sid * RADIX]);
+                offsets[k] += block_prefix + subgroup_prefix;
+            }
+        }
+    }
+    workgroupBarrier();
+
+    if (threadid.x < RADIX) {
+        let pass_plane = shift >> 3u;
+        let base_plane = pass_plane * info.thread_blocks * RADIX;
+        let bin = threadid.x;
+        let block_prefix = wg_localHist[bin];
+        var prev_reduction = 0u;
+        var lookbackid = partid;
+        loop {
+            let flag_payload = atomicLoad(&pass_hist[bin + base_plane + lookbackid * RADIX]);
+            if ((flag_payload & FLAG_MASK) > FLAG_NOT_READY) {
+                prev_reduction += flag_payload >> 2u;
+                if ((flag_payload & FLAG_MASK) == FLAG_INCLUSIVE) {
+                    if (partid < info.thread_blocks - 1u) {
+                        let next_idx = bin + base_plane + (partid + 1u) * RADIX;
+                        atomicStore(&pass_hist[next_idx], ((prev_reduction + local_reduction) << 2u) | FLAG_INCLUSIVE);
+                    }
+                    wg_localHist[bin] = prev_reduction - block_prefix;
+                    break;
+                } else {
+                    lookbackid -= 1u;
+                }
+            }
+        }
+    }
+    workgroupBarrier();
+
+    for (var k = 0u; k < KEYS_PER_THREAD; k += 1u) {
+        if (keyValid[k]) {
+            let digit = (keys[k] >> shift) & RADIX_MASK;
+            let global_offset = wg_localHist[digit] + offsets[k];
+            if (global_offset < info.size) {
+                alt[global_offset] = keys[k];
+                alt_payload[global_offset] = values[k];
+            }
+        }
+    }
+}
+`;
+
+export const subgroupDetectShader = `
+enable subgroups;
+
+@group(0) @binding(0)
+var<storage, read_write> outSize : array<u32, 1>;
+
+@compute @workgroup_size(1)
+fn main(@builtin(subgroup_size) subgroupSize : u32) {
+    outSize[0] = subgroupSize;
+}
+`;

--- a/src/webgpu/bvh_ray_functions.wgsl.js
+++ b/src/webgpu/bvh_ray_functions.wgsl.js
@@ -1,5 +1,9 @@
 import { wgslFn } from 'three/tsl';
-import { bvhNodeStruct, intersectionResultStruct, intersectsBounds, rayStruct, constants } from './common_functions.wgsl.js';
+import {
+	bvhNodeStruct, bvh2NodeStruct, intersectionResultStruct, intersectionResultWithStatsStruct,
+	traversalStatsStruct, intersectsBounds, intersectsBoundsBVH2, rayStruct, constants,
+	instanceStruct, tlasHitResultStruct
+} from './common_functions.wgsl.js';
 
 export const intersectsTriangle = wgslFn( /* wgsl */ `
 
@@ -173,3 +177,545 @@ export const bvhIntersectFirstHit = wgslFn( /* wgsl */ `
 	}
 
 `, [ intersectTriangles, intersectsBounds, rayStruct, bvhNodeStruct, intersectionResultStruct, constants ] );
+
+// BVH2 traversal - works directly with H-PLOC GPU builder output
+// Uses absolute child indices instead of relative offsets
+// Leaf nodes have leftChild == INVALID_IDX, rightChild == triangle index
+export const bvh2IntersectFirstHit = wgslFn( /* wgsl */ `
+
+	fn bvh2IntersectFirstHit(
+		bvh_index: ptr<storage, array<vec3u>, read>,
+		bvh_position: ptr<storage, array<vec3f>, read>,
+		bvh: ptr<storage, array<BVH2Node>, read>,
+		ray: Ray,
+		rootIndex: u32,
+	) -> IntersectionResult {
+
+		const INVALID_IDX = 0xFFFFFFFFu;
+
+		var pointer = 0;
+		var stack: array<u32, BVH_STACK_DEPTH>;
+		stack[ 0 ] = rootIndex;
+
+		var bestHit: IntersectionResult;
+
+		bestHit.didHit = false;
+		bestHit.dist = INFINITY;
+
+		loop {
+
+			if ( pointer < 0 || pointer >= i32( BVH_STACK_DEPTH ) ) {
+
+				break;
+
+			}
+
+			let currNodeIndex = stack[ pointer ];
+			let node = bvh[ currNodeIndex ];
+
+			pointer = pointer - 1;
+
+			var boundsHitDistance: f32 = 0.0;
+
+			if ( ! intersectsBoundsBVH2( ray, node.boundsMin, node.boundsMax, &boundsHitDistance ) || boundsHitDistance > bestHit.dist ) {
+
+				continue;
+
+			}
+
+			let isLeaf = node.leftChild == INVALID_IDX;
+
+			if ( isLeaf ) {
+
+				// For leaf nodes, rightChild contains the triangle index
+				let triIndex = node.rightChild;
+
+				let indices = bvh_index[ triIndex ];
+				let a = bvh_position[ indices.x ];
+				let b = bvh_position[ indices.y ];
+				let c = bvh_position[ indices.z ];
+
+				var triResult = intersectsTriangle( ray, a, b, c );
+
+				if ( triResult.didHit && triResult.dist < bestHit.dist ) {
+
+					bestHit = triResult;
+					bestHit.indices = vec4u( indices.xyz, triIndex );
+
+				}
+
+			} else {
+
+				// Internal node - use absolute child indices
+				let leftIndex = node.leftChild;
+				let rightIndex = node.rightChild;
+
+				// Determine traversal order based on ray direction and node bounds
+				// Use the largest axis of the node extent as split axis heuristic
+				let extent = node.boundsMax - node.boundsMin;
+				var splitAxis = 0u;
+				if ( extent.y > extent.x && extent.y > extent.z ) {
+					splitAxis = 1u;
+				} else if ( extent.z > extent.x ) {
+					splitAxis = 2u;
+				}
+
+				let leftToRight = ray.direction[ splitAxis ] >= 0.0;
+				let c1 = select( rightIndex, leftIndex, leftToRight );
+				let c2 = select( leftIndex, rightIndex, leftToRight );
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c2;
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c1;
+
+			}
+
+		}
+
+		return bestHit;
+
+	}
+
+`, [ intersectsTriangle, intersectsBoundsBVH2, rayStruct, bvh2NodeStruct, intersectionResultStruct, constants ] );
+
+// BVH2 traversal with statistics collection - for BVH quality comparison
+export const bvh2IntersectFirstHitWithStats = wgslFn( /* wgsl */ `
+
+	fn bvh2IntersectFirstHitWithStats(
+		bvh_index: ptr<storage, array<vec3u>, read>,
+		bvh_position: ptr<storage, array<vec3f>, read>,
+		bvh: ptr<storage, array<BVH2Node>, read>,
+		ray: Ray,
+		rootIndex: u32,
+	) -> IntersectionResultWithStats {
+
+		const INVALID_IDX = 0xFFFFFFFFu;
+
+		var pointer = 0;
+		var stack: array<u32, BVH_STACK_DEPTH>;
+		stack[ 0 ] = rootIndex;
+
+		var bestHit: IntersectionResultWithStats;
+
+		bestHit.didHit = false;
+		bestHit.dist = INFINITY;
+		bestHit.stats.nodesVisited = 0u;
+		bestHit.stats.trianglesTested = 0u;
+
+		loop {
+
+			if ( pointer < 0 || pointer >= i32( BVH_STACK_DEPTH ) ) {
+
+				break;
+
+			}
+
+			let currNodeIndex = stack[ pointer ];
+			let node = bvh[ currNodeIndex ];
+
+			pointer = pointer - 1;
+
+			bestHit.stats.nodesVisited = bestHit.stats.nodesVisited + 1u;
+
+			var boundsHitDistance: f32 = 0.0;
+
+			if ( ! intersectsBoundsBVH2( ray, node.boundsMin, node.boundsMax, &boundsHitDistance ) || boundsHitDistance > bestHit.dist ) {
+
+				continue;
+
+			}
+
+			let isLeaf = node.leftChild == INVALID_IDX;
+
+			if ( isLeaf ) {
+
+				// For leaf nodes, rightChild contains the triangle index
+				let triIndex = node.rightChild;
+
+				bestHit.stats.trianglesTested = bestHit.stats.trianglesTested + 1u;
+
+				let indices = bvh_index[ triIndex ];
+				let a = bvh_position[ indices.x ];
+				let b = bvh_position[ indices.y ];
+				let c = bvh_position[ indices.z ];
+
+				var triResult = intersectsTriangle( ray, a, b, c );
+
+				if ( triResult.didHit && triResult.dist < bestHit.dist ) {
+
+					bestHit.didHit = true;
+					bestHit.indices = vec4u( indices.xyz, triIndex );
+					bestHit.normal = triResult.normal;
+					bestHit.barycoord = triResult.barycoord;
+					bestHit.side = triResult.side;
+					bestHit.dist = triResult.dist;
+
+				}
+
+			} else {
+
+				// Internal node - use absolute child indices
+				let leftIndex = node.leftChild;
+				let rightIndex = node.rightChild;
+
+				// Determine traversal order based on ray direction and node bounds
+				let extent = node.boundsMax - node.boundsMin;
+				var splitAxis = 0u;
+				if ( extent.y > extent.x && extent.y > extent.z ) {
+					splitAxis = 1u;
+				} else if ( extent.z > extent.x ) {
+					splitAxis = 2u;
+				}
+
+				let leftToRight = ray.direction[ splitAxis ] >= 0.0;
+				let c1 = select( rightIndex, leftIndex, leftToRight );
+				let c2 = select( leftIndex, rightIndex, leftToRight );
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c2;
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c1;
+
+			}
+
+		}
+
+		return bestHit;
+
+	}
+
+`, [ intersectsTriangle, intersectsBoundsBVH2, rayStruct, bvh2NodeStruct, intersectionResultWithStatsStruct, traversalStatsStruct, constants ] );
+
+// CPU BVH (flattened) traversal with statistics collection - for BVH quality comparison
+export const bvhIntersectFirstHitWithStats = wgslFn( /* wgsl */ `
+
+	fn bvhIntersectFirstHitWithStats(
+		bvh_index: ptr<storage, array<vec3u>, read>,
+		bvh_position: ptr<storage, array<vec3f>, read>,
+		bvh: ptr<storage, array<BVHNode>,read>,
+		ray: Ray,
+	) -> IntersectionResultWithStats {
+
+		var pointer = 0;
+		var stack: array<u32, BVH_STACK_DEPTH>;
+		stack[ 0 ] = 0u;
+
+		var bestHit: IntersectionResultWithStats;
+
+		bestHit.didHit = false;
+		bestHit.dist = INFINITY;
+		bestHit.stats.nodesVisited = 0u;
+		bestHit.stats.trianglesTested = 0u;
+
+		loop {
+
+			if ( pointer < 0 || pointer >= i32( BVH_STACK_DEPTH ) ) {
+
+				break;
+
+			}
+
+			let currNodeIndex = stack[ pointer ];
+			let node = bvh[ currNodeIndex ];
+
+			pointer = pointer - 1;
+
+			bestHit.stats.nodesVisited = bestHit.stats.nodesVisited + 1u;
+
+			var boundsHitDistance: f32 = 0.0;
+
+			if ( ! intersectsBounds( ray, node.bounds, &boundsHitDistance ) || boundsHitDistance > bestHit.dist ) {
+
+				continue;
+
+			}
+
+			let boundsInfox = node.splitAxisOrTriangleCount;
+			let boundsInfoy = node.rightChildOrTriangleOffset;
+
+			let isLeaf = ( boundsInfox & 0xffff0000u ) != 0u;
+
+			if ( isLeaf ) {
+
+				let count = boundsInfox & 0x0000ffffu;
+				let offset = boundsInfoy;
+
+				for ( var i = offset; i < offset + count; i = i + 1u ) {
+
+					bestHit.stats.trianglesTested = bestHit.stats.trianglesTested + 1u;
+
+					let indices = bvh_index[ i ];
+					let a = bvh_position[ indices.x ];
+					let b = bvh_position[ indices.y ];
+					let c = bvh_position[ indices.z ];
+
+					var triResult = intersectsTriangle( ray, a, b, c );
+
+					if ( triResult.didHit && triResult.dist < bestHit.dist ) {
+
+						bestHit.didHit = true;
+						bestHit.indices = vec4u( indices.xyz, i );
+						bestHit.normal = triResult.normal;
+						bestHit.barycoord = triResult.barycoord;
+						bestHit.side = triResult.side;
+						bestHit.dist = triResult.dist;
+
+					}
+
+				}
+
+			} else {
+
+				let leftIndex = currNodeIndex + 1u;
+				let splitAxis = boundsInfox & 0x0000ffffu;
+				let rightIndex = currNodeIndex + boundsInfoy;
+
+				let leftToRight = ray.direction[splitAxis] >= 0.0;
+				let c1 = select( rightIndex, leftIndex, leftToRight );
+				let c2 = select( leftIndex, rightIndex, leftToRight );
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c2;
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c1;
+
+			}
+
+		}
+
+		return bestHit;
+
+	}
+
+`, [ intersectsTriangle, intersectsBounds, rayStruct, bvhNodeStruct, intersectionResultWithStatsStruct, traversalStatsStruct, constants ] );
+
+// BLAS intersection with local indices (for TLAS/BLAS system)
+// Returns hit in local space, caller must transform normal to world space
+export const bvh2IntersectBLAS = wgslFn( /* wgsl */ `
+
+	fn bvh2IntersectBLAS(
+		bvh_index: ptr<storage, array<vec3u>, read>,
+		bvh_position: ptr<storage, array<vec3f>, read>,
+		bvh: ptr<storage, array<BVH2Node>, read>,
+		localRay: Ray,
+		rootIndex: u32,
+		indexOffset: u32,
+		positionOffset: u32,
+		maxDist: f32,
+	) -> IntersectionResult {
+
+		const INVALID_IDX = 0xFFFFFFFFu;
+
+		var pointer = 0;
+		var stack: array<u32, BVH_STACK_DEPTH>;
+		stack[ 0 ] = rootIndex;
+
+		var bestHit: IntersectionResult;
+
+		bestHit.didHit = false;
+		bestHit.dist = maxDist;
+
+		loop {
+
+			if ( pointer < 0 || pointer >= i32( BVH_STACK_DEPTH ) ) {
+
+				break;
+
+			}
+
+			let currNodeIndex = stack[ pointer ];
+			let node = bvh[ currNodeIndex ];
+
+			pointer = pointer - 1;
+
+			var boundsHitDistance: f32 = 0.0;
+
+			if ( ! intersectsBoundsBVH2( localRay, node.boundsMin, node.boundsMax, &boundsHitDistance ) || boundsHitDistance > bestHit.dist ) {
+
+				continue;
+
+			}
+
+			let isLeaf = node.leftChild == INVALID_IDX;
+
+			if ( isLeaf ) {
+
+				// For leaf nodes, rightChild contains the local triangle index
+				let localTriIndex = node.rightChild;
+				let globalTriIndex = indexOffset + localTriIndex;
+
+				let indices = bvh_index[ globalTriIndex ];
+				let a = bvh_position[ indices.x ];
+				let b = bvh_position[ indices.y ];
+				let c = bvh_position[ indices.z ];
+
+				var triResult = intersectsTriangle( localRay, a, b, c );
+
+				if ( triResult.didHit && triResult.dist < bestHit.dist ) {
+
+					bestHit = triResult;
+					bestHit.indices = vec4u( indices.xyz, globalTriIndex );
+
+				}
+
+			} else {
+
+				let leftIndex = node.leftChild;
+				let rightIndex = node.rightChild;
+
+				let extent = node.boundsMax - node.boundsMin;
+				var splitAxis = 0u;
+				if ( extent.y > extent.x && extent.y > extent.z ) {
+					splitAxis = 1u;
+				} else if ( extent.z > extent.x ) {
+					splitAxis = 2u;
+				}
+
+				let leftToRight = localRay.direction[ splitAxis ] >= 0.0;
+				let c1 = select( rightIndex, leftIndex, leftToRight );
+				let c2 = select( leftIndex, rightIndex, leftToRight );
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c2;
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c1;
+
+			}
+
+		}
+
+		return bestHit;
+
+	}
+
+`, [ intersectsTriangle, intersectsBoundsBVH2, rayStruct, bvh2NodeStruct, intersectionResultStruct, constants ] );
+
+// Two-level BVH traversal: TLAS over instances, BLAS for geometry
+// TLAS is a simple BVH2 over instance AABBs
+// Each TLAS leaf contains an instance index
+export const tlasBlasIntersect = wgslFn( /* wgsl */ `
+
+	fn tlasBlasIntersect(
+		tlas: ptr<storage, array<BVH2Node>, read>,
+		instances: ptr<storage, array<Instance>, read>,
+		blas: ptr<storage, array<BVH2Node>, read>,
+		bvh_index: ptr<storage, array<vec3u>, read>,
+		bvh_position: ptr<storage, array<vec3f>, read>,
+		worldRay: Ray,
+		tlasRootIndex: u32,
+	) -> TLASHitResult {
+
+		const INVALID_IDX = 0xFFFFFFFFu;
+		const INSTANCE_FLAG = 0x80000000u;
+
+		var pointer = 0;
+		var stack: array<u32, BVH_STACK_DEPTH>;
+		stack[ 0 ] = tlasRootIndex;
+
+		var bestHit: TLASHitResult;
+		bestHit.didHit = false;
+		bestHit.dist = INFINITY;
+		bestHit.instanceIndex = 0u;
+		bestHit.materialIndex = 0u;
+
+		loop {
+
+			if ( pointer < 0 || pointer >= i32( BVH_STACK_DEPTH ) ) {
+
+				break;
+
+			}
+
+			let currNodeIndex = stack[ pointer ];
+			let node = tlas[ currNodeIndex ];
+
+			pointer = pointer - 1;
+
+			var boundsHitDistance: f32 = 0.0;
+
+			if ( ! intersectsBoundsBVH2( worldRay, node.boundsMin, node.boundsMax, &boundsHitDistance ) || boundsHitDistance > bestHit.dist ) {
+
+				continue;
+
+			}
+
+			let isLeaf = node.leftChild == INVALID_IDX;
+
+			if ( isLeaf ) {
+
+				// TLAS leaf: rightChild contains instance index
+				let instanceIndex = node.rightChild;
+				let instance = instances[ instanceIndex ];
+
+				// Transform ray to local space
+				var localRay: Ray;
+				let origin4 = instance.inverseTransform * vec4f( worldRay.origin, 1.0 );
+				localRay.origin = origin4.xyz;
+				let dir4 = instance.inverseTransform * vec4f( worldRay.direction, 0.0 );
+				localRay.direction = dir4.xyz;
+
+				// Traverse BLAS in local space
+				let blasHit = bvh2IntersectBLAS(
+					bvh_index,
+					bvh_position,
+					blas,
+					localRay,
+					instance.blasRootIndex + instance.blasOffset,
+					instance.indexOffset,
+					instance.positionOffset,
+					bestHit.dist
+				);
+
+				if ( blasHit.didHit && blasHit.dist < bestHit.dist ) {
+
+					bestHit.didHit = true;
+					bestHit.dist = blasHit.dist;
+					bestHit.indices = blasHit.indices;
+					bestHit.barycoord = blasHit.barycoord;
+					bestHit.side = blasHit.side;
+					bestHit.instanceIndex = instanceIndex;
+					bestHit.materialIndex = instance.materialIndex;
+
+					// Transform normal from local to world space
+					let n4 = transpose( instance.inverseTransform ) * vec4f( blasHit.normal, 0.0 );
+					bestHit.normal = normalize( n4.xyz );
+
+				}
+
+			} else {
+
+				let leftIndex = node.leftChild;
+				let rightIndex = node.rightChild;
+
+				let extent = node.boundsMax - node.boundsMin;
+				var splitAxis = 0u;
+				if ( extent.y > extent.x && extent.y > extent.z ) {
+					splitAxis = 1u;
+				} else if ( extent.z > extent.x ) {
+					splitAxis = 2u;
+				}
+
+				let leftToRight = worldRay.direction[ splitAxis ] >= 0.0;
+				let c1 = select( rightIndex, leftIndex, leftToRight );
+				let c2 = select( leftIndex, rightIndex, leftToRight );
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c2;
+
+				pointer = pointer + 1;
+				stack[ pointer ] = c1;
+
+			}
+
+		}
+
+		return bestHit;
+
+	}
+
+`, [ bvh2IntersectBLAS, intersectsBoundsBVH2, rayStruct, bvh2NodeStruct, instanceStruct, tlasHitResultStruct, constants ] );


### PR DESCRIPTION
This PR adds a H-PLOC-like GPU BVH2 builder for WebGPU and wires it into new/updated WebGPU examples. It's a draft as there's a lot going on still and discussion is needed for sure. :)

Adds:
- GPUMeshBVH with GPU build/refit paths.
- build from CPU geometry and directly from GPU buffers.
- the OneSweep sorter
- BVH2 traversal support

Performance:

**The timings in the videos are incorrect, as the build/refit are both async, so those displayed times are submit only. But for a ~900k triangle asset, the BVH builds in ~13 ms, and is refit in ~5 ms.** Optionally timing queries can be enabled in the skinned mesh example, but they add quite a bit of overhead. Generally I think there's room for improvement here, but it does get quite tricky quite fast with WebGPU's limitations. I do have a BVH validator example locally, which is used to benchmark the performance and measure the quality of the BVH, but I not sure if it's a great fit for the PR scope.

Documentation: ✅ 

Examples:
 
- example/webgpu_skinnedMesh.html/js (Full GPU skinning + BVH rebuild/refit flow)

https://github.com/user-attachments/assets/2013fd91-b679-473a-9dae-0546d8a7768d

- example/webgpu_explodingMesh.html/js (Worst case for refit, makes the case for fast full rebuilds)
      
https://github.com/user-attachments/assets/8154a9be-58ca-4953-8724-798ebbbe8013

- example/webgpu_gpuPathTracingSimple_gpuBuild.html/js (same as the existing one, but just with GPU build)

https://github.com/user-attachments/assets/3347cde1-e553-43b1-a8a2-b2dfc795127a

- TLAS/BLAS example? I have one locally, but maybe too much for repo?

https://github.com/user-attachments/assets/3d439744-32a6-4ae8-9df9-275a3cfa8aa6

- shared heavy asset (about a 900k tris asset): example/inferno-beast-from-space-from-jurafjvs-cc0-2.glb