### PR TITLE
fix: avoid UMD self-require in ObjectBVH and SkinnedMeshBVH

### DIFF
--- a/src/core/ObjectBVH.js
+++ b/src/core/ObjectBVH.js
@@ -1,7 +1,8 @@
 /** @import { Object3D } from 'three' */
 /** @import { IntersectsBoundsCallback, IntersectsRangeCallback, BoundsTraverseOrderCallback } from './BVH.js' */
 import { Box3, BufferGeometry, Matrix4, Mesh, Vector3, Ray, Sphere } from 'three';
-import { BVH, INTERSECTED, NOT_INTERSECTED } from 'three-mesh-bvh';
+import { BVH } from './BVH.js';
+import { INTERSECTED, NOT_INTERSECTED } from './Constants.js';
 
 const _geometry = /* @__PURE__ */ new BufferGeometry();
 const _matrix = /* @__PURE__ */ new Matrix4();

--- a/src/core/SkinnedMeshBVH.js
+++ b/src/core/SkinnedMeshBVH.js
@@ -1,7 +1,9 @@
 /** @import { SkinnedMesh } from 'three' */
 /** @import { IntersectsBoundsCallback, IntersectsRangeCallback, BoundsTraverseOrderCallback } from './BVH.js' */
 import { Vector3, Vector2, Ray, Matrix4, FrontSide, BackSide, Triangle, REVISION } from 'three';
-import { GeometryBVH, ExtendedTriangle, INTERSECTED, NOT_INTERSECTED, SKIP_GENERATION } from 'three-mesh-bvh';
+import { GeometryBVH } from './GeometryBVH.js';
+import { ExtendedTriangle } from '../math/ExtendedTriangle.js';
+import { INTERSECTED, NOT_INTERSECTED, SKIP_GENERATION } from './Constants.js';
 
 const _v0 = /* @__PURE__ */ new Vector3();
 const _v1 = /* @__PURE__ */ new Vector3();


### PR DESCRIPTION
## Summary

Fixes #862. `ObjectBVH` and `SkinnedMeshBVH` were the only files under `src/core/` importing their siblings via the package's own bare specifier (`from 'three-mesh-bvh'`) instead of relative paths. This caused the generated UMD bundle to `require` itself, which breaks every CJS consumer with `TypeError: Class extends value undefined is not a constructor or null`. This PR switches those two imports to the relative paths used by every other file in `src/core/`.

## The bug, briefly

Rollup treats `'three-mesh-bvh'` as an external when bundling the UMD build (it is the package's own name), so `build/index.umd.cjs` ends up wrapping the factory like this:

```js
typeof exports === 'object' && typeof module !== 'undefined'
    ? factory(exports, require('three'), require('three-mesh-bvh'))   // self-require
    : ...
```

Because `build/index.umd.cjs` is also the `main`/`require` entry of `three-mesh-bvh`, the inner `require('three-mesh-bvh')` resolves back to the same module while it is still mid-evaluation. Node returns the partially-populated `module.exports` (no exports have been assigned yet), so `threeMeshBvh.BVH` and `threeMeshBvh.GeometryBVH` are `undefined` when the `class ObjectBVH extends threeMeshBvh.BVH` and `class SkinnedMeshBVH extends threeMeshBvh.GeometryBVH` declarations run.

ESM consumers are unaffected because ESM live bindings settle the cycle before the `extends` clause is evaluated. 0.9.8 is unaffected because these two files did not exist yet in `src/core/` and the UMD bundle only externalized `three`.

## The change

```diff
 // src/core/ObjectBVH.js
-import { BVH, INTERSECTED, NOT_INTERSECTED } from 'three-mesh-bvh';
+import { BVH } from './BVH.js';
+import { INTERSECTED, NOT_INTERSECTED } from './Constants.js';
```

```diff
 // src/core/SkinnedMeshBVH.js
-import { GeometryBVH, ExtendedTriangle, INTERSECTED, NOT_INTERSECTED, SKIP_GENERATION } from 'three-mesh-bvh';
+import { GeometryBVH } from './GeometryBVH.js';
+import { ExtendedTriangle } from '../math/ExtendedTriangle.js';
+import { INTERSECTED, NOT_INTERSECTED, SKIP_GENERATION } from './Constants.js';
```

Two files touched, five lines changed in total. No public API change, no type-definition change.

## Side-effect analysis

- **ESM consumers**: behaviorally identical. Whether you reach `BVH` through `src/index.js` (which re-exports from `./BVH.js`) or directly through `./BVH.js`, ESM module caching guarantees the same class instance. The full test suite confirms this — see below.
- **CJS / UMD consumers**: this is the fix. After rebuilding, the UMD factory only externalizes `three`:
  ```js
  factory(exports, require('three'))
  ```
  and `BVH`, `GeometryBVH`, `ObjectBVH`, `SkinnedMeshBVH` are all defined as expected.
- **Bundle size**: effectively unchanged. The symbols were already being pulled into the UMD bundle through `src/index.js`; the change only affects how Rollup resolves them, not whether they end up in the bundle.
- **Type definitions (`src/index.d.ts`)**: not touched.

## Verification

1. `npm run build` — UMD now externalizes only `three`:
   ```
   $ head -2 build/index.umd.cjs
   (function (global, factory) {
       typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('three')) :
   ```
2. `npm run test` — all **30,224** tests pass across 21 files, including the 600-test `ObjectBVH.test.js` and 600-test `SkinnedMeshBVH.test.js` suites.
3. `npm run lint` — no new errors introduced (existing warnings only, all unrelated).
4. CJS smoke check, loading the rebuilt UMD from a Node CJS entry point:
   ```js
   const bvh = require('./build/index.umd.cjs');
   // OK: ObjectBVH extends BVH, SkinnedMeshBVH extends GeometryBVH
   ```
   Previously this threw `Class extends value undefined is not a constructor or null` at module load.

## Test coverage

I considered adding a regression test that loads `build/index.umd.cjs` from a CJS context, but the existing test suite is Vitest/ESM only and there is no current precedent for testing built artifacts. The existing 600 + 600 tests for `ObjectBVH` and `SkinnedMeshBVH` already exercise the affected classes thoroughly, and the bug is in the build output rather than the source semantics. Happy to add a small CJS load test in `test/` if you would like one — just let me know the shape you prefer.
