### PR TITLE
Fix WebGPU SDF storage buffer vector reads

### DIFF
--- a/example/webgpu_sdfGeneration.js
+++ b/example/webgpu_sdfGeneration.js
@@ -107,8 +107,9 @@ async function init() {
 		matrix: uniform( new THREE.Matrix4() ),
 		dim: uniform( 0 ),
 
-		bvh_index: storage( geom_index, 'uvec3', geom_index.count ).toReadOnly(),
-		bvh_position: storage( geom_position, 'vec3', geom_position.count ).toReadOnly(),
+		// Read as vec4 because storage-buffer vec3 array reads are padded to 16-byte stride.
+		bvh_index: storage( geom_index, 'uvec4', geom_index.count ).toReadOnly(),
+		bvh_position: storage( geom_position, 'vec4', geom_position.count ).toReadOnly(),
 		bvh: storage( bvhNodes, 'BVHNode', bvhNodes.count ).toReadOnly(),
 
 		globalId: globalId,
@@ -118,8 +119,8 @@ async function init() {
 	const computeShader = wgslFn( /* wgsl */ `
 
 		fn computeSdf(
-			bvh_index: ptr<storage, array<vec3u>, read>,
-			bvh_position: ptr<storage, array<vec3f>, read>,
+			bvh_index: ptr<storage, array<vec4u>, read>,
+			bvh_position: ptr<storage, array<vec4f>, read>,
 			bvh: ptr<storage, array<BVHNode>, read>,
 
 			matrix: mat4x4f,

--- a/src/webgpu/distance_functions.wgsl.js
+++ b/src/webgpu/distance_functions.wgsl.js
@@ -74,8 +74,9 @@ export const closestPointToTriangle = wgslFn( /* wgsl */ `
 export const distanceToTriangles = wgslFn( /* wgsl */ `
 	fn distanceToTriangles(
 		// geometry info and triangle range
-		bvh_index: ptr<storage, array<vec3u>, read>,
-		bvh_position: ptr<storage, array<vec3f>, read>,
+		// Read geometry as vec4 because storage-buffer vec3 array elements use 16-byte stride.
+		bvh_index: ptr<storage, array<vec4u>, read>,
+		bvh_position: ptr<storage, array<vec4f>, read>,
 
 		offset: u32, count: u32,
 
@@ -87,9 +88,9 @@ export const distanceToTriangles = wgslFn( /* wgsl */ `
 		for ( var i = offset; i < offset + count; i = i + 1u ) {
 
 			let indices = bvh_index[ i ];
-			let a = bvh_position[ indices.x ];
-			let b = bvh_position[ indices.y ];
-			let c = bvh_position[ indices.z ];
+			let a = bvh_position[ indices.x ].xyz;
+			let b = bvh_position[ indices.y ].xyz;
+			let c = bvh_position[ indices.z ].xyz;
 
 			// get the closest point and barycoord
 			let pointRes = closestPointToTriangle( point, a, b, c );
@@ -139,8 +140,8 @@ export const distanceSqToBVHNodeBoundsPoint = wgslFn( /* wgsl */ `
 
 export const closestPointToPoint = wgslFn( /* wgsl */ `
 	fn bvhClosestPointToPoint(
-		bvh_index: ptr<storage, array<vec3u>, read>,
-		bvh_position: ptr<storage, array<vec3f>, read>,
+		bvh_index: ptr<storage, array<vec4u>, read>,
+		bvh_position: ptr<storage, array<vec4f>, read>,
 		bvh: ptr<storage, array<BVHNode>, read>,
 
 		point: vec3f,


### PR DESCRIPTION
### Summary

- Read WebGPU BVH index and position storage buffers as vec4 in the SDF example and closest-point WGSL helpers.
- Keep the source StorageBufferAttribute itemSize at 3 so the WebGPU backend can pad to 16-byte stride.
- Use `.xyz` when consuming index and position values.

### Context

Safari WebGPU produced zero SDF output when dynamically reading geometry storage buffers declared as `array<vec3u>` / `array<vec3f>`. Reading the same padded buffers as `array<vec4u>` / `array<vec4f>` avoids the issue and matches the 16-byte stride layout used for vec3 storage-buffer array elements.

### Testing

- Verified locally in Safari: SDF readback is no longer all zeros and raymarching renders.
- `node --check example/webgpu_sdfGeneration.js`
- `node --check src/webgpu/distance_functions.wgsl.js`
- `git diff --check -- example/webgpu_sdfGeneration.js src/webgpu/distance_functions.wgsl.js`
