### PR TITLE
ObjectBVH: Fix "firstHitOnly" early out

### DIFF
--- a/src/core/LineBVH.js
+++ b/src/core/LineBVH.js
@@ -122,18 +122,18 @@ export class LineSegmentsBVH extends GeometryBVH {
 			},
 			intersectsBounds: box => {
 
-				_box.copy( box ).expandByScalar( Math.abs( localThreshold ) );
+				_box.copy( box ).expandByScalar( localThreshold );
 
 				if ( firstHitOnly ) {
 
-					if ( ! _ray.intersectBox( box, _vec ) ) {
+					if ( ! _ray.intersectBox( _box, _vec ) ) {
 
 						return NOT_INTERSECTED;
 
 					}
 
 					let dist;
-					if ( box.containsPoint( _ray.origin ) ) {
+					if ( _box.containsPoint( _ray.origin ) ) {
 
 						dist = 0;
 

--- a/src/core/LineBVH.js
+++ b/src/core/LineBVH.js
@@ -11,6 +11,7 @@ const _linePool = /* @__PURE__ */ new PrimitivePool( () => new Line3() );
 const _intersectPointOnRay = /*@__PURE__*/ new Vector3();
 const _intersectPointOnSegment = /*@__PURE__*/ new Vector3();
 const _box = /* @__PURE__ */ new Box3();
+const _vec = /* @__PURE__ */ new Vector3();
 const _getters = [ 'getX', 'getY', 'getZ' ];
 
 /**
@@ -121,9 +122,36 @@ export class LineSegmentsBVH extends GeometryBVH {
 			},
 			intersectsBounds: box => {
 
-				// TODO: for some reason trying to early-out here is causing firstHitOnly tests to fail
 				_box.copy( box ).expandByScalar( Math.abs( localThreshold ) );
-				return _ray.intersectsBox( _box ) ? INTERSECTED : NOT_INTERSECTED;
+
+				if ( firstHitOnly ) {
+
+					if ( ! _ray.intersectBox( box, _vec ) ) {
+
+						return NOT_INTERSECTED;
+
+					}
+
+					let dist;
+					if ( box.containsPoint( _ray.origin ) ) {
+
+						dist = 0;
+
+					} else {
+
+						_vec.applyMatrix4( matrixWorld );
+						dist = raycaster.ray.origin.distanceTo( _vec );
+
+					}
+
+					// early out if the box is further than the closest raycast
+					return dist < closestDistance ? INTERSECTED : NOT_INTERSECTED;
+
+				} else {
+
+					return _ray.intersectsBox( _box ) ? INTERSECTED : NOT_INTERSECTED;
+
+				}
 
 			},
 			intersectsLine: ( line, index ) => {

--- a/src/core/ObjectBVH.js
+++ b/src/core/ObjectBVH.js
@@ -56,7 +56,7 @@ export class ObjectBVH extends BVH {
 		// for the instanceId count
 		const objects = Array.from( objectSet );
 		const idBits = Math.ceil( Math.log2( objects.length ) );
-		const idMask = constructIdMask( idBits );
+		const idMask = ( 1 << idBits ) - 1;
 
 		this.objects = objects;
 		this.idBits = idBits;
@@ -100,7 +100,11 @@ export class ObjectBVH extends BVH {
 
 	init( options ) {
 
-		const { objects, idBits } = this;
+		const { objects, idBits, matrixWorld } = this;
+
+		// pre-cache the inverse matrix for use in the "getPrimitiveBoundingBox" function
+		_inverseMatrix.copy( matrixWorld ).invert();
+
 		this.primitiveBuffer = new Uint32Array( this._countPrimitives( objects ) );
 		this._fillPrimitiveBuffer( objects, idBits, this.primitiveBuffer );
 
@@ -108,15 +112,21 @@ export class ObjectBVH extends BVH {
 
 	}
 
-	writePrimitiveBounds( i, targetBuffer, writeOffset ) {
+	refit( ...args ) {
 
-		// TODO: it would be best to cache this matrix inversion
-		const { primitiveBuffer } = this;
+		// pre-cache the inverse matrix for use in the "getPrimitiveBoundingBox" function
 		_inverseMatrix.copy( this.matrixWorld ).invert();
 
-		this._getPrimitiveBoundingBox( primitiveBuffer[ i ], _inverseMatrix, _box );
-		const { min, max } = _box;
+		super.refit( ...args );
 
+	}
+
+	writePrimitiveBounds( i, targetBuffer, writeOffset ) {
+
+		const { primitiveBuffer } = this;
+		this._getPrimitiveBoundingBox( primitiveBuffer[ i ], _inverseMatrix, _box );
+
+		const { min, max } = _box;
 		targetBuffer[ writeOffset + 0 ] = min.x;
 		targetBuffer[ writeOffset + 1 ] = min.y;
 		targetBuffer[ writeOffset + 2 ] = min.z;
@@ -186,9 +196,20 @@ export class ObjectBVH extends BVH {
 
 					}
 
+					let dist;
+					if ( box.containsPoint( _ray.origin ) ) {
+
+						dist = 0;
+
+					} else {
+
+						_vec.applyMatrix4( matrixWorld );
+						dist = raycaster.ray.origin.distanceTo( _vec );
+
+					}
+
 					// early out if the box is further than the closest raycast
-					_vec.applyMatrix4( matrixWorld );
-					return raycaster.ray.origin.distanceTo( _vec ) < closestDistance ? INTERSECTED : NOT_INTERSECTED;
+					return dist < closestDistance ? INTERSECTED : NOT_INTERSECTED;
 
 				} else {
 
@@ -545,20 +566,6 @@ export class ObjectBVH extends BVH {
 }
 
 // id functions
-// construct a mask with the given number of bits set to 1
-function constructIdMask( idBits ) {
-
-	let mask = 0;
-	for ( let i = 0; i < idBits; i ++ ) {
-
-		mask = mask << 1 | 1;
-
-	}
-
-	return mask;
-
-}
-
 // extract the primary object id given the provided mask
 function getObjectId( id, idMask ) {
 

--- a/src/core/PointsBVH.js
+++ b/src/core/PointsBVH.js
@@ -113,18 +113,18 @@ export class PointsBVH extends GeometryBVH {
 			},
 			intersectsBounds: box => {
 
-				_box.copy( box ).expandByScalar( Math.abs( localThreshold ) );
+				_box.copy( box ).expandByScalar( localThreshold );
 
 				if ( firstHitOnly ) {
 
-					if ( ! _ray.intersectBox( box, _vec ) ) {
+					if ( ! _ray.intersectBox( _box, _vec ) ) {
 
 						return NOT_INTERSECTED;
 
 					}
 
 					let dist;
-					if ( box.containsPoint( _ray.origin ) ) {
+					if ( _box.containsPoint( _ray.origin ) ) {
 
 						dist = 0;
 
@@ -148,6 +148,7 @@ export class PointsBVH extends GeometryBVH {
 			intersectsPoint: ( point, index ) => {
 
 				const rayPointDistanceSq = _ray.distanceSqToPoint( point );
+
 				if ( rayPointDistanceSq < localThresholdSq ) {
 
 					const intersectPoint = new Vector3();

--- a/src/core/PointsBVH.js
+++ b/src/core/PointsBVH.js
@@ -8,6 +8,7 @@ const _inverseMatrix = /* @__PURE__ */ new Matrix4();
 const _ray = /* @__PURE__ */ new Ray();
 const _pointPool = /* @__PURE__ */ new PrimitivePool( () => new Vector3() );
 const _box = /* @__PURE__ */ new Box3();
+const _vec = /* @__PURE__ */ new Vector3();
 
 /**
  * @callback IntersectsPointCallback
@@ -112,9 +113,36 @@ export class PointsBVH extends GeometryBVH {
 			},
 			intersectsBounds: box => {
 
-				// TODO: for some reason trying to early-out here is causing firstHitOnly tests to fail
 				_box.copy( box ).expandByScalar( Math.abs( localThreshold ) );
-				return _ray.intersectsBox( _box ) ? INTERSECTED : NOT_INTERSECTED;
+
+				if ( firstHitOnly ) {
+
+					if ( ! _ray.intersectBox( box, _vec ) ) {
+
+						return NOT_INTERSECTED;
+
+					}
+
+					let dist;
+					if ( box.containsPoint( _ray.origin ) ) {
+
+						dist = 0;
+
+					} else {
+
+						_vec.applyMatrix4( matrixWorld );
+						dist = raycaster.ray.origin.distanceTo( _vec );
+
+					}
+
+					// early out if the box is further than the closest raycast
+					return dist < closestDistance ? INTERSECTED : NOT_INTERSECTED;
+
+				} else {
+
+					return _ray.intersectsBox( _box ) ? INTERSECTED : NOT_INTERSECTED;
+
+				}
 
 			},
 			intersectsPoint: ( point, index ) => {

--- a/src/core/SkinnedMeshBVH.js
+++ b/src/core/SkinnedMeshBVH.js
@@ -11,6 +11,7 @@ const _v2 = /* @__PURE__ */ new Vector3();
 const _ray = /* @__PURE__ */ new Ray();
 const _inverseMatrix = /* @__PURE__ */ new Matrix4();
 const _localPoint = /* @__PURE__ */ new Vector3();
+const _vec = /* @__PURE__ */ new Vector3();
 const _axes = [ 'x', 'y', 'z' ];
 
 const IS_GT_REVISION_169 = parseInt( REVISION ) >= 169;
@@ -177,7 +178,34 @@ export class SkinnedMeshBVH extends GeometryBVH {
 			},
 			intersectsBounds: box => {
 
-				return _ray.intersectsBox( box ) ? INTERSECTED : NOT_INTERSECTED;
+				if ( firstHitOnly ) {
+
+					if ( ! _ray.intersectBox( box, _vec ) ) {
+
+						return NOT_INTERSECTED;
+
+					}
+
+					let dist;
+					if ( box.containsPoint( _ray.origin ) ) {
+
+						dist = 0;
+
+					} else {
+
+						_vec.applyMatrix4( matrixWorld );
+						dist = raycaster.ray.origin.distanceTo( _vec );
+
+					}
+
+					// early out if the box is further than the closest raycast
+					return dist < closestDistance ? INTERSECTED : NOT_INTERSECTED;
+
+				} else {
+
+					return _ray.intersectsBox( box ) ? INTERSECTED : NOT_INTERSECTED;
+
+				}
 
 			},
 			intersectsTriangle: ( tri, triIndex ) => {


### PR DESCRIPTION
Related to #891

Includes some improvements from #891, and fixes a first hit only bug relating to "ray.intersectBox" not returning "0" if the origin is inside the bounds.

**TODO**
- Review LineBVH, PointsBVH, SkinnedMeshBVH to add improvement
- validate points bvh intersection logic
