### PR TITLE
Suppress coplanar-triangles warning in distanceToTriangle

### DIFF
--- a/src/math/ExtendedTriangle.js
+++ b/src/math/ExtendedTriangle.js
@@ -782,7 +782,11 @@ ExtendedTriangle.prototype.distanceToTriangle = ( function () {
 	return function distanceToTriangle( other, target1 = null, target2 = null ) {
 
 		const lineTarget = target1 || target2 ? line1 : null;
-		if ( this.intersectsTriangle( other, lineTarget ) ) {
+		// `intersectsTriangle` returns a zero-length segment for coplanar
+		// intersecting triangles, which is fine for our purposes here. We
+		// don't need the segment itself in this function. So we can suppress
+		// the warning about coplanar triangles.
+		if ( this.intersectsTriangle( other, lineTarget, true ) ) {
 
 			if ( target1 || target2 ) {
 


### PR DESCRIPTION
Closes #871

Per your comment, `intersectsTriangle` returns 0 for the distance if the triangles are coplanar with is fine for `distanceToTriangle`, so we can suppress the warning.