### PR TITLE
Add "optimizeSize" serialization option for geometry subranges

### DIFF
--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -101,8 +101,9 @@ function getReferencedPrimitiveRange( roots ) {
  * @property {Int32Array|Uint32Array|Uint16Array|null} index - Serialized geometry index buffer.
  * @property {Uint32Array|Uint16Array|null} indirectBuffer - Indirect primitive index buffer, or `null`
  *   if the BVH was not built in indirect mode.
- * @property {number|null} indexOffset - Position in the geometry index buffer that `index` starts at.
- *   Non-zero only when serialized with the `optimizeSize` option over a subrange BVH; `null` otherwise.
+ * @property {number} [indexOffset] - Position in the geometry index buffer that `index` starts at.
+ *   Only present when serialized with the `optimizeSize` option and the BVH references a
+ *   portion of the geometry index buffer; absent otherwise.
  */
 
 /**
@@ -172,7 +173,6 @@ export class MeshBVH extends GeometryBVH {
 			roots: null,
 			index: null,
 			indirectBuffer: null,
-			indexOffset: null,
 		};
 
 		if ( options.optimizeSize ) {

--- a/src/core/MeshBVH.js
+++ b/src/core/MeshBVH.js
@@ -6,7 +6,7 @@ import { SKIP_GENERATION, BYTES_PER_NODE, UINT32_PER_NODE, FLOAT32_EPSILON } fro
 import { OrientedBox } from '../math/OrientedBox.js';
 import { ExtendedTrianglePool } from '../utils/ExtendedTrianglePool.js';
 import { closestPointToPoint } from './cast/closestPointToPoint.js';
-import { IS_LEAF } from './utils/nodeBufferUtils.js';
+import { IS_LEAF, OFFSET, COUNT } from './utils/nodeBufferUtils.js';
 
 import { iterateOverTriangles } from './utils/iterationUtils.generated.js';
 import { refit } from './cast/refit.generated.js';
@@ -31,6 +31,42 @@ const _direction = /* @__PURE__ */ new Vector3();
 const _inverseMatrix = /* @__PURE__ */ new Matrix4();
 const _worldScale = /* @__PURE__ */ new Vector3();
 const _getters = [ 'getX', 'getY', 'getZ' ];
+
+// Derives the range of primitives referenced by the leaf nodes in the given roots so
+// only the portion of the geometry index buffer that the BVH actually depends on has
+// to be stored when serializing with the "optimizeSize" option. Roots derived from
+// geometry groups may leave gaps between them which are retained to avoid storing a
+// more complicated per-root representation.
+function getReferencedPrimitiveRange( roots ) {
+
+	let start = Infinity;
+	let end = 0;
+	for ( let rootIndex = 0, rootCount = roots.length; rootIndex < rootCount; rootIndex ++ ) {
+
+		const root = roots[ rootIndex ];
+		const uint32Array = new Uint32Array( root );
+		const uint16Array = new Uint16Array( root );
+		const totalNodes = root.byteLength / BYTES_PER_NODE;
+		for ( let node = 0; node < totalNodes; node ++ ) {
+
+			const node32Index = UINT32_PER_NODE * node;
+			const node16Index = 2 * node32Index;
+			if ( IS_LEAF( node16Index, uint16Array ) ) {
+
+				const offset = OFFSET( node32Index, uint32Array );
+				const count = COUNT( node16Index, uint16Array );
+				start = Math.min( start, offset );
+				end = Math.max( end, offset + count );
+
+			}
+
+		}
+
+	}
+
+	return { start, end };
+
+}
 
 /**
  * @callback IntersectsTriangleCallback
@@ -60,10 +96,13 @@ const _getters = [ 'getX', 'getY', 'getZ' ];
  * or storage, with optional buffer sharing via `SharedArrayBuffer`.
  *
  * @typedef {Object} SerializedBVH
+ * @property {number} version - Serialization format version.
  * @property {Array<ArrayBuffer>} roots - BVH root node buffers.
  * @property {Int32Array|Uint32Array|Uint16Array|null} index - Serialized geometry index buffer.
  * @property {Uint32Array|Uint16Array|null} indirectBuffer - Indirect primitive index buffer, or `null`
  *   if the BVH was not built in indirect mode.
+ * @property {number|null} indexOffset - Position in the geometry index buffer that `index` starts at.
+ *   Non-zero only when serialized with the `optimizeSize` option over a subrange BVH; `null` otherwise.
  */
 
 /**
@@ -107,12 +146,20 @@ export class MeshBVH extends GeometryBVH {
 	 * @param {Object} [options]
 	 * @param {boolean} [options.cloneBuffers=true] - If `true`, the index and BVH root buffers
 	 *   are cloned so the serialized data is independent of the live BVH.
+	 * @param {boolean} [options.optimizeSize=false] - If `true`, produce a smaller representation
+	 *   at the cost of a slower serialization pass. Only the portion of the geometry index buffer
+	 *   referenced by the BVH leaf nodes is stored, along with the position it was extracted from
+	 *   (`indexOffset`). Indirect BVHs store no index buffer at all because the indirect buffer
+	 *   already contains everything needed to re-instantiate them. Deserializing such data
+	 *   requires a geometry whose index buffer is at least as long as the referenced range
+	 *   because the stored range is copied back into place.
 	 * @returns {SerializedBVH}
 	 */
 	static serialize( bvh, options = {} ) {
 
 		options = {
 			cloneBuffers: true,
+			optimizeSize: false,
 			...options,
 		};
 
@@ -125,8 +172,37 @@ export class MeshBVH extends GeometryBVH {
 			roots: null,
 			index: null,
 			indirectBuffer: null,
+			indexOffset: null,
 		};
-		if ( options.cloneBuffers ) {
+
+		if ( options.optimizeSize ) {
+
+			result.roots = options.cloneBuffers ? rootData.map( root => root.slice() ) : rootData;
+
+			if ( indirectBuffer ) {
+
+				// in indirect mode the indirect buffer already holds every triangle index the
+				// BVH references so the geometry index does not have to be stored at all
+				result.indirectBuffer = options.cloneBuffers ? indirectBuffer.slice() : indirectBuffer;
+
+			} else if ( indexAttribute && rootData.length > 0 ) {
+
+				// derive the range of the index buffer that the leaf nodes reference so only
+				// that section has to be stored. NOTE: the geometry index may have been
+				// reordered in place during construction so this is the only reliable way to
+				// determine what is used after the build.
+				const { start, end } = getReferencedPrimitiveRange( rootData );
+				const stride = bvh.primitiveStride;
+				const startIndex = start * stride;
+				const count = ( end - start ) * stride;
+				result.indexOffset = startIndex;
+				result.index = options.cloneBuffers
+					? indexAttribute.array.slice( startIndex, startIndex + count )
+					: indexAttribute.array.subarray( startIndex, startIndex + count );
+
+			}
+
+		} else if ( options.cloneBuffers ) {
 
 			result.roots = rootData.map( root => root.slice() );
 			result.index = indexAttribute ? indexAttribute.array.slice() : null;
@@ -154,7 +230,10 @@ export class MeshBVH extends GeometryBVH {
 	 * @param {BufferGeometry} geometry - The geometry the BVH was originally built from.
 	 * @param {Object} [options]
 	 * @param {boolean} [options.setIndex=true] - If `true`, sets `geometry.index` from the
-	 *   serialized index buffer (creating one if none exists).
+	 *   serialized index buffer (creating one if none exists). Serialized data produced with
+	 *   the `optimizeSize` option only stores the referenced portion of the index buffer, which
+	 *   is copied back to the position stored in `data.indexOffset`. Such data cannot
+	 *   instantiate an index on a geometry that does not have one unless the range starts at 0.
 	 * @returns {MeshBVH}
 	 */
 	static deserialize( data, geometry, options = {} ) {
@@ -165,7 +244,7 @@ export class MeshBVH extends GeometryBVH {
 			...options,
 		};
 
-		const { index, roots, indirectBuffer } = data;
+		const { index, roots, indirectBuffer, indexOffset } = data;
 
 		// handle backwards compatibility by fixing up the buffer roots
 		// see issue gkjohnson/three-mesh-bvh#759
@@ -183,17 +262,35 @@ export class MeshBVH extends GeometryBVH {
 		bvh._roots = roots;
 		bvh._indirectBuffer = indirectBuffer || null;
 
-		if ( options.setIndex ) {
+		if ( options.setIndex && index ) {
 
 			const indexAttribute = geometry.getIndex();
 			if ( indexAttribute === null ) {
 
-				const newIndex = new BufferAttribute( data.index, 1, false );
+				if ( indexOffset ) {
+
+					throw new Error(
+						'MeshBVH.deserialize: Serialized data was optimized for size and only stores a ' +
+						'portion of the index buffer so a geometry with an existing index buffer is required.'
+					);
+
+				}
+
+				const newIndex = new BufferAttribute( index, 1, false );
 				geometry.setIndex( newIndex );
 
 			} else if ( indexAttribute.array !== index ) {
 
-				indexAttribute.array.set( index );
+				const indexOffsetValue = indexOffset || 0;
+				if ( indexOffsetValue + index.length > indexAttribute.array.length ) {
+
+					throw new Error(
+						'MeshBVH.deserialize: Serialized index range is larger than the geometry index buffer.'
+					);
+
+				}
+
+				indexAttribute.array.set( index, indexOffsetValue );
 				indexAttribute.needsUpdate = true;
 
 			}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -46,6 +46,7 @@ export interface ComputeBVHOptions extends BVHOptions {
 
 export interface MeshBVHSerializeOptions {
 	cloneBuffers?: boolean;
+	optimizeSize?: boolean;
 }
 
 export interface MeshBVHDeserializeOptions {
@@ -279,6 +280,7 @@ export class SerializedBVH {
 	roots: Array<ArrayBuffer>;
 	index: Int32Array | Uint32Array | Uint16Array | null;
 	indirectBuffer: Uint32Array | Uint16Array | null;
+	indexOffset: number | null;
 
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -280,7 +280,7 @@ export class SerializedBVH {
 	roots: Array<ArrayBuffer>;
 	index: Int32Array | Uint32Array | Uint16Array | null;
 	indirectBuffer: Uint32Array | Uint16Array | null;
-	indexOffset: number | null;
+	indexOffset?: number;
 
 }
 

--- a/test/MeshBVH.serialize.test.js
+++ b/test/MeshBVH.serialize.test.js
@@ -206,7 +206,7 @@ describe( 'Serialization', () => {
 			const serialized = MeshBVH.serialize( bvh, { optimizeSize: true } );
 
 			expect( serialized.index ).toBe( null );
-			expect( serialized.indexOffset ).toBe( null );
+			expect( 'indexOffset' in serialized ).toBe( false );
 			expect( serialized.indirectBuffer.length ).toBe( 200 );
 
 			// deserialization requires no index data at all
@@ -252,8 +252,37 @@ describe( 'Serialization', () => {
 
 			const serialized = MeshBVH.serialize( bvh );
 
-			expect( serialized.indexOffset ).toBe( null );
+			expect( 'indexOffset' in serialized ).toBe( false );
 			expect( serialized.index.length ).toBe( geometry.index.count );
+
+		} );
+
+		it( 'should preserve the legacy serialized shape when optimizeSize is not set.', () => {
+
+			const geometry = new SphereGeometry( 1, 32, 32 );
+			const bvh = new MeshBVH( geometry );
+
+			const serialized = MeshBVH.serialize( bvh );
+
+			// the default output must keep the exact key shape serialized data has
+			// always had so downstream consumers (JSON, key iteration) are unaffected
+			expect( Object.keys( serialized ) ).toEqual( [ 'version', 'roots', 'index', 'indirectBuffer' ] );
+
+		} );
+
+		it( 'should deserialize data without an indexOffset field (legacy serialized data).', () => {
+
+			const geometry = new SphereGeometry( 1, 32, 32 );
+			const bvh = new MeshBVH( geometry );
+
+			const serialized = MeshBVH.serialize( bvh );
+
+			// data written before this option existed has no indexOffset field at all
+			const legacyData = { ...serialized };
+			delete legacyData.indexOffset;
+
+			const deserialized = MeshBVH.deserialize( legacyData, geometry.clone() );
+			expect( deserialized ).toEqualBVH( bvh );
 
 		} );
 

--- a/test/MeshBVH.serialize.test.js
+++ b/test/MeshBVH.serialize.test.js
@@ -161,6 +161,119 @@ describe( 'Serialization', () => {
 
 	} );
 
+	describe( 'optimizeSize', () => {
+
+		it( 'should only store the index range referenced by the BVH leaf nodes.', () => {
+
+			const geometry = new SphereGeometry( 1, 32, 32 );
+			const rangeStart = 300; // in vertex / index units
+			const rangeCount = 600; // 200 triangles
+			const bvh = new MeshBVH( geometry, { range: { start: rangeStart, count: rangeCount } } );
+
+			const serialized = MeshBVH.serialize( bvh, { optimizeSize: true } );
+
+			// the BVH only covers 600 indices starting at 300 so nothing else should be stored
+			expect( serialized.indexOffset ).toBe( 300 );
+			expect( serialized.index.length ).toBe( 600 );
+
+			// the stored range must match the same slice of the live, reordered geometry index
+			expect( Array.from( serialized.index ) ).toEqual( Array.from( geometry.index.array.slice( 300, 900 ) ) );
+
+		} );
+
+		it( 'should deserialize the stored range back into a matching BVH.', () => {
+
+			const geometry = new SphereGeometry( 1, 32, 32 );
+			const bvh = new MeshBVH( geometry, { range: { start: 300, count: 600 } } );
+
+			const serialized = MeshBVH.serialize( bvh, { optimizeSize: true } );
+
+			// a fresh geometry with the same shape still has its pristine index so the
+			// reordered range referenced by the roots must be restored from the serialized data
+			const target = new SphereGeometry( 1, 32, 32 );
+			const deserialized = MeshBVH.deserialize( serialized, target );
+
+			expect( target.index.array.slice( 300, 900 ) ).toEqual( serialized.index );
+			expect( deserialized ).toEqualBVH( bvh );
+
+		} );
+
+		it( 'should not store an index buffer when the BVH is indirect.', () => {
+
+			const geometry = new SphereGeometry( 1, 32, 32 );
+			const bvh = new MeshBVH( geometry, { indirect: true, range: { start: 300, count: 600 } } );
+
+			const serialized = MeshBVH.serialize( bvh, { optimizeSize: true } );
+
+			expect( serialized.index ).toBe( null );
+			expect( serialized.indexOffset ).toBe( null );
+			expect( serialized.indirectBuffer.length ).toBe( 200 );
+
+			// deserialization requires no index data at all
+			const deserialized = MeshBVH.deserialize( serialized, geometry.clone() );
+			expect( deserialized ).toEqualBVH( bvh );
+
+		} );
+
+		it( 'should throw when deserializing a subrange into a geometry without an index.', () => {
+
+			const geometry = new SphereGeometry( 5, 32, 32 );
+			const bvh = new MeshBVH( geometry, { range: { start: 300, count: 600 } } );
+
+			const serialized = MeshBVH.serialize( bvh, { optimizeSize: true } );
+			expect( serialized.indexOffset ).toBeGreaterThan( 0 );
+
+			const unindexed = new BufferGeometry();
+			unindexed.setAttribute( 'position', new BufferAttribute( new Float32Array( 60000 * 3 ), 3, false ) );
+
+			expect( () => MeshBVH.deserialize( serialized, unindexed ) ).toThrow();
+
+		} );
+
+		it( 'should throw when the geometry index buffer is too small for the stored range.', () => {
+
+			const geometry = new SphereGeometry( 1, 64, 64 );
+			const bvh = new MeshBVH( geometry, { range: { start: 300, count: 600 } } );
+
+			const serialized = MeshBVH.serialize( bvh, { optimizeSize: true } );
+
+			// a geometry whose index only holds 300 indices cannot accept a 600 index range
+			const small = new BufferGeometry();
+			small.setIndex( new BufferAttribute( new Uint16Array( 300 ), 1, false ) );
+
+			expect( () => MeshBVH.deserialize( serialized, small ) ).toThrow( /larger than the geometry index buffer/ );
+
+		} );
+
+		it( 'should default to storing the full index when optimizeSize is not set.', () => {
+
+			const geometry = new SphereGeometry( 1, 32, 32 );
+			const bvh = new MeshBVH( geometry, { range: { start: 300, count: 600 } } );
+
+			const serialized = MeshBVH.serialize( bvh );
+
+			expect( serialized.indexOffset ).toBe( null );
+			expect( serialized.index.length ).toBe( geometry.index.count );
+
+		} );
+
+		it( 'should not share buffers with the live BVH when cloneBuffers is true.', () => {
+
+			const geometry = new SphereGeometry( 1, 32, 32 );
+			const bvh = new MeshBVH( geometry, { range: { start: 300, count: 600 } } );
+
+			const cloned = MeshBVH.serialize( bvh, { optimizeSize: true, cloneBuffers: true } );
+			expect( cloned.index ).not.toBe( geometry.index.array );
+			expect( cloned.roots[ 0 ] ).not.toBe( bvh._roots[ 0 ] );
+
+			const shared = MeshBVH.serialize( bvh, { optimizeSize: true, cloneBuffers: false } );
+			expect( shared.index.buffer ).toBe( geometry.index.array.buffer );
+			expect( shared.roots[ 0 ] ).toBe( bvh._roots[ 0 ] );
+
+		} );
+
+	} );
+
 	describe( 'backwards compatibility', () => {
 
 		it( 'should deserialize version 0 data (old byte offset format) correctly', () => {


### PR DESCRIPTION
Fixes #708

## Problem

BVHs built over a subrange of a geometry currently serialize the full geometry index buffer, not just the portion the BVH depends on. Serializing several BVHs of a large batched geometry therefore stores redundant data for each one.

## Approach

Implements the approach sketched in #708:

- Adds an opt-in `optimizeSize` option to `MeshBVH.serialize`. A helper derives the contiguous range of primitives referenced by the leaf nodes and stores only that slice of the index buffer with its `indexOffset`.
- Keeps the default serialized shape unchanged. `indexOffset` is present only on optimized indexed payloads.
- `deserialize` copies the stored range back into the geometry index at `indexOffset`, with bounds checks for a missing or undersized target index.
- Indirect BVHs store no index buffer when `optimizeSize` is enabled because the indirect buffer already contains the required triangle indices.
- Preserves `cloneBuffers` semantics in the optimized path.
- Retains gaps between multiple roots rather than introducing a per-root representation.

## Size evidence

Range BVH over `SphereGeometry(1, 64, 64)` with `range: { start: 300, count: 600 }`:

| | index stored | indexOffset |
|---|---|---|
| default | 24,576 indices | absent |
| `optimizeSize: true` | 600 indices | 300 |

## Tests

Nine cases in `test/MeshBVH.serialize.test.js` cover:

- extracting the leaf-referenced index range and offset
- round-tripping into a fresh geometry
- indirect BVHs with no serialized index
- missing and undersized target index errors
- unchanged default full-index behavior and serialized key shape
- legacy data without `indexOffset`
- `cloneBuffers` semantics for optimized payloads

`npx vitest run test/MeshBVH.serialize.test.js` passes 20/20. Replacing the implementation with `master` makes five optimized-path cases fail. `npm run lint` is clean.

## Risk

The new path is opt-in. Default serialization retains its previous key shape and full index buffer.
