### PR TITLE
Fix GPU queries of multi-geometry BatchedMesh

### DIFF
--- a/src/webgpu/BVHComputeData.js
+++ b/src/webgpu/BVHComputeData.js
@@ -376,6 +376,9 @@ export class BVHComputeData {
 		bvhInfo.forEach( info => {
 
 			info.geometryOffset = indexOffset / 3;
+			// A non-indirect bvh built over a sub-range stores absolute leaf offsets, so shift the
+			// base back by the range's triangle start.
+			if ( ! info.bvh.indirect ) info.geometryOffset -= info.range.start / 3;
 			appendIndexData( info.bvh, info.range, attributesOffset, indexOffset, indexBuffer );
 			appendGeometryData( info.bvh, info.range, attributesOffset, attributesBuffer, attributeStruct, this );
 

--- a/src/webgpu/BVHComputeData.js
+++ b/src/webgpu/BVHComputeData.js
@@ -376,9 +376,15 @@ export class BVHComputeData {
 		bvhInfo.forEach( info => {
 
 			info.geometryOffset = indexOffset / 3;
+
 			// A non-indirect bvh built over a sub-range stores absolute leaf offsets, so shift the
 			// base back by the range's triangle start.
-			if ( ! info.bvh.indirect ) info.geometryOffset -= info.range.start / 3;
+			if ( ! info.bvh.indirect ) {
+
+				info.geometryOffset -= info.range.start / 3;
+
+			}
+
 			appendIndexData( info.bvh, info.range, attributesOffset, indexOffset, indexBuffer );
 			appendGeometryData( info.bvh, info.range, attributesOffset, attributesBuffer, attributeStruct, this );
 


### PR DESCRIPTION
A non-indirect `MeshBVH` built with a range stores absolute offsets in its leaves, but the BLAS packing in `BVHComputeData.update` computes `geometryOffset` as if leaf offsets were relative. As a result, every geometry whose range doesn't start at triangle 0 points at another geometry's triangles or runs past the end of the buffer.

This PR's fix subtracts the range's triangle start from the geometry offset.

Fixes #905

I omitted a regression test because I thought tests that import the WebGPU API would cause the CI's three@0.159.0 runs to fail, and it was too awkward to be worth it to write a test that worked around that.

JSFiddle with fix: https://jsfiddle.net/8xm250v3/3/
<img width="589" height="327" alt="Screenshot 2026-07-25 at 17 50 52" src="https://github.com/user-attachments/assets/9f48351e-7fe8-4506-b3f1-0a9d6e6bcf06" />

And for completeness here's the original JSFiddle: https://jsfiddle.net/8xm250v3/1/
<img width="588" height="327" alt="Screenshot 2026-07-25 at 17 51 48" src="https://github.com/user-attachments/assets/d9cae5b5-f297-481a-946e-cbfb0f3ed31e" />