### PR TITLE
BVHComputeData: Add utility features

### DIFF
--- a/src/webgpu/BVHComputeData.js
+++ b/src/webgpu/BVHComputeData.js
@@ -194,6 +194,7 @@ export class BVHComputeData {
 	 * @param {string} [options.name] - Function name. Defaults to a random identifier.
 	 * @param {StructTypeNode} options.shapeStruct - TSL struct or definition describing the query shape.
 	 * @param {StructTypeNode|null} [options.resultStruct] - TSL struct for the accumulated result, or null.
+	 * @param {Function|null} [options.prefixFn] - function node that runs before the bvh traversal - useful for resetting or initializing necessary module variables.
 	 * @param {Function|null} [options.boundsOrderFn] - function node controlling left/right child traversal order.
 	 * @param {Function} options.intersectsBoundsFn - function node testing the shape against a BVH node's bounds.
 	 * @param {Function} options.intersectRangeFn - function node testing the shape against a leaf triangle range.

--- a/src/webgpu/nodes/WGSLTagFnNode.js
+++ b/src/webgpu/nodes/WGSLTagFnNode.js
@@ -70,13 +70,21 @@ function extractIncludes( args ) {
 
 // normalize args so generate can resolve them uniformly with build():
 // - callable wrappers > PropertyRefNode (emits just the function name)
-function normalizeArgs( args ) {
+function normalizeArgs( args, builder ) {
 
 	return args.map( arg => {
 
+		if ( arg && ! arg.isNode && arg instanceof Function ) {
+
+			arg = arg( builder );
+
+		}
+
 		if ( arg && arg.isNode ) {
 
-			if ( arg instanceof WGSLTagCodeNode ) {
+			// TODO: this need to be made to work fluidly with the proxy node w/ context
+			// instanceof is not safe for the proxy case
+			if ( arg instanceof WGSLTagCodeNode || arg.isFn ) {
 
 				// use a custom flag for this node to inline the output
 				return new PropertyRefNode( arg, 'inline' );
@@ -139,6 +147,7 @@ export class WGSLTagFnNode extends FunctionNode {
 
 		super( '', extractIncludes( args ), lang );
 
+		this.isWGSLTagFnNode = true;
 		this.tokens = tokens;
 		this.args = args;
 
@@ -148,7 +157,7 @@ export class WGSLTagFnNode extends FunctionNode {
 	getNodeFunction( builder ) {
 
 		const { tokens } = this;
-		const args = normalizeArgs( this.args );
+		const args = normalizeArgs( this.args, builder );
 
 		const nodeData = builder.getDataFromNode( this );
 		let nodeFunction = nodeData.nodeFunction;
@@ -210,7 +219,7 @@ export class WGSLTagFnNode extends FunctionNode {
 	generate( builder, output ) {
 
 		const result = super.generate( builder, output );
-		const fullCode = assembleTemplate( this.tokens, normalizeArgs( this.args ), builder );
+		const fullCode = assembleTemplate( this.tokens, normalizeArgs( this.args, builder ), builder );
 
 		const { type } = this.getNodeFunction( builder );
 		const nodeCode = builder.getCodeFromNode( this, type );
@@ -234,6 +243,7 @@ export class WGSLTagCodeNode extends CodeNode {
 
 		super( '', extractIncludes( args ), lang );
 
+		this.isWGSLTagCodeNode = true;
 		this.tokens = tokens;
 		this.args = args;
 
@@ -243,7 +253,7 @@ export class WGSLTagCodeNode extends CodeNode {
 
 		if ( output === 'inline' ) {
 
-			return assembleTemplate( this.tokens, normalizeArgs( this.args ), builder );
+			return assembleTemplate( this.tokens, normalizeArgs( this.args, builder ), builder );
 
 		} else {
 
@@ -258,7 +268,7 @@ export class WGSLTagCodeNode extends CodeNode {
 		super.generate( builder );
 
 		const nodeCode = builder.getCodeFromNode( this, this.getNodeType( builder ) );
-		nodeCode.code = assembleTemplate( this.tokens, normalizeArgs( this.args ), builder );
+		nodeCode.code = assembleTemplate( this.tokens, normalizeArgs( this.args, builder ), builder );
 		return nodeCode.code;
 
 	}

--- a/src/webgpu/shapecastFns/getShapecastFn.js
+++ b/src/webgpu/shapecastFns/getShapecastFn.js
@@ -34,6 +34,7 @@ export function getShapecastFn( bvhData, options ) {
 		shapeStruct,
 		resultStruct = null,
 
+		prefixFn = null,
 		boundsOrderFn = null,
 		intersectsBoundsFn,
 		intersectRangeFn,
@@ -44,6 +45,13 @@ export function getShapecastFn( bvhData, options ) {
 
 	// these are proxy nodes, so they can be referenced before the storage buffers exist
 	const { nodes, transforms } = bvhData.storage;
+
+	let prefixSnippet = '';
+	if ( prefixFn ) {
+
+		prefixSnippet = wgslTagCode/* wgsl */`${ prefixFn }();`;
+
+	}
 
 	// handle optional functions
 	let transformResultSnippet = '';
@@ -88,6 +96,8 @@ export function getShapecastFn( bvhData, options ) {
 	const tlasFn = wgslTagFn/* wgsl */`
 		// fn
 		fn ${ name }( shape: ${ shapeStruct }, ${ resultPtrSnippet } ) -> bool {
+
+			${ prefixSnippet }
 
 			var didHit = false;
 

--- a/src/webgpu/shapecastFns/getShapecastFn.js
+++ b/src/webgpu/shapecastFns/getShapecastFn.js
@@ -14,6 +14,7 @@ import { BVH_STACK_DEPTH } from '../tsl/constants.js';
  * @param {string} [options.name] - Function name. Defaults to a random identifier.
  * @param {StructTypeNode} options.shapeStruct - TSL struct or definition describing the query shape.
  * @param {StructTypeNode|null} [options.resultStruct] - TSL struct for the accumulated result, or null.
+ * @param {Function|null} [options.prefixFn] - function node that runs before the bvh traversal - useful for resetting or initializing necessary module variables.
  * @param {Function|null} [options.boundsOrderFn] - function node controlling left/right child traversal order.
  * @param {Function} options.intersectsBoundsFn - function node testing the shape against a BVH node's bounds.
  * @param {Function} options.intersectRangeFn - function node testing the shape against a leaf triangle range.


### PR DESCRIPTION
Related to #884 

- Add support for a "prefix" function to run initialization ahead of time
- Add support for inline functions returning the node to inline for "define"-like logic
- Add support for context proxy node

**TODO**
- Reduce / remove storage buffer reinitialization on update
- Test Fn nodes
