### PR TITLE
TS: Correct boundingData type to Float32Array for the traverse function

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,7 +104,7 @@ export class BVH {
 		callback: (
 			depth: number,
 			isLeaf: boolean,
-			boundingData: ArrayBuffer,
+			boundingData: Float32Array,
 			offsetOrSplit: number,
 			count: number
 		) => void,


### PR DESCRIPTION
See discussion in https://github.com/gkjohnson/three-mesh-bvh/issues/816#issuecomment-4257784707