### PR TITLE
Shaders: Output the barycoords in the the correct order

### DIFF
--- a/src/webgl/glsl/bvh_distance_functions.glsl.js
+++ b/src/webgl/glsl/bvh_distance_functions.glsl.js
@@ -60,6 +60,7 @@ vec3 closestPointToTriangle( vec3 p, vec3 v0, vec3 v1, vec3 v2, out vec3 barycoo
 
 	}
 
+	// output the barycoord in v0, v1, v2 weight order
 	barycoord = vec3( w, u, v );
     return u * v1 + v * v2 + w * v0;
 

--- a/src/webgl/glsl/bvh_distance_functions.glsl.js
+++ b/src/webgl/glsl/bvh_distance_functions.glsl.js
@@ -19,7 +19,8 @@ float dot2( vec3 v ) {
 
 }
 
-// https://www.shadertoy.com/view/ttfGWl
+// implementation from https://www.shadertoy.com/view/ttfGWl, though method 2 has been removed
+// and is now available at this fork: https://www.shadertoy.com/view/WlB3zW
 vec3 closestPointToTriangle( vec3 p, vec3 v0, vec3 v1, vec3 v2, out vec3 barycoord ) {
 
     vec3 v10 = v1 - v0;
@@ -59,7 +60,7 @@ vec3 closestPointToTriangle( vec3 p, vec3 v0, vec3 v1, vec3 v2, out vec3 barycoo
 
 	}
 
-	barycoord = vec3( u, v, w );
+	barycoord = vec3( w, u, v );
     return u * v1 + v * v2 + w * v0;
 
 }

--- a/src/webgpu/distance_functions.wgsl.js
+++ b/src/webgpu/distance_functions.wgsl.js
@@ -67,6 +67,7 @@ export const closestPointToTriangle = wgslFn( /* wgsl */ `
 
 		}
 
+		// output the barycoord in v0, v1, v2 weight order
 		var result: ClosestPointToTriangleResult;
 		result.barycoord = vec3f( w, u, v );
 		result.point = u * v1 + v * v2 + w * v0;

--- a/src/webgpu/distance_functions.wgsl.js
+++ b/src/webgpu/distance_functions.wgsl.js
@@ -26,8 +26,9 @@ export const closestPointToTriangleResultStruct = wgsl( /* wgsl */ `
 /** @deprecated Use {@link BVHComputeData} instead. */
 export const closestPointToTriangle = wgslFn( /* wgsl */ `
 
+	// implementation from https://www.shadertoy.com/view/ttfGWl, though method 2 has been removed
+	// and is now available at this fork: https://www.shadertoy.com/view/WlB3zW
 	fn closestPointToTriangle( p: vec3f, v0: vec3f, v1: vec3f, v2: vec3f ) -> ClosestPointToTriangleResult {
-		// https://www.shadertoy.com/view/ttfGWl
 
 		let v10 = v1 - v0;
 		let v21 = v2 - v1;
@@ -40,7 +41,7 @@ export const closestPointToTriangle = wgslFn( /* wgsl */ `
 		let nor = cross( v10, v02 );
 
 		// method 2, in barycentric space
-		let  q = cross( nor, p0 );
+		let q = cross( nor, p0 );
 		let d = 1.0 / dot( nor, nor );
 		var u = d * dot( q, v02 );
 		var v = d * dot( q, v10 );
@@ -67,7 +68,7 @@ export const closestPointToTriangle = wgslFn( /* wgsl */ `
 		}
 
 		var result: ClosestPointToTriangleResult;
-		result.barycoord = vec3f( u, v, w );
+		result.barycoord = vec3f( w, u, v );
 		result.point = u * v1 + v * v2 + w * v0;
 
 		return result;


### PR DESCRIPTION
Fix #914 

Swaps the output order of the barycoordinate values to v0, v1, v2 from v1, v2, v0 as specified in the original function.